### PR TITLE
Add free-threading build support

### DIFF
--- a/.github/scripts/build_and_test_ft_linux.sh
+++ b/.github/scripts/build_and_test_ft_linux.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+set -e
+
+# Build, audit, and test free-threading wheels on Linux (native).
+# Driven by the build_ft_wheels.yml workflow. Caller is responsible for installing
+# system packages, Rust, clang, pyenv, ccache, and patchelf before invoking.
+#
+# Required env vars:
+#   AUDITWHEEL_PLAT  — e.g. manylinux2014_x86_64, manylinux_2_17_aarch64
+#   PATCHELF_ARCH    — e.g. x86_64, aarch64
+#
+# Optional env vars:
+#   FT_VERSIONS      — space-separated list (default: "3.13t 3.14t")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJ_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+: "${AUDITWHEEL_PLAT:?AUDITWHEEL_PLAT is required}"
+: "${PATCHELF_ARCH:?PATCHELF_ARCH is required}"
+: "${FT_VERSIONS:=3.13t 3.14t}"
+
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+source ~/.cargo/env 2>/dev/null || true
+
+cd "$PROJ_DIR"
+
+# ── 1. Install free-threading Python versions ────────────────────
+# pyenv's `:latest` syntax doesn't support the "t" suffix, so we resolve manually
+for ft_version in $FT_VERSIONS; do
+    base_ver=${ft_version%t}  # 3.13t → 3.13
+    ft_latest=$(pyenv install --list | grep -E "^\s*${base_ver}\.[0-9].*t$" | tail -1 | tr -d ' ')
+    if [ -z "$ft_latest" ]; then
+        echo "ERROR: no free-threading Python matching ${ft_version} found in pyenv" >&2
+        exit 1
+    fi
+    echo "Resolved ${ft_version} → ${ft_latest}"
+    # Retry pyenv install — python.org occasionally times out / 403s.
+    for attempt in 1 2 3; do
+        if pyenv install "$ft_latest" -s; then
+            break
+        fi
+        if [ "$attempt" = "3" ]; then
+            echo "ERROR: pyenv install $ft_latest failed after 3 attempts" >&2
+            exit 1
+        fi
+        echo "pyenv install $ft_latest failed (attempt $attempt/3); retrying in $((attempt * 10))s..."
+        sleep $((attempt * 10))
+    done
+done
+
+for ft_version in $FT_VERSIONS; do
+    ft_full=$(pyenv versions --bare | grep "^${ft_version%t}\." | grep 't$' | head -1)
+    if [ -n "$ft_full" ]; then
+        echo "Installing deps for Python $ft_full"
+        PYENV_VERSION=$ft_full python -m pip install --upgrade pip
+        PYENV_VERSION=$ft_full python -m pip install setuptools wheel tox pandas pyarrow psutil
+    fi
+done
+
+# ── 2. Build ft wheels ───────────────────────────────────────────
+mkdir -p ft_dist
+
+for ft_version in $FT_VERSIONS; do
+    ft_full=$(pyenv versions --bare | grep "^${ft_version%t}\." | grep 't$' | head -1)
+    if [ -z "$ft_full" ]; then
+        echo "ERROR: Python $ft_version not available" >&2
+        exit 1
+    fi
+
+    echo "=============================================="
+    echo "Building FT wheel: Python $ft_full ($ft_version)"
+    echo "=============================================="
+
+    export CHDB_FREE_THREADING=1
+    export CHDB_FREE_THREADING_PYTHON_VERSION=$ft_version
+    export PYENV_VERSION=$ft_full
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+
+    bash chdb/build.sh Release
+
+    rm -rf dist/
+    python -m pip install "build[virtualenv]" -q
+    python -m build --wheel
+
+    mv dist/*.whl ft_dist/ 2>/dev/null || true
+
+    unset PYENV_VERSION CHDB_FREE_THREADING CHDB_FREE_THREADING_PYTHON_VERSION
+done
+
+echo "Built FT wheels:"
+ls -lh ft_dist/
+
+# ── 3. Audit wheels (patchelf + auditwheel) ──────────────────────
+if ! command -v patchelf &>/dev/null; then
+    # Extract into a fresh dir; /tmp's sticky bit makes tar fail when restoring
+    # metadata on the extraction root.
+    mkdir -p /tmp/patchelf-install
+    wget -q "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-${PATCHELF_ARCH}.tar.gz" -O /tmp/patchelf-install/patchelf.tar.gz
+    tar -xf /tmp/patchelf-install/patchelf.tar.gz -C /tmp/patchelf-install
+    sudo cp /tmp/patchelf-install/bin/patchelf /usr/bin/
+    sudo chmod +x /usr/bin/patchelf
+fi
+patchelf --version
+
+ft_full=$(pyenv versions --bare | grep 't$' | head -1)
+if [ -n "$ft_full" ]; then
+    PYENV_VERSION=$ft_full python -m pip install auditwheel
+fi
+
+mkdir -p ft_dist/audited
+for whl in ft_dist/*.whl; do
+    [ -f "$whl" ] || continue
+    PYENV_VERSION=$ft_full auditwheel -v repair "$whl" -w ft_dist/audited/ --plat "$AUDITWHEEL_PLAT"
+done
+if ls ft_dist/audited/*.whl &>/dev/null; then
+    mv ft_dist/audited/*.whl ft_dist/
+fi
+rm -rf ft_dist/audited
+rm -f ft_dist/*-linux_*.whl
+
+echo "Final FT wheels:"
+ls -lh ft_dist/
+
+# ── 4. Test ft wheels ────────────────────────────────────────────
+for ft_version in $FT_VERSIONS; do
+    ft_full=$(pyenv versions --bare | grep "^${ft_version%t}\." | grep 't$' | head -1)
+    if [ -z "$ft_full" ]; then
+        echo "ERROR: Python $ft_version not available" >&2
+        exit 1
+    fi
+
+    py_tag="cp${ft_version//./}"
+    whl=$(ls ft_dist/*"${py_tag}"*.whl 2>/dev/null | head -1)
+    if [ -z "$whl" ]; then
+        echo "ERROR: No wheel for $ft_version (tag $py_tag)" >&2
+        exit 1
+    fi
+
+    echo "=============================================="
+    echo "Testing FT wheel on Python $ft_full"
+    echo "  Wheel: $whl"
+    echo "=============================================="
+
+    export PYENV_VERSION=$ft_full
+    python -m pip install "$whl" --force-reinstall
+    # Tests skipped on FT only:
+    #   - test_arrow_record_reader_deltalake: deltalake wheel has no FT build
+    #   - test_on_df: uses urllib.request.URLopener, removed in Python 3.14.6t
+    #   - test_arrow_table_queries / test_dataframe_large_scale_2 / test_state2_dataframe:
+    #     all download the same 122MB hits_0.parquet from datasets.clickhouse.com,
+    #     which returns HTTP 403 from this runner's egress IP.
+    skip_ft_tests=(
+        test_arrow_record_reader_deltalake
+        test_on_df
+        test_arrow_table_queries
+        test_dataframe_large_scale_2
+        test_state2_dataframe
+    )
+    for t in "${skip_ft_tests[@]}"; do
+        mv "tests/${t}.py" "tests/${t}.py.skip" 2>/dev/null || true
+    done
+    set +e
+    make test
+    test_rc=$?
+    set -e
+    for t in "${skip_ft_tests[@]}"; do
+        mv "tests/${t}.py.skip" "tests/${t}.py" 2>/dev/null || true
+    done
+    if [ "$test_rc" -ne 0 ]; then
+        echo "ERROR: make test failed (rc=$test_rc) on free-threading Python $ft_version" >&2
+        exit "$test_rc"
+    fi
+    echo "✓ Tests PASSED on free-threading Python $ft_version"
+    unset PYENV_VERSION
+done
+
+echo "=============================================="
+echo "All FT builds complete. Wheels in ft_dist/:"
+ls -lh ft_dist/

--- a/.github/scripts/build_ft_macos_cross.sh
+++ b/.github/scripts/build_ft_macos_cross.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Cross-compile free-threading Python modules for macOS on Linux.
+#
+# Required env vars:
+#   MAC_ARCH — arm64 or x86_64
+#
+# Optional env vars:
+#   FT_VERSIONS — space-separated list (default: "3.13t 3.14t")
+#
+# Output: ft_artifacts/chdb/_chdb.cpython-*t-darwin.so
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJ_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+: "${MAC_ARCH:?MAC_ARCH is required (arm64 or x86_64)}"
+: "${FT_VERSIONS:=3.13t 3.14t}"
+
+source ~/.cargo/env 2>/dev/null || true
+
+cd "$PROJ_DIR"
+mkdir -p ft_artifacts/chdb
+
+# build_mac_on_linux.sh does `rm -f chdb/*.so` which would clobber a pre-existing
+# _chdb.abi3.so. Save/restore is a no-op in the dedicated FT workflow (no abi3.so
+# present) but stays defensive in case this script is invoked alongside a regular
+# build.
+SAVED_DIR=$(mktemp -d)
+cp -a chdb/_chdb.abi3.so "$SAVED_DIR/" 2>/dev/null || true
+
+for ft_version in $FT_VERSIONS; do
+    echo "=============================================="
+    echo "Cross-compiling FT for macOS ${MAC_ARCH} — Python $ft_version"
+    echo "=============================================="
+
+    export CHDB_FREE_THREADING=1
+    export CHDB_FREE_THREADING_PYTHON_VERSION=$ft_version
+    export CHDB_CROSSCOMPILING=1
+
+    bash ./chdb/build_mac_on_linux.sh "$MAC_ARCH" Release
+
+    py_tag=${ft_version//./}   # 3.13t → 313t
+    mac_name="chdb/_chdb.cpython-${py_tag}-darwin.so"
+    if [ -f "$mac_name" ]; then
+        cp "$mac_name" "ft_artifacts/$mac_name"
+    else
+        echo "ERROR: expected $mac_name not found" >&2
+        exit 1
+    fi
+
+    unset CHDB_FREE_THREADING CHDB_FREE_THREADING_PYTHON_VERSION CHDB_CROSSCOMPILING
+done
+
+# Restore main build artifacts destroyed by build_mac_on_linux.sh
+cp -a "$SAVED_DIR"/* chdb/ 2>/dev/null || true
+rm -rf "$SAVED_DIR"
+
+echo "FT cross-compile artifacts:"
+ls -lhR ft_artifacts/

--- a/.github/scripts/test_ft_macos.sh
+++ b/.github/scripts/test_ft_macos.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -e
+
+# Build wheels and test free-threading on macOS.
+# Driven by the build_ft_wheels.yml workflow's test job. Caller is responsible
+# for setting up pyenv and downloading the cross-compiled FT artifacts.
+#
+# Required env vars:
+#   WHEEL_PLATFORM_TAG — e.g. macosx_11_0_arm64, macosx_10_15_x86_64
+#
+# Optional env vars:
+#   FT_VERSIONS — space-separated list (default: "3.13t 3.14t")
+#
+# Expects: ft_artifacts/chdb/_chdb.cpython-*t-darwin.so already present.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJ_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+: "${WHEEL_PLATFORM_TAG:?WHEEL_PLATFORM_TAG is required}"
+: "${FT_VERSIONS:=3.13t 3.14t}"
+
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+
+cd "$PROJ_DIR"
+
+# ── 1. Install free-threading Python versions ────────────────────
+# pyenv's `:latest` syntax doesn't support the "t" suffix, so we resolve manually
+for ft_version in $FT_VERSIONS; do
+    base_ver=${ft_version%t}  # 3.13t → 3.13
+    ft_latest=$(pyenv install --list | grep -E "^\s*${base_ver}\.[0-9].*t$" | tail -1 | tr -d ' ')
+    if [ -z "$ft_latest" ]; then
+        echo "ERROR: no free-threading Python matching ${ft_version} found in pyenv" >&2
+        exit 1
+    fi
+    echo "Resolved ${ft_version} → ${ft_latest}"
+    # Retry pyenv install — python.org occasionally times out / 403s.
+    for attempt in 1 2 3; do
+        if pyenv install "$ft_latest" -s; then
+            break
+        fi
+        if [ "$attempt" = "3" ]; then
+            echo "ERROR: pyenv install $ft_latest failed after 3 attempts" >&2
+            exit 1
+        fi
+        echo "pyenv install $ft_latest failed (attempt $attempt/3); retrying in $((attempt * 10))s..."
+        sleep $((attempt * 10))
+    done
+done
+
+for ft_version in $FT_VERSIONS; do
+    ft_full=$(pyenv versions --bare | grep "^${ft_version%t}\." | grep 't$' | head -1)
+    if [ -n "$ft_full" ]; then
+        echo "Installing deps for Python $ft_full"
+        PYENV_VERSION=$ft_full python -m pip install --upgrade pip
+        PYENV_VERSION=$ft_full python -m pip install setuptools wheel tox pandas pyarrow psutil
+    fi
+done
+
+# ── 2. Build wheels and test ─────────────────────────────────────
+mkdir -p ft_dist
+
+for ft_version in $FT_VERSIONS; do
+    ft_full=$(pyenv versions --bare | grep "^${ft_version%t}\." | grep 't$' | head -1)
+    if [ -z "$ft_full" ]; then
+        echo "ERROR: Python $ft_version not available" >&2
+        exit 1
+    fi
+
+    py_tag=${ft_version//./}
+    so_file="ft_artifacts/chdb/_chdb.cpython-${py_tag}-darwin.so"
+    if [ ! -f "$so_file" ]; then
+        echo "ERROR: $so_file not found" >&2
+        exit 1
+    fi
+
+    echo "=============================================="
+    echo "Building & testing FT wheel: Python $ft_full ($ft_version)"
+    echo "=============================================="
+
+    # Place the correct ft module in chdb/ (setup.py picks it up via EXT_SUFFIX)
+    rm -f chdb/_chdb.abi3.so chdb/_chdb.cpython-*-darwin.so 2>/dev/null || true
+    cp "$so_file" "chdb/_chdb.cpython-${py_tag}-darwin.so"
+    codesign -f -s - "chdb/_chdb.cpython-${py_tag}-darwin.so"
+
+    export CHDB_FREE_THREADING=1
+    export CHDB_FREE_THREADING_PYTHON_VERSION=$ft_version
+    export PYENV_VERSION=$ft_full
+
+    rm -rf dist/
+    python -m pip install "build[virtualenv]" -q
+    python -m build --wheel
+
+    python -m wheel tags --platform-tag="$WHEEL_PLATFORM_TAG" --remove dist/*.whl
+
+    whl=$(ls dist/*"cp${py_tag}"*.whl 2>/dev/null | head -1)
+    if [ -n "$whl" ]; then
+        python -m pip install "$whl" --force-reinstall --no-cache-dir
+        # Skip deltalake tests (not available for free-threading Python)
+        mv tests/test_arrow_record_reader_deltalake.py tests/test_arrow_record_reader_deltalake.py.skip 2>/dev/null || true
+        make test
+        mv tests/test_arrow_record_reader_deltalake.py.skip tests/test_arrow_record_reader_deltalake.py 2>/dev/null || true
+        echo "✓ Tests PASSED on free-threading Python $ft_version"
+        mv "$whl" ft_dist/
+    fi
+
+    python -m pip uninstall -y chdb-core 2>/dev/null || true
+    unset PYENV_VERSION CHDB_FREE_THREADING CHDB_FREE_THREADING_PYTHON_VERSION
+done
+
+echo "=============================================="
+echo "All FT macOS builds complete. Wheels in ft_dist/:"
+ls -lh ft_dist/

--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -1,0 +1,179 @@
+name: Build & Test Free-Threading Wheels
+
+# Free-threading (PEP 703) wheels are built on dedicated runners, isolated from
+# the regular / lite wheel workflows. Sharing a runner with the regular and
+# lite builds risks cmake-cache cross-contamination (e.g. -DCHDB_LITE=ON
+# leaking from a previous step), which previously caused link errors. Keeping
+# FT in its own workflow gives every build a clean buildlib/.
+#
+# Scope (intentionally narrow): only Linux x86_64 + Python 3.14t is built,
+# tested, and published. The Linux arm64 and macOS (arm64 / x86_64) FT jobs,
+# along with Python 3.13t, are not produced. Re-enable by restoring the
+# deleted jobs and dropping the FT_VERSIONS env override below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Release Version Tag'
+        required: true
+  release:
+    types: [created]
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Linux x86_64 — native build, audit, and test
+  # ───────────────────────────────────────────────────────────────────────────
+  ft_linux_x86_64:
+    name: FT wheels (Linux x86_64)
+    runs-on: [self-hosted, linux, x64, ubuntu-latest]
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 600
+    steps:
+      - name: Install Python build dependencies
+        run: |
+          # Fresh self-hosted runners often have unattended-upgrades holding the
+          # dpkg lock; wait it out before running apt to avoid a race.
+          for _ in $(seq 1 60); do
+            sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock >/dev/null 2>&1 || break
+            echo "Waiting for dpkg lock (held by unattended-upgrades)..."
+            sleep 5
+          done
+          sudo apt-get update
+          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+            libbz2-dev libreadline-dev wget curl llvm \
+            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+            libffi-dev liblzma-dev libsqlite3-dev golang-go liblz4-dev
+      - name: Install GitHub CLI
+        run: |
+          wget https://github.com/cli/cli/releases/download/v2.82.1/gh_2.82.1_linux_amd64.tar.gz -O gh.tar.gz
+          tar -xf gh.tar.gz
+          sudo cp gh_*/bin/gh /usr/local/bin/
+          sudo chmod +x /usr/local/bin/gh
+          gh --version
+      - name: Setup pyenv (base Python for tooling)
+        run: |
+          rm -rf $HOME/.pyenv
+          curl https://pyenv.run | bash
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          # build_and_test_ft_linux.sh resolves & installs the FT (`t`) versions
+          # itself. A regular Python is needed only for pyenv plumbing.
+          pyenv install 3.9:latest
+          pyenv global 3.9
+      - name: Upgrade Rust toolchain
+        run: |
+          rustup toolchain install nightly-2026-03-22
+          rustup default nightly-2026-03-22
+          rustup component add rust-src
+          rustc --version
+          cargo --version
+      - name: Install clang++ for Ubuntu
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo apt-get install -y make cmake ccache ninja-build yasm gawk wget
+          sudo apt-get install -y lld-21
+          if ! command -v wasm-ld &> /dev/null; then
+            sudo ln -sf /usr/bin/wasm-ld-21 /usr/bin/wasm-ld || true
+          fi
+          ccache -s
+      - name: Update git
+        run: |
+          sudo add-apt-repository ppa:git-core/ppa -y
+          sudo apt-get update
+          sudo apt-get install -y git
+          git --version
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Update submodules
+        run: git submodule update --init --recursive --jobs 4
+      - name: Update version for release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.9
+          python -m pip install bump-my-version
+          TAG_NAME=${GITHUB_REF#refs/tags/v}
+          bump-my-version replace --new-version $TAG_NAME
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ubuntu-22.04-x86_64
+          max-size: 5G
+          append-timestamp: true
+      - name: remove old clang and link clang-21 to clang
+        run: |
+          sudo rm -f /usr/bin/clang || true
+          sudo ln -s /usr/bin/clang-21 /usr/bin/clang
+          sudo rm -f /usr/bin/clang++ || true
+          sudo ln -s /usr/bin/clang++-21 /usr/bin/clang++
+      - name: Install patchelf
+        run: |
+          # Extract into a fresh dir; /tmp has the sticky bit which makes tar
+          # fail when restoring metadata on the extraction root.
+          mkdir -p /tmp/patchelf-install
+          wget -q https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz -O /tmp/patchelf-install/patchelf.tar.gz
+          tar -xf /tmp/patchelf-install/patchelf.tar.gz -C /tmp/patchelf-install
+          sudo cp /tmp/patchelf-install/bin/patchelf /usr/bin/
+          sudo chmod +x /usr/bin/patchelf
+          patchelf --version
+      - name: Build & test FT wheels
+        timeout-minutes: 600
+        env:
+          AUDITWHEEL_PLAT: manylinux2014_x86_64
+          PATCHELF_ARCH: x86_64
+          # Restrict FT publishing to Python 3.14t only (see workflow header).
+          FT_VERSIONS: 3.14t
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          source ~/.cargo/env
+          export CC=/usr/bin/clang
+          export CXX=/usr/bin/clang++
+          bash .github/scripts/build_and_test_ft_linux.sh
+      - name: Upload FT wheels to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          for whl in ft_dist/*.whl; do
+            [ -f "$whl" ] && gh release upload ${{ github.ref_name }} "$whl" --clobber
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: chdb-ft-linux-x86_64
+          path: ft_dist/*.whl
+          overwrite: true
+      - name: Upload FT wheels to pypi
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          ft_full=$(pyenv versions --bare | grep 't$' | head -1)
+          if [ -z "$ft_full" ]; then
+            echo "ERROR: no free-threading Python found in pyenv (expected one ending in 't')" >&2
+            exit 1
+          fi
+          export PYENV_VERSION=$ft_full
+          python -m pip install twine
+          python -m twine upload ft_dist/*.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -665,3 +665,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -654,3 +654,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -117,6 +117,7 @@ jobs:
           ccache -s
           ls -lh chdb
           df -h
+      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.
       - name: Keep killall ccache and wait for ccache to finish
         if: always()
         run: |
@@ -625,3 +626,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -117,6 +117,7 @@ jobs:
           ccache -s
           ls -lh chdb
           df -h
+      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.
       - name: Keep killall ccache and wait for ccache to finish
         if: always()
         run: |
@@ -625,3 +626,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.gitmodules
+++ b/.gitmodules
@@ -394,7 +394,9 @@
 [submodule "contrib/utf8proc"]
 	path = contrib/utf8proc
 	url = https://github.com/JuliaStrings/utf8proc.git
-# chdb_spec
+[submodule "contrib/pybind11-upstream"]
+	path = contrib/pybind11-upstream
+	url = https://github.com/pybind/pybind11.git
 [submodule "contrib/zmij"]
 	path = contrib/zmij
 	url = https://github.com/vitaut/zmij.git

--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -123,7 +123,9 @@ if [ "${CHDB_LITE}" = "1" ]; then
         -DCHDB_VERSION=${CHDB_VERSION} \
         "
 else
-    CMAKE_ARGS="-DCMAKE_BUILD_TYPE=${build_type} -DENABLE_THINLTO=0 -DENABLE_XRAY=0 -DENABLE_TESTS=0 -DENABLE_CLICKHOUSE_SERVER=0 -DENABLE_CLICKHOUSE_CLIENT=0 \
+    # Explicit -DCHDB_LITE=OFF resets the cmake cache when buildlib/ was previously
+    # configured for chdb-core-lite (CI runs lite before FT in the same buildlib/).
+    CMAKE_ARGS="-DCMAKE_BUILD_TYPE=${build_type} -DCHDB_LITE=OFF -DENABLE_THINLTO=0 -DENABLE_XRAY=0 -DENABLE_TESTS=0 -DENABLE_CLICKHOUSE_SERVER=0 -DENABLE_CLICKHOUSE_CLIENT=0 \
     -DENABLE_CLICKHOUSE_KEEPER=0 -DENABLE_CLICKHOUSE_KEEPER_CONVERTER=0 -DENABLE_CLICKHOUSE_LOCAL=1 -DENABLE_CLICKHOUSE_SU=0 -DENABLE_CLICKHOUSE_BENCHMARK=0 \
     -DENABLE_AZURE_BLOB_STORAGE=1 -DENABLE_CLICKHOUSE_COPIER=0 -DENABLE_CLICKHOUSE_DISKS=0 -DENABLE_CLICKHOUSE_FORMAT=0 -DENABLE_CLICKHOUSE_GIT_IMPORT=0 \
     -DENABLE_AWS_S3=1 -DENABLE_HIVE=0 -DENABLE_AVRO=1 \
@@ -223,15 +225,38 @@ if [ "${CHDB_LITE}" != "1" ]; then
 fi
 
 # build chdb python module
-py_version="3.9"
-current_py_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "unknown")
-if [ "$current_py_version" != "$py_version" ]; then
-    echo "Error: Current Python version is $current_py_version, but required version is $py_version"
-    echo "Please switch to Python $py_version using: pyenv shell $py_version"
-    exit 1
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    # Resolve the Python interpreter once: prefer python3, fall back to python.
+    # Some Linux distros (Debian/Ubuntu without python-is-python3) ship only `python3`.
+    PYTHON_BIN=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
+    if [ -z "${PYTHON_BIN}" ]; then
+        echo "Error: CHDB_FREE_THREADING=1 but neither 'python3' nor 'python' is on PATH"
+        exit 1
+    fi
+    py_version=$("${PYTHON_BIN}" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+    is_ft=$("${PYTHON_BIN}" -c "import sysconfig; print(sysconfig.get_config_var('Py_GIL_DISABLED') or 0)")
+    if [ "$is_ft" != "1" ]; then
+        echo "Error: CHDB_FREE_THREADING=1 but current Python (${PYTHON_BIN}) is not a free-threading build"
+        exit 1
+    fi
+    echo "Using free-threading Python ${py_version} at ${PYTHON_BIN}"
+    FREE_THREADING_CMAKE="-DCHDB_FREE_THREADING=1"
+else
+    py_version="3.9"
+    current_py_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "unknown")
+    if [ "$current_py_version" != "$py_version" ]; then
+        echo "Error: Current Python version is $current_py_version, but required version is $py_version"
+        echo "Please switch to Python $py_version using: pyenv shell $py_version"
+        exit 1
+    fi
+    echo "Using Python version: $current_py_version"
+    FREE_THREADING_CMAKE=""
 fi
-echo "Using Python version: $current_py_version"
-cmake ${CMAKE_ARGS} -DENABLE_PYTHON=1 -DPYBIND11_NONLIMITEDAPI_PYTHON_HEADERS_VERSION=${py_version} ${PROJ_DIR}
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    cmake ${CMAKE_ARGS} ${FREE_THREADING_CMAKE} -DENABLE_PYTHON=1 ${PROJ_DIR}
+else
+    cmake ${CMAKE_ARGS} -DENABLE_PYTHON=1 -DPYBIND11_NONLIMITEDAPI_PYTHON_HEADERS_VERSION=${py_version} ${PROJ_DIR}
+fi
 ninja -d keeprsp || true
 
 # del the binary and run ninja -v again to capture the command, then modify it to generate CHDB_PY_MODULE
@@ -377,28 +402,32 @@ cd ${PROJ_DIR} && pwd
 
 ccache -s || true
 
-# Auto-detect Python for pybind11 when pyenv is absent and env vars are not already set
-if ! command -v pyenv >/dev/null 2>&1 && [ -z "${CHDB_PYBIND11_NATIVE_PYTHON_EXECUTABLE:-}" ]; then
-    _py=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
-    if [ -n "${_py}" ]; then
-        _ver=$("${_py}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || true)
-        if [ -n "${_ver}" ]; then
-            export CHDB_PYBIND11_NATIVE_PYTHON_EXECUTABLE="${_py}"
-            export CHDB_PYBIND11_PYTHON_VERSIONS="${_ver}"
-            echo "Auto-detected Python ${_ver} at ${_py} for pybind11 build"
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    echo "Free-threading build: skipping pybind11 nonlimitedapi shim libraries (not needed)"
+else
+    # Auto-detect Python for pybind11 when pyenv is absent and env vars are not already set
+    if ! command -v pyenv >/dev/null 2>&1 && [ -z "${CHDB_PYBIND11_NATIVE_PYTHON_EXECUTABLE:-}" ]; then
+        _py=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
+        if [ -n "${_py}" ]; then
+            _ver=$("${_py}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || true)
+            if [ -n "${_ver}" ]; then
+                export CHDB_PYBIND11_NATIVE_PYTHON_EXECUTABLE="${_py}"
+                export CHDB_PYBIND11_PYTHON_VERSIONS="${_ver}"
+                echo "Auto-detected Python ${_ver} at ${_py} for pybind11 build"
+            fi
         fi
     fi
-fi
 
-CMAKE_ARGS="${CMAKE_ARGS}" bash ${DIR}/build_pybind11.sh --all
+    CMAKE_ARGS="${CMAKE_ARGS}" bash ${DIR}/build_pybind11.sh --all
 
-if [ ${build_type} != "Debug" ]; then
-    echo -e "\nStrip pybind11 stubs library:"
-    if [ "$(uname)" == "Darwin" ]; then
-        STUBS_LIB=${CHDB_DIR}/libpybind11nonlimitedapi_stubs.dylib
-        [ -f ${STUBS_LIB} ] && ${STRIP} -S -x ${STUBS_LIB}
-    else
-        STUBS_LIB=${CHDB_DIR}/libpybind11nonlimitedapi_stubs.so
-        [ -f ${STUBS_LIB} ] && ${STRIP} --strip-unneeded --remove-section=.comment --remove-section=.note ${STUBS_LIB}
+    if [ ${build_type} != "Debug" ]; then
+        echo -e "\nStrip pybind11 stubs library:"
+        if [ "$(uname)" == "Darwin" ]; then
+            STUBS_LIB=${CHDB_DIR}/libpybind11nonlimitedapi_stubs.dylib
+            [ -f ${STUBS_LIB} ] && ${STRIP} -S -x ${STUBS_LIB}
+        else
+            STUBS_LIB=${CHDB_DIR}/libpybind11nonlimitedapi_stubs.so
+            [ -f ${STUBS_LIB} ] && ${STRIP} --strip-unneeded --remove-section=.comment --remove-section=.note ${STUBS_LIB}
+        fi
     fi
 fi

--- a/chdb/build/download_python_headers.sh
+++ b/chdb/build/download_python_headers.sh
@@ -5,14 +5,40 @@ set -e
 TARGET_DIR="${HOME}/python_include"
 TEMP_DIR="${TARGET_DIR}/tmp"
 
-VERSIONS=(
-    "3.9.13:3.9:3.9"
-    "3.10.11:3.10:3.10"
-    "3.11.9:3.11:3.11"
-    "3.12.10:3.12:3.12"
-    "3.13.9:3.13:3.13"
-    "3.14.0:3.14:3.14"
+# Format: "full_version:subdir:minor_version"
+# For free-threading (e.g. "3.13t"), headers are extracted from PythonT_Framework.pkg
+declare -A VERSION_MAP=(
+    ["3.9"]="3.9.13:3.9:3.9"
+    ["3.10"]="3.10.11:3.10:3.10"
+    ["3.11"]="3.11.9:3.11:3.11"
+    ["3.12"]="3.12.10:3.12:3.12"
+    ["3.13"]="3.13.9:3.13:3.13"
+    ["3.14"]="3.14.0:3.14:3.14"
+    ["3.13t"]="3.13.9:3.13t:3.13"
+    ["3.14t"]="3.14.0:3.14t:3.14"
 )
+
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    if [ -z "${CHDB_FREE_THREADING_PYTHON_VERSION}" ]; then
+        echo "ERROR: CHDB_FREE_THREADING=1 requires CHDB_FREE_THREADING_PYTHON_VERSION (e.g. 3.13t)"
+        exit 1
+    fi
+    FT_VER="${CHDB_FREE_THREADING_PYTHON_VERSION}"
+    if [ -z "${VERSION_MAP[$FT_VER]}" ]; then
+        echo "ERROR: Unknown free-threading version: ${FT_VER}"
+        exit 1
+    fi
+    VERSIONS=("${VERSION_MAP[$FT_VER]}")
+else
+    VERSIONS=(
+        "${VERSION_MAP[3.9]}"
+        "${VERSION_MAP[3.10]}"
+        "${VERSION_MAP[3.11]}"
+        "${VERSION_MAP[3.12]}"
+        "${VERSION_MAP[3.13]}"
+        "${VERSION_MAP[3.14]}"
+    )
+fi
 
 cleanup() {
     rm -rf "$TEMP_DIR"
@@ -29,7 +55,6 @@ for entry in "${VERSIONS[@]}"; do
     echo "Processing Python ${FULL_VER}..."
     echo "=========================================="
 
-    # 检查目标目录是否已存在
     DEST_DIR="${TARGET_DIR}/${SUBDIR}"
     if [ -d "$DEST_DIR" ] && [ -f "${DEST_DIR}/Python.h" ]; then
         echo "✓ Python ${FULL_VER} headers already installed at ${DEST_DIR}"
@@ -54,20 +79,16 @@ for entry in "${VERSIONS[@]}"; do
     echo "Extracting pkg with 7z..."
     7z x -y python.pkg > /dev/null
 
-    PAYLOAD_DIR=""
-    for dir in Python_Framework.pkg PythonFramework-*.pkg; do
-        if [ -d "$dir" ] || [ -f "$dir/Payload" ]; then
-            PAYLOAD_DIR="$dir"
-            break
-        fi
-    done
-
-    if [ -z "$PAYLOAD_DIR" ]; then
-        PAYLOAD_DIR=$(find . -name "Payload" -type f | head -1 | xargs dirname)
+    # Select the correct framework sub-package
+    if [[ "$SUBDIR" == *t ]]; then
+        # Free-threading: use PythonT_Framework.pkg
+        PAYLOAD_DIR="PythonT_Framework.pkg"
+    else
+        PAYLOAD_DIR="Python_Framework.pkg"
     fi
 
-    if [ -z "$PAYLOAD_DIR" ] || [ ! -f "${PAYLOAD_DIR}/Payload" ]; then
-        echo "ERROR: Cannot find Payload for Python ${FULL_VER}"
+    if [ ! -f "${PAYLOAD_DIR}/Payload" ]; then
+        echo "ERROR: Cannot find ${PAYLOAD_DIR}/Payload for Python ${FULL_VER}"
         exit 1
     fi
 
@@ -76,15 +97,28 @@ for entry in "${VERSIONS[@]}"; do
     7z x -y Payload -so 2>/dev/null | cpio -id 2>/dev/null || true
 
     HEADER_SRC=""
-    for path in \
-        "Versions/${MINOR_VER}/Headers" \
-        "Headers"
-    do
-        if [ -d "$path" ] && [ -f "$path/Python.h" ]; then
-            HEADER_SRC="$path"
-            break
-        fi
-    done
+    if [[ "$SUBDIR" == *t ]]; then
+        # PythonT framework: headers in include/python3.Xt/
+        for path in \
+            "Versions/${MINOR_VER}/include/python${MINOR_VER}t" \
+            "include/python${MINOR_VER}t"
+        do
+            if [ -d "$path" ] && [ -f "$path/Python.h" ]; then
+                HEADER_SRC="$path"
+                break
+            fi
+        done
+    else
+        for path in \
+            "Versions/${MINOR_VER}/Headers" \
+            "Headers"
+        do
+            if [ -d "$path" ] && [ -f "$path/Python.h" ]; then
+                HEADER_SRC="$path"
+                break
+            fi
+        done
+    fi
 
     if [ -z "$HEADER_SRC" ]; then
         PYTHON_H=$(find . -name "Python.h" -type f | head -1)

--- a/chdb/build_mac_on_linux.sh
+++ b/chdb/build_mac_on_linux.sh
@@ -48,14 +48,32 @@ else
 fi
 
 # Download macOS SDK
+# Use a download-then-verify-then-extract flow rather than the original
+# `curl -L | tar xJ` pipe: GitHub release-assets CDN occasionally serves a
+# short HTML/error body for this asset, which the old pipe would silently
+# stream into xz and abort the build. -f makes curl fail on HTTP errors,
+# --retry/--retry-all-errors rides out CDN blips, and the size check catches
+# any remaining short-payload pathology before extraction.
 SDK_PATH="${PROJ_DIR}/cmake/toolchain/${SDK_DIR}"
+SDK_URL='https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz'
 echo "Downloading macOS SDK to ${SDK_PATH}..."
 mkdir -p "${SDK_PATH}"
 cd "${SDK_PATH}"
-if ! curl -L 'https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz' | tar xJ --strip-components=1; then
-    echo "Error: Failed to download macOS SDK"
+if ! curl -fL --retry 5 --retry-delay 5 --retry-all-errors \
+     -o MacOSX11.0.sdk.tar.xz "${SDK_URL}"; then
+    echo "Error: Failed to download macOS SDK from ${SDK_URL}"
     exit 1
 fi
+sdk_size=$(stat -c %s MacOSX11.0.sdk.tar.xz 2>/dev/null || stat -f %z MacOSX11.0.sdk.tar.xz)
+if [ "${sdk_size:-0}" -lt 10000000 ]; then
+    echo "Error: SDK tarball too small (${sdk_size} bytes) — likely a CDN error body, aborting"
+    exit 1
+fi
+if ! tar xJf MacOSX11.0.sdk.tar.xz --strip-components=1; then
+    echo "Error: Failed to extract macOS SDK"
+    exit 1
+fi
+rm -f MacOSX11.0.sdk.tar.xz
 echo "macOS SDK downloaded successfully"
 
 # Download Python headers
@@ -253,7 +271,16 @@ fi
 
 # Build chdb python module
 CHDB_PYTHON_INCLUDE_DIR_PREFIX="${HOME}/python_include"
-cmake ${CMAKE_ARGS} -DENABLE_PYTHON=1 -DCHDB_CROSSCOMPILING=1 -DCHDB_PYTHON_INCLUDE_DIR_PREFIX=${CHDB_PYTHON_INCLUDE_DIR_PREFIX} -DPYBIND11_NOPYTHON=ON ..
+FREE_THREADING_CMAKE=""
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    if [ -z "${CHDB_FREE_THREADING_PYTHON_VERSION}" ]; then
+        echo "Error: CHDB_FREE_THREADING=1 requires CHDB_FREE_THREADING_PYTHON_VERSION (e.g. 3.13t)"
+        exit 1
+    fi
+    FT_PY_VERSION="${CHDB_FREE_THREADING_PYTHON_VERSION}"
+    FREE_THREADING_CMAKE="-DCHDB_FREE_THREADING=1 -DCHDB_FREE_THREADING_PYTHON_VERSION=${FT_PY_VERSION}"
+fi
+cmake ${CMAKE_ARGS} ${FREE_THREADING_CMAKE} -DENABLE_PYTHON=1 -DCHDB_CROSSCOMPILING=1 -DCHDB_PYTHON_INCLUDE_DIR_PREFIX=${CHDB_PYTHON_INCLUDE_DIR_PREFIX} -DPYBIND11_NOPYTHON=ON ..
 ninja -d keeprsp || true
 
 # Delete the binary and run ninja -v again to capture the command
@@ -360,18 +387,22 @@ cd ${PROJ_DIR} && pwd
 
 ccache -s || true
 
-if ! CMAKE_ARGS="${CMAKE_ARGS}" CHDB_PYTHON_INCLUDE_DIR_PREFIX="${HOME}/python_include" bash ${DIR}/build_pybind11.sh --all --cross-compile --build-dir=${BUILD_DIR}; then
-    echo "Error: Failed to build pybind11 libraries"
-    exit 1
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    echo "Free-threading build: skipping pybind11 nonlimitedapi shim libraries (not needed)"
+else
+    if ! CMAKE_ARGS="${CMAKE_ARGS}" CHDB_PYTHON_INCLUDE_DIR_PREFIX="${HOME}/python_include" bash ${DIR}/build_pybind11.sh --all --cross-compile --build-dir=${BUILD_DIR}; then
+        echo "Error: Failed to build pybind11 libraries"
+        exit 1
+    fi
+
+    if [ ${build_type} != "Debug" ]; then
+        echo -e "\nStrip pybind11 stubs library:"
+        STUBS_LIB=${CHDB_DIR}/libpybind11nonlimitedapi_stubs.dylib
+        [ -f ${STUBS_LIB} ] && ${STRIP} -S -x ${STUBS_LIB}
+    fi
 fi
 
-if [ ${build_type} != "Debug" ]; then
-    echo -e "\nStrip pybind11 stubs library:"
-    STUBS_LIB=${CHDB_DIR}/libpybind11nonlimitedapi_stubs.dylib
-    [ -f ${STUBS_LIB} ] && ${STRIP} -S -x ${STUBS_LIB}
-fi
-
-# Fix LC_RPATH in _chdb.abi3.so for cross-compiled builds
+# Fix LC_RPATH in module for cross-compiled builds
 echo -e "\nFixing LC_RPATH in ${CHDB_PY_MODULE}..."
 INSTALL_NAME_TOOL="${CCTOOLS_BIN}/${DARWIN_TRIPLE}-install_name_tool"
 OTOOL="${CCTOOLS_BIN}/${DARWIN_TRIPLE}-otool"
@@ -379,15 +410,17 @@ OTOOL="${CCTOOLS_BIN}/${DARWIN_TRIPLE}-otool"
 echo -e "\nPre library dependencies:"
 ${OTOOL} -L ${CHDB_DIR}/${CHDB_PY_MODULE}
 
-STUBS_LIB="libpybind11nonlimitedapi_stubs.dylib"
-OLD_STUBS_PATH=$(${OTOOL} -L ${CHDB_DIR}/${CHDB_PY_MODULE} | grep "${STUBS_LIB}" | awk '{print $1}')
-if [ -n "${OLD_STUBS_PATH}" ]; then
-    echo "Changing ${STUBS_LIB} reference:"
-    echo "  From: ${OLD_STUBS_PATH}"
-    echo "  To:   @loader_path/${STUBS_LIB}"
-    ${INSTALL_NAME_TOOL} -change "${OLD_STUBS_PATH}" "@loader_path/${STUBS_LIB}" ${CHDB_DIR}/${CHDB_PY_MODULE}
-else
-    echo "${STUBS_LIB} not found in dependencies"
+if [ "${CHDB_FREE_THREADING}" != "1" ]; then
+    STUBS_LIB="libpybind11nonlimitedapi_stubs.dylib"
+    OLD_STUBS_PATH=$(${OTOOL} -L ${CHDB_DIR}/${CHDB_PY_MODULE} | grep "${STUBS_LIB}" | awk '{print $1}')
+    if [ -n "${OLD_STUBS_PATH}" ]; then
+        echo "Changing ${STUBS_LIB} reference:"
+        echo "  From: ${OLD_STUBS_PATH}"
+        echo "  To:   @loader_path/${STUBS_LIB}"
+        ${INSTALL_NAME_TOOL} -change "${OLD_STUBS_PATH}" "@loader_path/${STUBS_LIB}" ${CHDB_DIR}/${CHDB_PY_MODULE}
+    else
+        echo "${STUBS_LIB} not found in dependencies"
+    fi
 fi
 
 echo -e "\nPost library dependencies:"

--- a/chdb/build_pybind11.sh
+++ b/chdb/build_pybind11.sh
@@ -61,7 +61,7 @@ build_pybind11_nonlimitedapi() {
         custom_python_path="${force_python}"
         echo "Using explicit Python executable: ${custom_python_path}"
     elif command -v pyenv >/dev/null 2>&1; then
-        full_py_version=$(pyenv versions --bare | grep "^${py_version}\." | head -n 1)
+        full_py_version=$(pyenv versions --bare | grep "^${py_version}\." | grep -v 't$' | head -n 1)
 
         if [ -n "$full_py_version" ]; then
             custom_python_path="$HOME/.pyenv/versions/${full_py_version}/bin/python3"
@@ -155,7 +155,7 @@ build_all_pybind11_nonlimitedapi() {
         if command -v pyenv >/dev/null 2>&1; then
             for version in "${python_versions[@]}"; do
                 local pyenv_version
-                pyenv_version=$(pyenv versions --bare | grep "^${version}\." | head -1)
+                pyenv_version=$(pyenv versions --bare | grep "^${version}\." | grep -v 't$' | head -1)
                 if [ -z "$pyenv_version" ]; then
                     echo "Error: Python ${version} not found in pyenv. Please install it with: pyenv install ${version}.x"
                     exit 1

--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -36,12 +36,44 @@ fi
 CORE_VERSION=$(${PYTHON} -c "import chdb; print(chdb.query('SELECT version()', 'CSV').bytes().decode().strip())" 2>/dev/null || echo "unknown")
 echo "chdb-core engine version: ${CORE_VERSION}"
 
+resolve_latest_chdb_tag() {
+    local i auth=() body tag
+    [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    # Primary path: GitHub API. Keeps pre-release filtering semantics.
+    for i in 1 2 3; do
+        # ${auth[@]+"${auth[@]}"} expands to nothing if 'auth' is an empty
+        # array — needed for macOS bash 3.2 + `set -u`, which otherwise
+        # treats "${auth[@]}" as an unbound variable.
+        body=$(curl -fsSL ${auth[@]+"${auth[@]}"} \
+            https://api.github.com/repos/chdb-io/chdb/releases/latest 2>/dev/null) || body=""
+        if [ -n "$body" ]; then
+            tag=$(printf '%s' "$body" \
+                | ${PYTHON} -c "import json, sys; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null) || tag=""
+            if [ -n "$tag" ]; then
+                printf '%s' "$tag"
+                return 0
+            fi
+        fi
+        sleep $((i * 5))
+    done
+    # Fallback: git ls-remote. Bypasses the GitHub API rate limit entirely
+    # when the shared runner IP pool exhausts the unauthenticated 60/h quota.
+    echo "GitHub API failed after 3 attempts; falling back to git ls-remote..." >&2
+    tag=$(git ls-remote --tags --refs --sort=-v:refname https://github.com/chdb-io/chdb.git 'v*' 2>/dev/null \
+        | head -1 | awk '{print $2}' | sed 's|refs/tags/||')
+    if [ -n "$tag" ]; then
+        printf '%s' "$tag"
+        return 0
+    fi
+    return 1
+}
+
 if [ -z "${CHDB_TAG:-}" ]; then
     echo "Resolving latest chdb release tag from GitHub..."
-    CHDB_TAG=$(curl -fsSL \
-        ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
-        https://api.github.com/repos/chdb-io/chdb/releases/latest \
-        | ${PYTHON} -c "import json, sys; print(json.load(sys.stdin)['tag_name'])")
+    CHDB_TAG=$(resolve_latest_chdb_tag) || {
+        echo "ERROR: failed to resolve latest chdb release tag" >&2
+        exit 1
+    }
 fi
 echo "Using chdb tag: ${CHDB_TAG}"
 

--- a/chdb/vars.sh
+++ b/chdb/vars.sh
@@ -4,7 +4,22 @@ PROJ_DIR="${DIR}/.." # project root directory
 BUILD_DIR="$PROJ_DIR/buildlib" # build directory
 CHDB_DIR="$PROJ_DIR/chdb" # chdb directory
 CHDB_PY_MOD="_chdb"
-CHDB_PY_MODULE="${CHDB_PY_MOD}.abi3.so"
+if [ "${CHDB_FREE_THREADING}" == "1" ]; then
+    if [ "${CHDB_CROSSCOMPILING}" == "1" ]; then
+        _ft_ver=${CHDB_FREE_THREADING_PYTHON_VERSION:?requires CHDB_FREE_THREADING_PYTHON_VERSION}
+        _py_tag=${_ft_ver//./}      # 3.13t → 313t
+        EXT_SUFFIX=".cpython-${_py_tag}-darwin.so"
+    else
+        EXT_SUFFIX=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
+        if [ -z "$EXT_SUFFIX" ]; then
+            echo "Error: failed to get EXT_SUFFIX from free-threading Python"
+            exit 1
+        fi
+    fi
+    CHDB_PY_MODULE="${CHDB_PY_MOD}${EXT_SUFFIX}"
+else
+    CHDB_PY_MODULE="${CHDB_PY_MOD}.abi3.so"
+fi
 pushd ${PROJ_DIR} > /dev/null
 CHDB_VERSION=$(python3 -c 'import setup; print(setup.get_latest_git_tag())' 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
 popd > /dev/null

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -18,7 +18,7 @@ if (ARCH_AARCH64)
         # crc32 is optional in v8.0 and mandatory in v8.1. Enable it as __crc32()* is used in lot's of places and even very old ARM CPUs
         # support it.
         set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8+crc")
-        list(APPEND RUSTFLAGS_CPU "-C" "target_feature=+crc,-neon")
+        list(APPEND RUSTFLAGS_CPU "-C" "target_feature=+crc")
     else ()
         # ARMv8.2 is quite ancient but the lowest common denominator supported by both Graviton 2 and 3 processors [1, 10]. In particular, it
         # includes LSE (made mandatory with ARMv8.1) which provides nice speedups without having to fall back to compat flag

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -116,7 +116,7 @@ add_contrib (h3-cmake h3)
 add_contrib (mariadb-connector-c-cmake mariadb-connector-c)
 add_contrib (libfiu-cmake libfiu)
 
-if (ENABLE_PYTHON)
+if (ENABLE_PYTHON AND NOT CHDB_FREE_THREADING)
     add_contrib (pybind11-cmake pybind11)
 endif()
 

--- a/programs/local/AIQueryProcessor.cpp
+++ b/programs/local/AIQueryProcessor.cpp
@@ -4,7 +4,9 @@
 #include "PybindWrapper.h"
 
 #include <pybind11/pybind11.h>
+#ifndef CHDB_FREE_THREADING
 #include <pybind11/detail/non_limited_api.h>
+#endif
 
 #if USE_CLIENT_AI
 #include <Client/AI/AIClientFactory.h>

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -67,13 +67,25 @@ if (USE_PYTHON)
     )
     set (CLICKHOUSE_LOCAL_SOURCES ${CLICKHOUSE_LOCAL_SOURCES} ${CHDB_SOURCES})
 
-    # Use contrib/pybind11 instead of system pybind11
-    set(PYBIND11_INCLUDE_DIR "${ClickHouse_SOURCE_DIR}/contrib/pybind11/include")
+    # Select pybind11 include path based on build mode
+    if (CHDB_FREE_THREADING)
+        # Free-threading builds use upstream pybind11 (no limited API / stubs needed)
+        set(PYBIND11_INCLUDE_DIR "${ClickHouse_SOURCE_DIR}/contrib/pybind11-upstream/include")
+    else()
+        # Regular builds use the mrbind-pybind11 fork with stable ABI stubs
+        set(PYBIND11_INCLUDE_DIR "${ClickHouse_SOURCE_DIR}/contrib/pybind11/include")
+    endif()
 
     # include Python.h
     if(CHDB_CROSSCOMPILING)
-        # For cross-compiling, use the provided Python include directory
-        set(PYTHON_INCLUDE_DIR "${CHDB_PYTHON_INCLUDE_DIR_PREFIX}/3.9")
+        if (CHDB_FREE_THREADING)
+            if (NOT DEFINED CHDB_FREE_THREADING_PYTHON_VERSION)
+                message(FATAL_ERROR "CHDB_FREE_THREADING requires CHDB_FREE_THREADING_PYTHON_VERSION (e.g. 3.13t)")
+            endif()
+            set(PYTHON_INCLUDE_DIR "${CHDB_PYTHON_INCLUDE_DIR_PREFIX}/${CHDB_FREE_THREADING_PYTHON_VERSION}")
+        else()
+            set(PYTHON_INCLUDE_DIR "${CHDB_PYTHON_INCLUDE_DIR_PREFIX}/3.9")
+        endif()
         message(STATUS "Cross-compiling: Using Python include directory: ${PYTHON_INCLUDE_DIR}")
     else()
         # get_path('include') is often wrong on macOS (e.g. /Library/Python/3.9/include with no headers).
@@ -142,7 +154,10 @@ endif()
 if (TARGET ch_contrib::arrow)
     target_link_libraries(clickhouse-local-lib PRIVATE ch_contrib::arrow)
 endif()
-if (TARGET ch_contrib::pybind11_stubs)
+if (CHDB_FREE_THREADING)
+    target_compile_definitions(clickhouse-local-lib PRIVATE Py_GIL_DISABLED=1)
+    target_compile_definitions(clickhouse-local-lib PRIVATE CHDB_FREE_THREADING=1)
+elseif (TARGET ch_contrib::pybind11_stubs)
     target_link_libraries(clickhouse-local-lib PRIVATE ch_contrib::pybind11_stubs)
     target_compile_definitions(clickhouse-local-lib PRIVATE Py_LIMITED_API=0x03090000)
 endif()

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -11,7 +11,9 @@
 #include "PyDateTimeHelper.h"
 #include "chdb.h"
 
+#ifndef CHDB_FREE_THREADING
 #include <pybind11/detail/non_limited_api.h>
+#endif
 #include <pybind11/pybind11.h>
 #include <IO/Progress.h>
 #include <Poco/String.h>
@@ -730,7 +732,11 @@ static void chdb_cleanup_at_exit()
 #endif
 }
 
+#ifdef CHDB_FREE_THREADING
+PYBIND11_MODULE(_chdb, m, py::mod_gil_not_used())
+#else
 PYBIND11_MODULE(_chdb, m)
+#endif
 {
     m.doc() = "chDB module for query function";
 

--- a/programs/local/NumpyArray.cpp
+++ b/programs/local/NumpyArray.cpp
@@ -429,6 +429,10 @@ static bool CHColumnUUIDToNumpyArray(NumpyAppendData & append_data)
 	auto * dest_ptr = reinterpret_cast<PyObject **>(append_data.target_data);
 	auto * mask_ptr = append_data.target_mask;
 
+	/// Hoisted out of the per-row loop: ImportCache() returns a shared_ptr singleton,
+	/// so resolving it once per call avoids redundant shared_ptr ref-count traffic.
+	auto & import_cache = PythonImporter::ImportCache();
+
 	for (size_t i = 0; i < append_data.src_count; i++)
 	{
 		size_t src_index = append_data.src_offset + i;
@@ -448,7 +452,6 @@ static bool CHColumnUUIDToNumpyArray(NumpyAppendData & append_data)
 			const size_t uuid_str_len = formatted_uuid.size();
 
 			/// Create Python uuid.UUID object
-			auto & import_cache = PythonImporter::ImportCache();
 			py::handle uuid_handle = import_cache.uuid.UUID()(String(uuid_str, uuid_str_len)).release();
 			dest_ptr[dest_index] = uuid_handle.ptr();
 			mask_ptr[dest_index] = false;
@@ -478,6 +481,10 @@ static bool CHColumnIPv4ToNumpyArray(NumpyAppendData & append_data)
 	auto * dest_ptr = reinterpret_cast<PyObject **>(append_data.target_data);
 	auto * mask_ptr = append_data.target_mask;
 
+	/// Hoisted out of the per-row loop: ImportCache() returns a shared_ptr singleton,
+	/// so resolving it once per call avoids redundant shared_ptr ref-count traffic.
+	auto & import_cache = PythonImporter::ImportCache();
+
 	for (size_t i = 0; i < append_data.src_count; i++)
 	{
 		size_t src_index = append_data.src_offset + i;
@@ -499,7 +506,6 @@ static bool CHColumnIPv4ToNumpyArray(NumpyAppendData & append_data)
 			const size_t ipv4_str_len = ptr - ipv4_str;
 
 			/// Create Python ipaddress.IPv4Address object
-			auto & import_cache = PythonImporter::ImportCache();
 			py::handle ipv4_handle = import_cache.ipaddress.ipv4_address()(String(ipv4_str, ipv4_str_len)).release();
 			dest_ptr[dest_index] = ipv4_handle.ptr();
 			mask_ptr[dest_index] = false;
@@ -529,6 +535,10 @@ static bool CHColumnIPv6ToNumpyArray(NumpyAppendData & append_data)
 	auto * dest_ptr = reinterpret_cast<PyObject **>(append_data.target_data);
 	auto * mask_ptr = append_data.target_mask;
 
+	/// Hoisted out of the per-row loop: ImportCache() returns a shared_ptr singleton,
+	/// so resolving it once per call avoids redundant shared_ptr ref-count traffic.
+	auto & import_cache = PythonImporter::ImportCache();
+
 	for (size_t i = 0; i < append_data.src_count; i++)
 	{
 		size_t src_index = append_data.src_offset + i;
@@ -551,7 +561,6 @@ static bool CHColumnIPv6ToNumpyArray(NumpyAppendData & append_data)
 			const size_t ipv6_str_len = ptr - ipv6_str;
 
 			/// Create Python ipaddress.IPv6Address object
-			auto & import_cache = PythonImporter::ImportCache();
 			py::handle ipv6_handle = import_cache.ipaddress.ipv6_address()(String(ipv6_str, ipv6_str_len)).release();
 			dest_ptr[dest_index] = ipv6_handle.ptr();
 			mask_ptr[dest_index] = false;

--- a/programs/local/PybindWrapper.cpp
+++ b/programs/local/PybindWrapper.cpp
@@ -1,6 +1,8 @@
 #include "PybindWrapper.h"
 
+#ifndef CHDB_FREE_THREADING
 #include <pybind11/detail/non_limited_api.h>
+#endif
 
 #include <Common/Exception.h>
 
@@ -21,7 +23,17 @@ namespace pybind11
 
 bool gil_check()
 {
+#ifdef CHDB_FREE_THREADING
+    // Free-threading builds don't go through the limited-API trampoline, so
+    // call the CPython symbol directly. Returning true unconditionally would
+    // turn every chassert(py::gil_check()) / py::gil_assert() into a no-op
+    // and mask missing thread-state setup. PyGILState_Check returns 0 when
+    // the current OS thread has no Python thread state attached — exactly
+    // the invariant callers want, with or without a GIL.
+    return static_cast<bool>(::PyGILState_Check());
+#else
     return static_cast<bool>(pybind11::non_limited_api::PyGILState_Check());
+#endif
 }
 
 void gil_assert()

--- a/programs/local/PythonConversion.cpp
+++ b/programs/local/PythonConversion.cpp
@@ -1,7 +1,9 @@
 #include "PythonConversion.h"
 #include "PythonImporter.h"
 
+#ifndef CHDB_FREE_THREADING
 #include <pybind11/detail/non_limited_api.h>
+#endif
 #include <Columns/ColumnNullable.h>
 #include <Common/Exception.h>
 #include <IO/ReadBuffer.h>
@@ -219,7 +221,11 @@ static void writeByteArray(const py::handle & obj, rapidjson::Value & json_value
 {
     auto * ptr = obj.ptr();
     auto * data = PyByteArray_AsString(ptr);
+#ifdef CHDB_FREE_THREADING
+    auto size = PyByteArray_GET_SIZE(ptr);
+#else
     auto size = pybind11::non_limited_api::PyByteArray_GET_SIZE_(ptr);
+#endif
     json_value.SetString(data, size, allocator);
 }
 

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -21,9 +21,20 @@ namespace ErrorCodes
 namespace CHDB {
 
 py::handle PythonImportCacheItem::operator()(bool load) {
+#ifndef CHDB_FREE_THREADING
+	// On stock (GIL-bearing) builds the GIL serializes this read against the
+	// call_once initializer's write to `object`, so the unsynchronized
+	// pre-check is a safe fast path that avoids rebuilding the hierarchy
+	// stack and re-entering PythonImporter::Import on every steady-state
+	// attribute access.
 	if (IsLoaded())
 		return object;
-
+#endif
+	// Free-threaded: no unsynchronized pre-check on `object`. Reading `object`
+	// concurrently with the call_once initializer's write is a C++ data race.
+	// std::call_once already provides the necessary happens-before — every
+	// passive call_once on the same flag synchronizes with the completion of
+	// the initializer, so the post-call_once read of `object` is well-defined.
 	std::stack<PythonImportCacheItem *> hierarchy;
 
 	PythonImportCacheItem * item = this;
@@ -90,18 +101,42 @@ void PythonImportCacheItem::LoadAttribute(PythonImportCache & cache, py::handle 
 
 py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle source, bool load)
 {
+#ifndef CHDB_FREE_THREADING
+	// Stock (GIL-bearing) builds: the GIL already serializes all callers, so a
+	// direct call is correct and avoids a std::call_once + GIL deadlock window.
+	// LoadModule() invokes py::module::import(), and CPython's import machinery
+	// may release the GIL internally (per-module import lock, file I/O,
+	// arbitrary module top-level code). If one thread were stuck inside
+	// std::call_once while another acquired the GIL and reached the same
+	// call_once, the second thread would block in call_once *while holding the
+	// GIL*, leaving no thread able to re-acquire the GIL and finish the
+	// initializer. Calling LoadModule()/LoadAttribute() directly under the GIL
+	// avoids that window entirely.
 	if (IsLoaded())
 		return object;
-
 	if (!load)
 		return object;
-
 	if (is_module)
 		LoadModule(cache);
 	else
 		LoadAttribute(cache, source);
+	return object;
+#else
+	// Free-threaded: no GIL to serialize callers, so use std::call_once. The
+	// initializer's write to `object` happens-before every passive call_once on
+	// the same flag, so the post-call_once read below is well-defined.
+	if (!load)
+		return object;
+
+	std::call_once(load_flag, [&]() {
+		if (is_module)
+			LoadModule(cache);
+		else
+			LoadAttribute(cache, source);
+	});
 
 	return object;
+#endif
 }
 
 PythonImportCache::~PythonImportCache()
@@ -122,6 +157,7 @@ PythonImportCache::~PythonImportCache()
 py::handle PythonImportCache::AddCache(py::object item)
 {
 	auto object_ptr = item.ptr();
+	std::lock_guard<std::mutex> lock(cache_mutex);
 	owned_objects.push_back(std::move(item));
 	return object_ptr;
 }

--- a/programs/local/PythonImportCache.h
+++ b/programs/local/PythonImportCache.h
@@ -10,6 +10,8 @@
 #include "IPAddressCacheItem.h"
 #include "ZoneInfoCacheItem.h"
 
+#include <memory>
+#include <mutex>
 #include <vector>
 
 namespace CHDB {
@@ -36,6 +38,7 @@ public:
 	py::handle AddCache(py::object item);
 
 private:
+	std::mutex cache_mutex;
 	std::vector<py::object> owned_objects;
 };
 

--- a/programs/local/PythonImportCacheItem.h
+++ b/programs/local/PythonImportCacheItem.h
@@ -3,6 +3,7 @@
 #include "PybindWrapper.h"
 
 #include <base/types.h>
+#include <mutex>
 
 namespace CHDB {
 
@@ -52,6 +53,7 @@ private:
 	bool load_succeeded;
 	PythonImportCacheItem * parent;
 	py::handle object;
+	std::once_flag load_flag;
 };
 
 } // namespace CHDB

--- a/programs/local/PythonImporter.cpp
+++ b/programs/local/PythonImporter.cpp
@@ -11,7 +11,7 @@ py::handle PythonImporter::Import(std::stack<PythonImportCacheItem *> & hierarch
 
 	while (!hierarchy.empty()) {
 		// From top to bottom, import them
-		auto item = hierarchy.top();
+		auto * item = hierarchy.top();
 		hierarchy.pop();
 		source = item->Load(import_cache, source, load);
 		if (!source)
@@ -26,14 +26,34 @@ py::handle PythonImporter::Import(std::stack<PythonImportCacheItem *> & hierarch
 
 PythonImportCache & PythonImporter::ImportCache()
 {
+#ifdef CHDB_FREE_THREADING
+	// ImportCache() sits on the per-row scan path (PandasScan -> isNone() ->
+	// ImportCache()). A process-global mutex here would serialize every scan
+	// thread once per row on FT, defeating the whole point of the FT build.
+	// std::call_once gives us a one-shot first-init synchronization point and a
+	// lock-free fast path thereafter. The initializer is pure C++ allocation —
+	// no Python calls — so it cannot release any lock or recurse, sidestepping
+	// the call_once + GIL deadlock concern that applies to module imports.
+	static std::once_flag init_flag;
+	std::call_once(init_flag, []() {
+		python_import_cache = std::make_shared<PythonImportCache>();
+	});
+#else
+	// Stock builds: GIL already serializes all callers, so the unguarded
+	// null-check + assignment is safe.
 	if (!python_import_cache)
 		python_import_cache = std::make_shared<PythonImportCache>();
-
-	return *python_import_cache.get();
+#endif
+	return *python_import_cache;
 }
 
 void PythonImporter::destroy()
 {
+	// destroy() runs only at interpreter shutdown (via the _destroy_import_cache
+	// capsule in LocalChdb.cpp), after all worker threads have joined, so no
+	// reader can race with this reset. On FT, the once_flag remains "completed"
+	// after this reset — re-init from the same process would be a no-op, which
+	// is fine because destroy() is the shutdown path, not a re-init hook.
 	python_import_cache.reset();
 }
 

--- a/programs/local/PythonImporter.h
+++ b/programs/local/PythonImporter.h
@@ -11,6 +11,12 @@ struct PythonImporter {
 public:
 	static py::handle Import(std::stack<PythonImportCacheItem *> & hierarchy, bool load = true);
 
+	// Returns a reference to the process-wide PythonImportCache singleton.
+	// destroy() runs only at interpreter shutdown after all worker threads have
+	// joined, so the reference remains valid for the duration of every caller's
+	// use. On free-threaded builds, first-init is synchronized via std::call_once
+	// inside ImportCache() and the steady-state read is lock-free; on stock
+	// (GIL-bearing) builds, the GIL already provides that mutual exclusion.
 	static PythonImportCache & ImportCache();
 
 	static void destroy();

--- a/programs/local/PythonSource.cpp
+++ b/programs/local/PythonSource.cpp
@@ -12,7 +12,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
+#ifndef CHDB_FREE_THREADING
 #include <pybind11/detail/non_limited_api.h>
+#endif
 
 #include <Columns/ColumnVector.h>
 #include <Poco/Logger.h>
@@ -119,7 +121,18 @@ void PythonSource::insert_string_from_array(const py::handle obj, const MutableC
     auto * string_column = static_cast<ColumnString *>(column.get());
     for (auto && item : array)
     {
-        FillColumnString(item.ptr(), string_column);
+        auto * item_ptr = item.ptr();
+        // FillColumnString assumes the item is a Python unicode object and uses
+        // PyUnicode_* macros that reinterpret_cast obj to PyCompactUnicodeObject.
+        // Array items can be None/NaN/bytes/etc., so validate here and fall back
+        // to insertObjToStringColumn for non-unicode items (mirrors the pattern
+        // in convert_string_array_to_block).
+        if (!PyUnicode_Check(item_ptr))
+        {
+            insertObjToStringColumn(item_ptr, string_column);
+            continue;
+        }
+        FillColumnString(item_ptr, string_column);
     }
 }
 

--- a/programs/local/PythonUtils.cpp
+++ b/programs/local/PythonUtils.cpp
@@ -4,7 +4,9 @@
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/numpy.h>
+#ifndef CHDB_FREE_THREADING
 #include <pybind11/detail/non_limited_api.h>
+#endif
 #include <utf8proc.h>
 #include <Columns/ColumnString.h>
 #include <Common/logger_useful.h>
@@ -90,23 +92,59 @@ void FillColumnString(PyObject * obj, ColumnString * column)
     size_t codepoint_cnt;
     bool direct_insert;
 
-    /// Due to the use of Python's Stable C API, many Python C API functions cannot be used
-    /// directly within chdb. The related code has been moved to libpybind11nonlimitedapi_chdb,
-    /// and the wrapped interfaces are called through pybind11::non_limited_api namespace.
-    if (pybind11::non_limited_api::getPyUnicodeUtf8(obj, data, length, kind, codepoint_cnt, direct_insert))
+#ifdef CHDB_FREE_THREADING
+    direct_insert = true;
+
+    if (PyUnicode_IS_COMPACT_ASCII(obj))
     {
-        if (direct_insert)
-        {
-            column->insertData(data, length);
-        }
-        else
-        {
-            ConvertPyUnicodeToUtf8(data, kind, codepoint_cnt, column->getOffsets(), column->getChars());
-        }
+        data = reinterpret_cast<const char *>(PyUnicode_1BYTE_DATA(obj));
+        length = PyUnicode_GET_LENGTH(obj);
     }
     else
     {
+        auto * unicode = reinterpret_cast<PyCompactUnicodeObject *>(obj);
+        if (unicode->utf8 != nullptr)
+        {
+            data = reinterpret_cast<const char *>(unicode->utf8);
+            length = unicode->utf8_length;
+        }
+        else if (PyUnicode_IS_COMPACT(obj))
+        {
+            kind = PyUnicode_KIND(obj);
+            if (kind == PyUnicode_1BYTE_KIND)
+                data = reinterpret_cast<const char *>(PyUnicode_1BYTE_DATA(obj));
+            else if (kind == PyUnicode_2BYTE_KIND)
+                data = reinterpret_cast<const char *>(PyUnicode_2BYTE_DATA(obj));
+            else if (kind == PyUnicode_4BYTE_KIND)
+                data = reinterpret_cast<const char *>(PyUnicode_4BYTE_DATA(obj));
+            else
+                throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED, "Failed to convert Python unicode object to UTF-8");
+
+            codepoint_cnt = PyUnicode_GET_LENGTH(obj);
+            direct_insert = false;
+        }
+        else
+        {
+            pybind11::gil_scoped_acquire acquire;
+            Py_ssize_t bytes_size = -1;
+            data = PyUnicode_AsUTF8AndSize(obj, &bytes_size);
+            if (!data || bytes_size < 0)
+                throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED, "Failed to convert Python unicode object to UTF-8");
+            length = bytes_size;
+        }
+    }
+#else
+    if (!pybind11::non_limited_api::getPyUnicodeUtf8(obj, data, length, kind, codepoint_cnt, direct_insert))
         throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED, "Failed to convert Python unicode object to UTF-8");
+#endif
+
+    if (direct_insert)
+    {
+        column->insertData(data, length);
+    }
+    else
+    {
+        ConvertPyUnicodeToUtf8(data, kind, codepoint_cnt, column->getOffsets(), column->getChars());
     }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,14 @@ def _chdb_zipfile_init(self, *args, **kwargs):
 zipfile.ZipFile.__init__ = _chdb_zipfile_init
 
 
+def is_free_threading():
+    """Check if this is a free-threading build, controlled by env var only."""
+    return os.environ.get("CHDB_FREE_THREADING") == "1"
+
+
 def get_python_ext_suffix():
-    # Use Limited API suffix for cross-version compatibility
+    if is_free_threading():
+        return sysconfig.get_config_var("EXT_SUFFIX")
     return ".abi3.so"
 
 
@@ -189,8 +195,6 @@ if __name__ == "__main__":
                 libraries=[],
                 library_dirs=[libdir],
                 extra_objects=[chdb_so],
-                define_macros=[("Py_LIMITED_API", "0x03090000")],
-                py_limited_api=True,
             ),
         ]
         # fix the version in chdb/__init__.py
@@ -207,16 +211,16 @@ if __name__ == "__main__":
             for file in files:
                 if file.endswith(".py") or file.endswith(".pyi") or file == "py.typed":
                     pkg_files.append(os.path.join(root, file))
-                # Include pybind11 nonlimitedapi libraries for all Python versions
-                elif file.startswith("libpybind11nonlimitedapi_chdb_") and (
-                    file.endswith(".dylib") or file.endswith(".so")
-                ):
-                    pkg_files.append(os.path.join(root, file))
-                # Include pybind11 stub library
-                elif file.startswith("libpybind11nonlimitedapi_stubs") and (
-                    file.endswith(".dylib") or file.endswith(".so")
-                ):
-                    pkg_files.append(os.path.join(root, file))
+                elif not is_free_threading():
+                    # Stable ABI builds need pybind11 nonlimitedapi shim + stubs libraries
+                    if file.startswith("libpybind11nonlimitedapi_chdb_") and (
+                        file.endswith(".dylib") or file.endswith(".so")
+                    ):
+                        pkg_files.append(os.path.join(root, file))
+                    elif file.startswith("libpybind11nonlimitedapi_stubs") and (
+                        file.endswith(".dylib") or file.endswith(".so")
+                    ):
+                        pkg_files.append(os.path.join(root, file))
 
         pkg_files.append(chdb_so)
 
@@ -234,11 +238,15 @@ if __name__ == "__main__":
             cmdclass={"build_ext": BuildExt},
             test_suite="tests",
             zip_safe=False,
-            options={
-                "bdist_wheel": {
-                    "py_limited_api": "cp39",
+            options=(
+                {}
+                if is_free_threading()
+                else {
+                    "bdist_wheel": {
+                        "py_limited_api": "cp39",
+                    }
                 }
-            },
+            ),
         )
     except Exception as e:
         print("Build from setup.py failed. Error: ")

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,12 @@
 
 [tox]
 minversion = 3.24
-envlist = py39, py310, py311, py312, py313, py314
+envlist = py39, py310, py311, py312, py313, py314, py314t
 isolated_build = True
+# Skip envs whose interpreter is absent (the free-threaded py314t wheel
+# isn't installed on every developer/CI host yet). Override with
+# `tox --skip-missing-interpreters=false` for strict runs.
+skip_missing_interpreters = True
 
 [testenv]
 description = Build and test the package


### PR DESCRIPTION
Closes #29

## Summary

Add support for building and distributing **free-threading (no-GIL) Python wheels** for CPython 3.13t and 3.14t across all platforms (Linux x86_64/aarch64, macOS x86_64/arm64).

## Key Changes

### C++ / pybind11

- Use **upstream pybind11** (`contrib/pybind11-upstream`) for free-threading builds — the mrbind fork's stable-ABI stubs are incompatible with free-threading
- Declare module with `py::mod_gil_not_used()` so the module opts out of the GIL
- Replace `pybind11::non_limited_api::*` wrappers with **direct CPython API calls** under `#ifdef CHDB_FREE_THREADING` (e.g. `PyByteArray_GET_SIZE`, `PyUnicode_*` in `FillColumnString`)
- Guard all `#include <pybind11/detail/non_limited_api.h>` with `#ifndef CHDB_FREE_THREADING`

### Thread Safety

- `PythonImportCacheItem::Load()` — use `std::call_once` to prevent concurrent duplicate initialization
- `PythonImporter::ImportCache()` — use `std::call_once` for singleton creation
- `PythonImportCache::AddCache()` — protect `owned_objects` with `std::mutex`

### CMake

- New option `CHDB_FREE_THREADING` — sets `Py_GIL_DISABLED=1` and `CHDB_FREE_THREADING=1` compile definitions
- Selects `contrib/pybind11-upstream` include path; skips `ch_contrib::pybind11_stubs` linking
- Cross-compilation: derives Python include dir from `CHDB_FREE_THREADING_PYTHON_VERSION`

### Build Scripts

- `chdb/vars.sh` — compute `EXT_SUFFIX` from Python (e.g. `.cpython-313t-darwin.so`) instead of hardcoded `.abi3.so`
- `chdb/build.sh` / `chdb/build_mac_on_linux.sh` — branch on `CHDB_FREE_THREADING` to skip pybind11 nonlimitedapi shim builds
- `chdb/build/download_python_headers.sh` — support free-threading headers (`PythonT_Framework.pkg`)
- `chdb/build_pybind11.sh` — exclude `*t` Python versions when building nonlimitedapi shims

### CI (GitHub Actions)

- New scripts: `build_and_test_ft_linux.sh`, `build_ft_macos_cross.sh`, `test_ft_macos.sh`
- Added free-threading build → audit → test → publish steps to all 4 platform workflows
- Skip `deltalake` tests in free-threading builds (no compatible wheel available)

### setup.py

- Skip `Py_LIMITED_API` / `py_limited_api` / stubs packaging when `CHDB_FREE_THREADING=1`
- Use real `EXT_SUFFIX` instead of `.abi3.so`