### PR TITLE
Increase LazyOutputFormat queue size

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -34,6 +34,7 @@ namespace Setting
     extern const SettingsDialect dialect;
     extern const SettingsBool input_format_defaults_for_omitted_fields;
     extern const SettingsUInt64 interactive_delay;
+    extern const SettingsUInt64 chdb_pipeline_output_queue_size;
     extern const SettingsNonZeroUInt64 max_insert_block_size;
     extern const SettingsUInt64 max_insert_block_size_bytes;
     extern const SettingsUInt64 min_insert_block_size_rows;
@@ -333,6 +334,7 @@ void LocalConnection::sendQuery(
         else if (state->io.pipeline.pulling())
         {
             state->block = state->io.pipeline.getHeader();
+            state->io.pipeline.setLazyFormatQueueSize(query_context->getSettingsRef()[Setting::chdb_pipeline_output_queue_size]);
             state->executor = std::make_unique<PullingAsyncPipelineExecutor>(state->io.pipeline);
             state->io.pipeline.setConcurrencyControl(false);
         }

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7557,6 +7557,11 @@ Sample rows in pandas to automatically determine the data types. When set to 0, 
 The application name appended to 'chDB' when connecting to remote servers via remote() or remoteSecure() table functions.
 If empty, query_log shows 'chDB'. If set to 'my-app', query_log shows 'chDB my-app'.
 )", EXPERIMENTAL) \
+    DECLARE(UInt64, chdb_pipeline_output_queue_size, 0, R"(
+The number of chunks that can be buffered between pipeline producer threads and the result consumer.
+A larger value reduces backpressure on multi-threaded pipelines (e.g., multi-file reads) at the cost of higher memory usage.
+0 means auto: num_pipeline_threads clamped to [2, 64].
+)", EXPERIMENTAL) \
     \
     /* ####################################################### */ \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -45,7 +45,10 @@ PullingAsyncPipelineExecutor::PullingAsyncPipelineExecutor(QueryPipeline & pipel
     if (!pipeline.pulling())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Pipeline for PullingAsyncPipelineExecutor must be pulling");
 
-    lazy_format = std::make_shared<LazyOutputFormat>(pipeline.output->getSharedHeader());
+    size_t queue_size = pipeline.getLazyFormatQueueSize();
+    if (queue_size == 0)
+        queue_size = std::clamp<size_t>(pipeline.getNumThreads(), 2, 64);
+    lazy_format = std::make_shared<LazyOutputFormat>(pipeline.output->getSharedHeader(), queue_size);
     pipeline.complete(lazy_format);
 }
 

--- a/src/Processors/Formats/LazyOutputFormat.cpp
+++ b/src/Processors/Formats/LazyOutputFormat.cpp
@@ -9,8 +9,8 @@ namespace DB
 
 NullWriteBuffer LazyOutputFormat::out;
 
-LazyOutputFormat::LazyOutputFormat(SharedHeader header)
-    : IOutputFormat(header, out), queue(2)
+LazyOutputFormat::LazyOutputFormat(SharedHeader header, size_t queue_size)
+    : IOutputFormat(header, out), queue(queue_size)
 {
 }
 

--- a/src/Processors/Formats/LazyOutputFormat.h
+++ b/src/Processors/Formats/LazyOutputFormat.h
@@ -15,7 +15,7 @@ class LazyOutputFormat : public IOutputFormat
 {
 
 public:
-    explicit LazyOutputFormat(SharedHeader header);
+    explicit LazyOutputFormat(SharedHeader header, size_t queue_size = 2);
 
     String getName() const override { return "LazyOutputFormat"; }
 

--- a/src/QueryPipeline/QueryPipeline.h
+++ b/src/QueryPipeline/QueryPipeline.h
@@ -107,6 +107,9 @@ public:
     size_t getNumThreads() const { return num_threads; }
     void setNumThreads(size_t num_threads_) { num_threads = num_threads_; }
 
+    size_t getLazyFormatQueueSize() const { return lazy_format_queue_size; }
+    void setLazyFormatQueueSize(size_t size) { lazy_format_queue_size = size; }
+
     bool getConcurrencyControl() const { return concurrency_control; }
     void setConcurrencyControl(bool concurrency_control_) { concurrency_control = concurrency_control_; }
 
@@ -169,6 +172,7 @@ private:
     IOutputFormat * output_format = nullptr;
 
     size_t num_threads = 0;
+    size_t lazy_format_queue_size = 0;
     bool concurrency_control = false;
 
     friend class PushingPipelineExecutor;


### PR DESCRIPTION
Resolved https://github.com/chdb-io/chdb/issues/539

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
