### PR TITLE
Add zero-copy fast path for object-dtype string columns in pandas

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -388,6 +388,23 @@ jobs:
             pyenv shell --unset
           done
         continue-on-error: false
+      - name: Run benchmarks on Python 3.14 (pandas 2.x and 3.x)
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.14
+          for PANDAS_CONSTRAINT in "pandas<3.0" "pandas>=3.0"; do
+            echo "=== Benchmarks with $PANDAS_CONSTRAINT ==="
+            python -m pip install dist/*.whl "$PANDAS_CONSTRAINT" --force-reinstall --no-cache-dir -q
+            for bench in tests/benchmarks/bench_*.py; do
+              echo "--- Running $bench ---"
+              python "$bench"
+            done
+            python -m pip uninstall -y chdb-core
+          done
+          pyenv shell --unset
+        continue-on-error: true
       - name: Test torch compatibility on Python 3.11
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -373,6 +373,23 @@ jobs:
             pyenv shell --unset
           done
         continue-on-error: false
+      - name: Run benchmarks on Python 3.14 (pandas 2.x and 3.x)
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.14
+          for PANDAS_CONSTRAINT in "pandas<3.0" "pandas>=3.0"; do
+            echo "=== Benchmarks with $PANDAS_CONSTRAINT ==="
+            python -m pip install dist/*.whl "$PANDAS_CONSTRAINT" --force-reinstall --no-cache-dir -q
+            for bench in tests/benchmarks/bench_*.py; do
+              echo "--- Running $bench ---"
+              python "$bench"
+            done
+            python -m pip uninstall -y chdb-core
+          done
+          pyenv shell --unset
+        continue-on-error: true
       - name: Test torch compatibility on Python 3.11
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"

--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -222,8 +222,43 @@ void PandasDataFrame::fillColumn(
         }
     }
 
-    py::object underlying_array = series.attr("array");
     column.row_count = py::len(series);
+
+    /// Fast path for pandas 2.x object-dtype string columns:
+    /// series.values returns the underlying ndarray directly (zero-copy).
+    /// For pandas 3.x StringDtype columns, dtype is "string" or "str" (not "object"),
+    /// so they will skip this fast path and go through to_numpy() below.
+    if (column.row_count > 0 && numpy_type.type == NumpyNullableType::OBJECT)
+    {
+        py::array values_array = series.attr("values");
+        auto elem_type = series.attr("iloc").attr("__getitem__")(0).attr("__class__").attr("__name__").cast<std::string>();
+
+        if (elem_type == "str" || elem_type == "unicode")
+        {
+            /// Object dtype with string elements: zero-copy via series.values
+            column.data = values_array;
+            column.buf = const_cast<void *>(values_array.data());
+            chassert(py::hasattr(values_array, "strides"));
+            column.stride = values_array.attr("strides").attr("__getitem__")(0).cast<size_t>();
+            return;
+        }
+
+        if (elem_type == "bytes" || elem_type == "object")
+        {
+            /// bytes or other object: convert to str dtype first
+            auto str_obj = series.attr("astype")(py::dtype("str"));
+            py::array str_array = str_obj.attr("values");
+            column.data = str_array;
+            column.tmp = str_array;
+            column.tmp.inc_ref();
+            column.buf = const_cast<void *>(str_array.data());
+            chassert(py::hasattr(str_array, "strides"));
+            column.stride = str_array.attr("strides").attr("__getitem__")(0).cast<size_t>();
+            return;
+        }
+    }
+
+    py::object underlying_array = series.attr("array");
 
     if (py::hasattr(underlying_array, "_mask"))
     {

--- a/tests/benchmarks/bench_string_ingestion.py
+++ b/tests/benchmarks/bench_string_ingestion.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Benchmark: pandas string column ingestion via Python(df).
+
+Measures the zero-copy fast path for object-dtype string columns.
+Run separately from unit tests:
+    python tests/benchmarks/bench_string_ingestion.py
+"""
+
+import time
+import numpy as np
+import pandas as pd
+import chdb
+
+N_ROWS = 5000_000
+WARMUP = 2
+REPEATS = 5
+
+
+def make_df(n, rng):
+    return pd.DataFrame({
+        "s": pd.array(
+            [f"{'x' * 80}_{i}_{rng.integers(0, 100000)}" for i in range(n)],
+            dtype="object",
+        ),
+    })
+
+
+def bench(df, sql, warmup=WARMUP, repeats=REPEATS):
+    for _ in range(warmup):
+        chdb.query(sql, "CSV")
+    times = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        chdb.query(sql, "CSV")
+        elapsed = time.perf_counter() - t0
+        times.append(elapsed)
+    return times
+
+
+def main():
+    print(f"chdb={chdb.__version__}  pandas={pd.__version__}  numpy={np.__version__}")
+    print(f"rows={N_ROWS:,}  warmup={WARMUP}  repeats={REPEATS}")
+    print()
+
+    rng = np.random.default_rng(42)
+    df = make_df(N_ROWS, rng)
+    sql = "SELECT count() FROM Python(df)"
+
+    times = bench(df, sql)
+    best = min(times)
+    median = sorted(times)[len(times) // 2]
+    worst = max(times)
+
+    print(f"best={best:.3f}s  median={median:.3f}s  worst={worst:.3f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #30

## Summary

Optimize pandas 2.x object-dtype string column ingestion by adding a zero-copy fast path, avoiding unnecessary data copies through `to_numpy()`.

## Changes

### 1. Zero-copy fast path (`PandasDataFrame.cpp`)

Add a fast path in `fillColumn()` for `NumpyNullableType::OBJECT` columns:

- **`str`/`unicode` elements**: use `series.values` to access the underlying ndarray directly (zero-copy), skipping the previous `series.array` → `to_numpy()` path
- **`bytes`/`object` elements**: convert via `astype("str")` first, then extract ndarray
- **pandas 3.x StringDtype columns** (dtype is `"string"`, not `"object"`) are unaffected — they still go through the existing `to_numpy()` path

### 2. CI benchmark (`tests/benchmarks/bench_string_ingestion.py`)

Add a string ingestion benchmark:
- Generates a 5M-row object-dtype string DataFrame and measures ingestion time via `Python(df)`
- Runs on Linux x86 and arm64 CI with both pandas 2.x and 3.x