### PR TITLE
fix: add null check for numpy.datetime64 when numpy is not installed

### DIFF
--- a/programs/local/PythonConversion.cpp
+++ b/programs/local/PythonConversion.cpp
@@ -64,8 +64,11 @@ PythonObjectType GetPythonObjectType(const py::handle & obj)
 	if (py::isinstance(obj, import_cache.datetime.timedelta()))
 		return PythonObjectType::Timedelta;
 
-	if (py::isinstance(obj, import_cache.numpy.datetime64()))
-		return PythonObjectType::NdDatetime;
+	{
+		auto ndt = import_cache.numpy.datetime64();
+		if (ndt.ptr() && py::isinstance(obj, ndt))
+			return PythonObjectType::NdDatetime;
+	}
 
 	if (py::isinstance(obj, import_cache.decimal.Decimal()))
 		return PythonObjectType::Decimal;


### PR DESCRIPTION
## Summary

- Add null pointer guard before calling `py::isinstance` with `numpy.datetime64` type
- Prevents segfault when numpy is not installed, since `NumpyCacheItem` is optional (`IsRequired() = false`)

Closes #32