### PR TITLE
Add Arrow C Data Interface output (chdb_query_arrow_stream)

### DIFF
--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -41,6 +41,10 @@
         chdb_arrow_array_scan;
         chdb_arrow_unregister_table;
 
+        /* Arrow Output */
+        chdb_query_arrow_stream;
+        chdb_query_arrow_stream_n;
+
     local:
         *;
 };

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -35,3 +35,6 @@ _chdb_result_error
 _chdb_arrow_scan
 _chdb_arrow_array_scan
 _chdb_arrow_unregister_table
+
+_chdb_query_arrow_stream
+_chdb_query_arrow_stream_n

--- a/examples/chdbArrowOutputTest.c
+++ b/examples/chdbArrowOutputTest.c
@@ -1,0 +1,354 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "../programs/local/chdb.h"
+#include "arrow_c_abi.h"
+
+/*===----------------------------------------------------------------------===*/
+/* Test Utilities                                                              */
+/*===----------------------------------------------------------------------===*/
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void test_assert(bool condition, const char * test_name, const char * message)
+{
+    if (condition)
+    {
+        printf("  PASS: %s\n", test_name);
+        tests_passed++;
+    }
+    else
+    {
+        printf("  FAIL: %s", test_name);
+        if (message && strlen(message) > 0)
+            printf(" - %s", message);
+        printf("\n");
+        tests_failed++;
+    }
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Helper: consume an ArrowArrayStream and count total rows                    */
+/*===----------------------------------------------------------------------===*/
+
+static int64_t consume_stream_row_count(struct ArrowArrayStream * stream)
+{
+    int64_t total = 0;
+    while (1)
+    {
+        struct ArrowArray array;
+        memset(&array, 0, sizeof(array));
+
+        int rc = stream->get_next(stream, &array);
+        if (rc != 0)
+        {
+            printf("    get_next returned error %d\n", rc);
+            return -1;
+        }
+        if (array.release == NULL)
+            break; /* end of stream */
+
+        total += array.length;
+        array.release(&array);
+    }
+    return total;
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Test 1: Basic query — schema + row count                                    */
+/*===----------------------------------------------------------------------===*/
+
+static void test_basic_query(chdb_connection conn)
+{
+    struct ArrowArrayStream stream;
+    struct ArrowSchema schema;
+    chdb_state state;
+    int64_t row_count;
+    int rc;
+    char msg[256];
+
+    printf("\n--- Test: Basic query ---\n");
+
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(
+        conn, "SELECT number, toString(number) AS str FROM numbers(100)",
+        (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBSuccess, "chdb_query_arrow_stream returns CHDBSuccess", "");
+    test_assert(stream.release != NULL, "Stream release callback is set", "");
+
+    /* Verify schema */
+    memset(&schema, 0, sizeof(schema));
+    rc = stream.get_schema(&stream, &schema);
+    test_assert(rc == 0, "get_schema returns 0", "");
+    test_assert(schema.n_children == 2, "Schema has 2 columns",
+                schema.n_children != 2 ? "wrong column count" : "");
+
+    if (schema.n_children == 2)
+    {
+        test_assert(strcmp(schema.children[0]->name, "number") == 0,
+                    "First column is 'number'", schema.children[0]->name);
+        test_assert(strcmp(schema.children[1]->name, "str") == 0,
+                    "Second column is 'str'", schema.children[1]->name);
+    }
+
+    if (schema.release)
+        schema.release(&schema);
+
+    /* Count rows */
+    row_count = consume_stream_row_count(&stream);
+    snprintf(msg, sizeof(msg), "expected 100, got %lld", (long long)row_count);
+    test_assert(row_count == 100, "Row count is 100", msg);
+
+    stream.release(&stream);
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Test 2: Empty result                                                        */
+/*===----------------------------------------------------------------------===*/
+
+static void test_empty_result(chdb_connection conn)
+{
+    struct ArrowArrayStream stream;
+    chdb_state state;
+    int64_t row_count;
+    char msg[256];
+
+    printf("\n--- Test: Empty result ---\n");
+
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(
+        conn, "SELECT number FROM numbers(0)",
+        (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBSuccess, "Empty query returns CHDBSuccess", "");
+    test_assert(stream.release != NULL, "Stream is valid", "");
+
+    row_count = consume_stream_row_count(&stream);
+    snprintf(msg, sizeof(msg), "expected 0, got %lld", (long long)row_count);
+    test_assert(row_count == 0, "Row count is 0", msg);
+
+    stream.release(&stream);
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Test 3: Large result                                                        */
+/*===----------------------------------------------------------------------===*/
+
+static void test_large_result(chdb_connection conn)
+{
+    struct ArrowArrayStream stream;
+    chdb_state state;
+    int64_t row_count;
+    char msg[256];
+
+    printf("\n--- Test: Large result (1M rows) ---\n");
+
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(
+        conn, "SELECT number FROM numbers(1000000)",
+        (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBSuccess, "Large query returns CHDBSuccess", "");
+
+    row_count = consume_stream_row_count(&stream);
+    snprintf(msg, sizeof(msg), "expected 1000000, got %lld", (long long)row_count);
+    test_assert(row_count == 1000000, "Row count is 1,000,000", msg);
+
+    stream.release(&stream);
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Test 4: Type coverage                                                       */
+/*===----------------------------------------------------------------------===*/
+
+static void test_type_coverage(chdb_connection conn)
+{
+    struct ArrowArrayStream stream;
+    struct ArrowSchema schema;
+    chdb_state state;
+    int rc;
+
+    printf("\n--- Test: Type coverage ---\n");
+
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(
+        conn,
+        "SELECT "
+        "  toInt64(1)        AS col_int64, "
+        "  toFloat64(3.14)   AS col_float64, "
+        "  'hello'           AS col_string, "
+        "  toDate('2024-01-15')     AS col_date, "
+        "  toDateTime('2024-01-15 12:30:00') AS col_datetime",
+        (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBSuccess, "Type coverage query returns CHDBSuccess", "");
+
+    memset(&schema, 0, sizeof(schema));
+    rc = stream.get_schema(&stream, &schema);
+    test_assert(rc == 0, "get_schema returns 0", "");
+    test_assert(schema.n_children == 5, "Schema has 5 columns", "");
+
+    if (schema.n_children == 5)
+    {
+        /* Verify column names */
+        test_assert(strcmp(schema.children[0]->name, "col_int64") == 0,
+                    "Column 0 name is 'col_int64'", schema.children[0]->name);
+        test_assert(strcmp(schema.children[1]->name, "col_float64") == 0,
+                    "Column 1 name is 'col_float64'", schema.children[1]->name);
+        test_assert(strcmp(schema.children[2]->name, "col_string") == 0,
+                    "Column 2 name is 'col_string'", schema.children[2]->name);
+        test_assert(strcmp(schema.children[3]->name, "col_date") == 0,
+                    "Column 3 name is 'col_date'", schema.children[3]->name);
+        test_assert(strcmp(schema.children[4]->name, "col_datetime") == 0,
+                    "Column 4 name is 'col_datetime'", schema.children[4]->name);
+
+        /* Verify Arrow format strings */
+        /* Int64 → "l", Float64 → "g", String → "u" or "U",
+           Date32 → "tdD", DateTime(UInt32) → "tsu:" or "tdm" depending on ClickHouse version */
+        test_assert(strcmp(schema.children[0]->format, "l") == 0,
+                    "col_int64 format is 'l' (int64)", schema.children[0]->format);
+        test_assert(strcmp(schema.children[1]->format, "g") == 0,
+                    "col_float64 format is 'g' (float64)", schema.children[1]->format);
+        /* String could be "u" (utf8) or "U" (large_utf8) */
+        test_assert(schema.children[2]->format[0] == 'u' || schema.children[2]->format[0] == 'U',
+                    "col_string format starts with 'u' or 'U'", schema.children[2]->format);
+    }
+
+    if (schema.release)
+        schema.release(&schema);
+
+    /* Consume to clean up */
+    consume_stream_row_count(&stream);
+    stream.release(&stream);
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Test 5: Round-trip (Arrow output -> chdb_arrow_scan -> query)                */
+/*===----------------------------------------------------------------------===*/
+
+static void test_round_trip(chdb_connection conn)
+{
+    struct ArrowArrayStream stream;
+    chdb_state state;
+    chdb_result * count_result;
+    const char * error;
+    char * buffer;
+    char * end;
+    uint64_t actual_rows;
+    char msg[256];
+
+    printf("\n--- Test: Round-trip (output -> scan -> query) ---\n");
+
+    /* Step 1: Get Arrow output */
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(
+        conn, "SELECT number AS id, toString(number) AS value FROM numbers(500)",
+        (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBSuccess, "Arrow output query succeeds", "");
+
+    /* Step 2: Register the stream as a table */
+    state = chdb_arrow_scan(conn, "roundtrip_table", (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBSuccess, "chdb_arrow_scan registration succeeds", "");
+
+    /* Step 3: Query the registered table */
+    count_result = chdb_query(conn, "SELECT COUNT(*) FROM arrowstream(roundtrip_table)", "CSV");
+    test_assert(count_result != NULL, "Count query result is not null", "");
+
+    error = chdb_result_error(count_result);
+    test_assert(error == NULL, "Count query has no error", error ? error : "");
+
+    if (!error)
+    {
+        buffer = chdb_result_buffer(count_result);
+        test_assert(buffer != NULL, "Result buffer is not null", "");
+
+        if (buffer)
+        {
+            /* Parse the count — trim trailing whitespace */
+            char result_str[64];
+            strncpy(result_str, buffer, sizeof(result_str) - 1);
+            result_str[sizeof(result_str) - 1] = '\0';
+            end = result_str + strlen(result_str) - 1;
+            while (end > result_str && (*end == ' ' || *end == '\n' || *end == '\r'))
+            {
+                *end = '\0';
+                end--;
+            }
+            actual_rows = strtoull(result_str, NULL, 10);
+            snprintf(msg, sizeof(msg), "expected 500, got %llu", (unsigned long long)actual_rows);
+            test_assert(actual_rows == 500, "Round-trip row count is 500", msg);
+        }
+    }
+
+    chdb_destroy_query_result(count_result);
+
+    /* Cleanup */
+    chdb_arrow_unregister_table(conn, "roundtrip_table");
+
+    /* The stream may already have been consumed by the scan; release only if still valid */
+    if (stream.release)
+        stream.release(&stream);
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Test 6: Error handling                                                      */
+/*===----------------------------------------------------------------------===*/
+
+static void test_error_handling(chdb_connection conn)
+{
+    struct ArrowArrayStream stream;
+    chdb_state state;
+
+    printf("\n--- Test: Error handling ---\n");
+
+    /* Null connection */
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(NULL, "SELECT 1", (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBError, "Null connection returns CHDBError", "");
+
+    /* Null stream */
+    state = chdb_query_arrow_stream(conn, "SELECT 1", NULL);
+    test_assert(state == CHDBError, "Null stream returns CHDBError", "");
+
+    /* Invalid SQL */
+    memset(&stream, 0, sizeof(stream));
+    state = chdb_query_arrow_stream(
+        conn, "THIS IS NOT VALID SQL", (chdb_arrow_stream)&stream);
+    test_assert(state == CHDBError, "Invalid SQL returns CHDBError", "");
+}
+
+/*===----------------------------------------------------------------------===*/
+/* Main                                                                        */
+/*===----------------------------------------------------------------------===*/
+
+int main(void)
+{
+    char * argv[] = {"clickhouse", "--multiquery"};
+    int argc = sizeof(argv) / sizeof(argv[0]);
+    chdb_connection * conn_ptr;
+    chdb_connection conn;
+
+    printf("=== chDB Arrow Output Test ===\n");
+
+    conn_ptr = chdb_connect(argc, argv);
+    if (!conn_ptr || !*conn_ptr)
+    {
+        printf("Failed to create chDB connection\n");
+        return 1;
+    }
+    conn = *conn_ptr;
+    printf("Connection established.\n");
+
+    test_basic_query(conn);
+    test_empty_result(conn);
+    test_large_result(conn);
+    test_type_coverage(conn);
+    test_round_trip(conn);
+    test_error_handling(conn);
+
+    chdb_close_conn(conn_ptr);
+
+    printf("\n=== Results: %d passed, %d failed ===\n", tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -11,6 +11,7 @@ set (CLICKHOUSE_LOCAL_SOURCES
 if (NOT USE_PYTHON)
     set (CHDB_ARROW_SOURCES
         chdb-arrow.cpp
+        chdb-arrow-output.cpp
         ArrowStreamSource.cpp
         StorageArrowStream.cpp
         TableFunctionArrowStream.cpp

--- a/programs/local/chdb-arrow-output.cpp
+++ b/programs/local/chdb-arrow-output.cpp
@@ -1,0 +1,115 @@
+#include "chdb.h"
+
+#include <cstring>
+
+#include <arrow/buffer.h>
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/record_batch.h>
+
+namespace
+{
+
+/// Wrapper that ties the lifetime of a chdb_result to a shared_ptr so that
+/// the Arrow BufferReader (which does not own the data) cannot outlive the
+/// underlying byte buffer.
+struct ResultGuard
+{
+    chdb_result * result;
+    explicit ResultGuard(chdb_result * r) : result(r) {}
+    ~ResultGuard()
+    {
+        if (result)
+            chdb_destroy_query_result(result);
+    }
+};
+
+} // anonymous namespace
+
+chdb_state chdb_query_arrow_stream(
+    chdb_connection conn, const char * query,
+    chdb_arrow_stream out_stream)
+{
+    return chdb_query_arrow_stream_n(
+        conn, query, query ? std::strlen(query) : 0, out_stream);
+}
+
+chdb_state chdb_query_arrow_stream_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    chdb_arrow_stream out_stream)
+{
+    if (!conn || !out_stream)
+        return CHDBError;
+
+    // 1. Execute query with ArrowStream format
+    static const char format[] = "ArrowStream";
+    chdb_result * result = chdb_query_n(conn, query, query_len, format, sizeof(format) - 1);
+    if (!result)
+        return CHDBError;
+
+    const char * err = chdb_result_error(result);
+    if (err)
+    {
+        chdb_destroy_query_result(result);
+        return CHDBError;
+    }
+
+    char * buf = chdb_result_buffer(result);
+    size_t len = chdb_result_length(result);
+
+    // Empty result (0 rows) still needs a valid stream — the IPC bytes may
+    // contain just the schema message.  If there are truly no bytes at all
+    // we still try; the IPC reader will produce an empty stream.
+    if (!buf || !len)
+    {
+        buf = nullptr;
+        len = 0;
+    }
+
+    // 2. Keep the result alive via a shared guard
+    auto guard = std::make_shared<ResultGuard>(result);
+
+    // 3. Wrap the bytes in an Arrow Buffer (zero-copy, non-owning) and then
+    //    create a BufferReader.  The guard captured by the custom destructor
+    //    ensures the underlying memory stays valid.
+    auto arrow_buf = buf
+        ? std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t *>(buf), static_cast<int64_t>(len))
+        : std::make_shared<arrow::Buffer>(nullptr, 0);
+    auto buffer_reader = std::make_shared<arrow::io::BufferReader>(arrow_buf);
+
+    // 4. Open an IPC RecordBatchStreamReader
+    auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(buffer_reader);
+    if (!reader_result.ok())
+        return CHDBError;
+
+    std::shared_ptr<arrow::ipc::RecordBatchStreamReader> ipc_reader = *reader_result;
+
+    // 5. Wrap the IPC reader together with the guard so that the chdb_result
+    //    stays alive as long as the exported ArrowArrayStream is alive.
+    //    We do this by capturing guard in a shared_ptr custom destructor that
+    //    is itself captured inside a shared_ptr<RecordBatchReader> wrapper.
+    //    Since ExportRecordBatchReader takes shared_ptr<RecordBatchReader> and
+    //    the exported stream internally ref-counts it, attaching the guard
+    //    to the same shared_ptr ensures correct lifetime.
+    std::shared_ptr<arrow::RecordBatchReader> reader(
+        ipc_reader.get(),
+        [ipc_reader, guard, buffer_reader, arrow_buf](arrow::RecordBatchReader *) {
+            // prevent premature destruction; captured shared_ptrs are destroyed
+            // when this deleter is destroyed (i.e. when the ArrowArrayStream is
+            // released).
+            (void)ipc_reader;
+            (void)guard;
+            (void)buffer_reader;
+            (void)arrow_buf;
+        });
+
+    // 6. Export to the caller's ArrowArrayStream
+    auto * stream = reinterpret_cast<ArrowArrayStream *>(out_stream);
+    auto status = arrow::ExportRecordBatchReader(std::move(reader), stream);
+    if (!status.ok())
+        return CHDBError;
+
+    return CHDBSuccess;
+}

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -45,10 +45,12 @@ namespace CHDB
 extern "C"
 {
     extern chdb_state chdb_arrow_scan(chdb_connection, const char *, chdb_arrow_stream);
+    extern chdb_state chdb_query_arrow_stream(chdb_connection, const char *, chdb_arrow_stream);
 }
 
 [[maybe_unused]] void * force_link_arrow_functions[] = {
-    reinterpret_cast<void*>(chdb_arrow_scan)
+    reinterpret_cast<void*>(chdb_arrow_scan),
+    reinterpret_cast<void*>(chdb_query_arrow_stream)
 };
 #endif
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -420,6 +420,32 @@ CHDB_EXPORT chdb_state chdb_arrow_array_scan(
  */
 CHDB_EXPORT chdb_state chdb_arrow_unregister_table(chdb_connection conn, const char * table_name);
 
+/**
+ * Executes a query and exports the result as an ArrowArrayStream via the Arrow C Data Interface.
+ * The caller allocates an ArrowArrayStream on the stack, casts it to chdb_arrow_stream, and
+ * passes it in.  On success the stream callbacks are filled; the caller must call release()
+ * when done.
+ * @param conn Active connection handle
+ * @param query SQL query string to execute
+ * @param out_stream Pointer to caller-allocated ArrowArrayStream (cast to chdb_arrow_stream)
+ * @return CHDBSuccess on success, CHDBError on failure
+ */
+CHDB_EXPORT chdb_state chdb_query_arrow_stream(
+    chdb_connection conn, const char * query,
+    chdb_arrow_stream out_stream);
+
+/**
+ * Executes a query and exports the result as an ArrowArrayStream (length-counted variant).
+ * @param conn Active connection handle
+ * @param query SQL query buffer (may contain null bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param out_stream Pointer to caller-allocated ArrowArrayStream (cast to chdb_arrow_stream)
+ * @return CHDBSuccess on success, CHDBError on failure
+ */
+CHDB_EXPORT chdb_state chdb_query_arrow_stream_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    chdb_arrow_stream out_stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/programs/local/chdb.hpp
+++ b/programs/local/chdb.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "chdb.h"
+#include <cstring>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -8,6 +9,7 @@
 #include <optional>
 #include <stdexcept>
 #include <span>
+#include <arrow/c/abi.h>
 
 namespace CHDB
 {
@@ -251,6 +253,49 @@ private:
 };
 
 /**
+ * RAII wrapper for an ArrowArrayStream produced by chdb_query_arrow_stream.
+ * Move-only; calls stream_.release on destruction.
+ */
+class ArrowResult {
+public:
+    ArrowResult() { std::memset(&stream_, 0, sizeof(stream_)); }
+
+    ~ArrowResult() {
+        if (stream_.release) {
+            stream_.release(&stream_);
+        }
+    }
+
+    ArrowResult(const ArrowResult&) = delete;
+    ArrowResult& operator=(const ArrowResult&) = delete;
+
+    ArrowResult(ArrowResult&& other) noexcept : stream_(other.stream_) {
+        std::memset(&other.stream_, 0, sizeof(other.stream_));
+    }
+
+    ArrowResult& operator=(ArrowResult&& other) noexcept {
+        if (this != &other) {
+            if (stream_.release) {
+                stream_.release(&stream_);
+            }
+            stream_ = other.stream_;
+            std::memset(&other.stream_, 0, sizeof(other.stream_));
+        }
+        return *this;
+    }
+
+    /// Get pointer to the underlying ArrowArrayStream (for passing to C APIs).
+    ArrowArrayStream * get() { return &stream_; }
+    const ArrowArrayStream * get() const { return &stream_; }
+
+    /// True if the stream has been initialised (release callback is set).
+    bool valid() const { return stream_.release != nullptr; }
+
+private:
+    ArrowArrayStream stream_;
+};
+
+/**
  * The Connection class provides a high-level interface to ChDB database
  * operations. It manages the connection lifecycle automatically and provides
  * both regular and streaming query capabilities.
@@ -352,6 +397,22 @@ public:
         }
         
         return Result(result);
+    }
+
+    /** Execute SQL query and return result as an ArrowArrayStream */
+    ArrowResult query_arrow(const std::string & sql) const
+    {
+        if (!conn_) {
+            throw ChdbError(ChdbErrorCode::ConnectionClosed, "Connection is closed");
+        }
+        ArrowResult arrow_result;
+        chdb_state state = chdb_query_arrow_stream(
+            conn_, sql.c_str(),
+            reinterpret_cast<chdb_arrow_stream>(arrow_result.get()));
+        if (state != CHDBSuccess) {
+            throw ChdbError(ChdbErrorCode::QueryExecutionFailed, "Arrow query execution failed");
+        }
+        return arrow_result;
     }
 
     /** Cancel ongoing streaming query */


### PR DESCRIPTION
Closes #15

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `chdb_query_arrow_stream()` and `chdb_query_arrow_stream_n()` C API functions that export query results as an `ArrowArrayStream` via the Arrow C Data Interface, enabling near-zero-copy columnar data exchange for Go/Rust/Node/C++ bindings.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

#### New C API functions

```c
chdb_state chdb_query_arrow_stream(
    chdb_connection conn, const char * query,
    chdb_arrow_stream out_stream);

chdb_state chdb_query_arrow_stream_n(
    chdb_connection conn, const char * query, size_t query_len,
    chdb_arrow_stream out_stream);
```

Caller allocates an `ArrowArrayStream` on the stack, casts to `chdb_arrow_stream`, passes it in. On success the stream callbacks are filled; caller calls `release()` when done.

#### C++ wrapper

```cpp
CHDB::ArrowResult result = conn.query_arrow("SELECT ...");
ArrowArrayStream * stream = result.get();
```

#### Implementation

Thin wrapper over the existing `ArrowStream` output format:
1. Execute query with `format="ArrowStream"` → get IPC bytes
2. Wrap in `arrow::io::BufferReader` → open `arrow::ipc::RecordBatchStreamReader`
3. Export via `arrow::ExportRecordBatchReader()` → fills caller's `ArrowArrayStream`

~110 lines of new C++, no changes to ClickHouse internals.

#### Files changed

| File | Change |
|------|--------|
| `programs/local/chdb-arrow-output.cpp` | New — core implementation |
| `programs/local/chdb.h` | 2 new function declarations |
| `programs/local/chdb.hpp` | `ArrowResult` class + `Connection::query_arrow()` |
| `programs/local/CMakeLists.txt` | Add new source file |
| `programs/local/chdb.cpp` | Force-link reference |
| `chdb/libchdb_export.map` | Export new symbols (Linux) |
| `chdb/libchdb_export_macos.txt` | Export new symbols (macOS) |
| `examples/chdbArrowOutputTest.c` | New — 6 test cases, 32 assertions |

#### Test results

```
=== chDB Arrow Output Test ===
32 passed, 0 failed
```

Tests cover: basic query (schema + rows), empty result, 1M rows, type coverage (Int64/Float64/String/Date/DateTime), round-trip (output → chdb_arrow_scan → query), and error handling.