### PR TITLE
fix: Make build.sh more lenient in its command generation

### DIFF
--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -131,7 +131,7 @@ rm -f ${BINARY}
 
 cd ${BUILD_DIR}
 ninja -d keeprsp -v > build.log || true
-USING_RESPONSE_FILE=$(grep -m 1 'clang++.*-o programs/clickhouse .*' build.log | grep '@CMakeFiles/clickhouse.rsp' || true)
+USING_RESPONSE_FILE=$(grep -m 1 'clang.*-o programs/clickhouse .*' build.log | grep '@CMakeFiles/clickhouse.rsp' || true)
 
 if [ ! "${USING_RESPONSE_FILE}" == "" ]; then
     if [ -f CMakeFiles/clickhouse.rsp ]; then
@@ -142,7 +142,7 @@ if [ ! "${USING_RESPONSE_FILE}" == "" ]; then
     fi
 fi
 
-LIBCHDB_CMD=$(grep -m 1 'clang++.*-o programs/clickhouse .*' build.log \
+LIBCHDB_CMD=$(grep -m 1 'clang.*-o programs/clickhouse .*' build.log \
     | sed "s/-o programs\/clickhouse/-fPIC -shared -o ${LIBCHDB_SO}/" \
     | sed 's/^[^&]*&& //' | sed 's/&&.*//' \
     | sed 's/ -Wl,-undefined,error/ -Wl,-undefined,dynamic_lookup/g' \
@@ -196,7 +196,7 @@ ninja -d keeprsp || true
 cd ${BUILD_DIR}
 ninja -d keeprsp -v > build.log || true
 
-USING_RESPONSE_FILE=$(grep -m 1 'clang++.*-o programs/clickhouse .*' build.log | grep '@CMakeFiles/clickhouse.rsp' || true)
+USING_RESPONSE_FILE=$(grep -m 1 'clang.*-o programs/clickhouse .*' build.log | grep '@CMakeFiles/clickhouse.rsp' || true)
 
 if [ ! "${USING_RESPONSE_FILE}" == "" ]; then
     if [ -f CMakeFiles/clickhouse.rsp ]; then
@@ -208,7 +208,7 @@ if [ ! "${USING_RESPONSE_FILE}" == "" ]; then
 fi
 
 # extract the command to generate CHDB_PY_MODULE
-PYCHDB_CMD=$(grep -m 1 'clang++.*-o programs/clickhouse .*' build.log \
+PYCHDB_CMD=$(grep -m 1 'clang.*-o programs/clickhouse .*' build.log \
     | sed "s/-o programs\/clickhouse/-fPIC -Wl,-undefined,dynamic_lookup -shared -o ${CHDB_PY_MODULE}/" \
     | sed 's/^[^&]*&& //' | sed 's/&&.*//' \
     | sed 's/ -Wl,-undefined,error/ -Wl,-undefined,dynamic_lookup/g' \


### PR DESCRIPTION
When using a non-default compiler (for example when there're multiple clang versions installed), the CC or CXX invocations can specific paths, like:

```
/usr/lib/llvm20/bin/clang-20
```

This commit author's cpp chops aren't what they used to, so they ran the initial `make` as (note that CC and CXX are the same):

```
env CC=/usr/lib/llvm20/bin/clang-20 CXX=/usr/lib/llvm20/bin/clang-20 make buildlib -j24
```

...instead of properly specifying `CXX` as `/path/to/clang++`.

This works, as in, the clickhouse server compiles, but afterwards `build.sh` fails. This is the relevant output after prepending `set -x`:

```
++ grep -m 1 'clang++.*-o programs/clickhouse .*' build.log
++ grep @CMakeFiles/clickhouse.rsp
++ true
+ USING_RESPONSE_FILE=
+ '[' '!' '' == '' ']'
++ grep -m 1 'clang++.*-o programs/clickhouse .*' build.log
++ sed 's/-o programs\/clickhouse/-fPIC -shared -o libchdb.so/'
++ sed 's/^[^&]*&& //'
++ sed 's/&&.*//'
++ sed 's/ -Wl,-undefined,error/ -Wl,-undefined,dynamic_lookup/g'
++ sed 's/ -Xlinker --no-undefined//g'
++ sed 's/@CMakeFiles\/clickhouse.rsp/@CMakeFiles\/libchdb.rsp/g'
+ LIBCHDB_CMD=
++ echo
++ sed 's/ _chdb.abi3.so/ libchdb.so/g'
+ LIBCHDB_CMD=
+ '[' '!' '' == '' ']'
++ uname
+ '[' Linux == Darwin ']'
+ LIBCHDB_CMD=' -Wl,--version-script=/home/me/sources/chdb-core/chdb/../chdb/libchdb_export.map'
++ echo -Wl,--version-script=/home/me/sources/chdb-core/chdb/../chdb/libchdb_export.map
++ sed 's/@CMakeFiles\/clickhouse.rsp/@CMakeFiles\/libchdb.rsp/g'
+ LIBCHDB_CMD=-Wl,--version-script=/home/me/sources/chdb-core/chdb/../chdb/libchdb_export.map
+ echo -Wl,--version-script=/home/me/sources/chdb-core/chdb/../chdb/libchdb_export.map
+ -Wl,--version-script=/home/me/sources/chdb-core/chdb/../chdb/libchdb_export.map
build.sh: line 177: -Wl,--version-script=/home/me/sources/chdb-core/chdb/../chdb/libchdb_export.map: No such file or directory
make: *** [Makefile:5: buildlib] Error 127
```

Looking at the build.log, we do indeed see that the relevant `programs/clickhouse` line is (elided):

```
[3/4] : && /usr/lib/llvm20/bin/clang-20 [ ... ] @CMakeFiles/clickhouse.rsp -o programs/clickhouse && [ ... ]
```

So the `grep` never matches.

This commit is getting the build flowing despite a maybe...unconventional configuration. Nuking the builddir after realising what I've done meant waiting the 30 minutes for it to compile, but debugging it and writing this PR only took somewhat longer, [so xkcd has my side](https://xkcd.com/974/).

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support building in environments with non-standard clang paths.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

<details>
    <summary>CI Settings</summary>

**NOTE:** If your merge the PR with modified CI you **MUST KNOW** what you are doing
**NOTE:** Checked options will be applied if set before CI RunConfig/PrepareRunConfig step

#### Run these jobs only (required builds will be added automatically):
- [ ] <!---ci_include_integration--> Integration Tests
- [ ] <!---ci_include_stateless--> Stateless tests
- [ ] <!---ci_include_stateful--> Stateful tests
- [ ] <!---ci_include_unit--> Unit tests
- [ ] <!---ci_include_performance--> Performance tests
- [ ] <!---ci_include_aarch64--> All with aarch64
- [ ] <!---ci_include_asan--> All with ASAN
- [ ] <!---ci_include_tsan--> All with TSAN
- [ ] <!---ci_include_analyzer--> All with Analyzer
- [ ] <!---ci_include_azure --> All with Azure
- [ ] <!---ci_include_KEYWORD--> Add your option here

#### Deny these jobs:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64

#### Extra options:
- [ ] <!---do_not_test--> do not test (only style check)
- [ ] <!---no_merge_commit--> disable merge-commit (no merge from master before tests)
- [ ] <!---no_ci_cache--> disable CI cache (job reuse)

#### Only specified batches in multi-batch jobs:
- [ ] <!---batch_0--> 1
- [ ] <!---batch_1--> 2
- [ ] <!---batch_2--> 3
- [ ] <!---batch_3--> 4

</details>
