### PR TITLE
feat: support DDL/arbitrary SQL execution via remote() query parameter

### DIFF
--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -2,6 +2,7 @@
 
 #include <Storages/getStructureOfRemoteTable.h>
 #include <Storages/StorageDistributed.h>
+#include <Storages/StorageValues.h>
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <Storages/NamedCollectionsHelpers.h>
 #include <Storages/Distributed/DistributedSettings.h>
@@ -11,8 +12,14 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/Cluster.h>
+#include <Interpreters/ClusterProxy/executeQuery.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/IdentifierSemantic.h>
+#include <QueryPipeline/RemoteQueryExecutor.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Common/typeid_cast.h>
 #include <Common/parseRemoteDescription.h>
 #include <Common/Macros.h>
@@ -64,32 +71,45 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
     std::vector<std::pair<std::string, ASTPtr>> complex_args;
     if (!is_cluster_function && (named_collection = tryGetNamedCollectionWithOverrides(args, context, false, &complex_args)))
     {
-        validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(
-            *named_collection,
-            {"addresses_expr", "host", "hostname", "table"},
-            {"username", "user", "password", "sharding_key", "port", "database", "db"});
-
-        if (!complex_args.empty())
+        if (named_collection->has("query"))
         {
-            for (const auto & [arg_name, arg_ast] : complex_args)
-            {
-                if (arg_name == "database" || arg_name == "db")
-                    remote_table_function_ptr = arg_ast;
-                else if (arg_name == "sharding_key")
-                    sharding_key = arg_ast;
-                else
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected argument representation for {}", arg_name);
-            }
+            validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(
+                *named_collection,
+                {"addresses_expr", "host", "hostname"},
+                {"username", "user", "password", "port", "query"});
+
+            remote_query = named_collection->get<String>("query");
         }
         else
-            database = named_collection->getAnyOrDefault<String>({"db", "database"}, "default");
+        {
+            validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(
+                *named_collection,
+                {"addresses_expr", "host", "hostname", "table"},
+                {"username", "user", "password", "sharding_key", "port", "database", "db"});
+
+            if (!complex_args.empty())
+            {
+                for (const auto & [arg_name, arg_ast] : complex_args)
+                {
+                    if (arg_name == "database" || arg_name == "db")
+                        remote_table_function_ptr = arg_ast;
+                    else if (arg_name == "sharding_key")
+                        sharding_key = arg_ast;
+                    else
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected argument representation for {}", arg_name);
+                }
+            }
+            else
+                database = named_collection->getAnyOrDefault<String>({"db", "database"}, "default");
+
+            table = named_collection->get<String>("table");
+        }
 
         cluster_description = named_collection->getOrDefault<String>("addresses_expr", "");
         if (cluster_description.empty() && named_collection->hasAny({"host", "hostname"}))
             cluster_description = named_collection->has("port")
                 ? named_collection->getAny<String>({"host", "hostname"}) + ':' + toString(named_collection->get<UInt64>("port"))
                 : named_collection->getAny<String>({"host", "hostname"});
-        table = named_collection->get<String>("table");
         username = named_collection->getAnyOrDefault<String>({"username", "user"}, "default");
         password = named_collection->getOrDefault<String>("password", "");
     }
@@ -110,6 +130,11 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
         /// remote('addresses_expr', db.table, 'user', 'password', sharding_key)
         /// remote('addresses_expr', 'db', 'table', 'user', 'password', sharding_key)
         ///
+        /// DDL / arbitrary query execution:
+        /// remote('addresses_expr', query = 'DDL or any SQL')
+        /// remote('addresses_expr', query = 'DDL or any SQL', 'user')
+        /// remote('addresses_expr', query = 'DDL or any SQL', 'user', 'password')
+        ///
         /// remoteSecure() - same as remote()
         ///
         /// cluster()
@@ -120,6 +145,30 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
         /// cluster('cluster_name', 'db', 'table', sharding_key)
         ///
         /// clusterAllReplicas() - same as cluster()
+
+        /// Extract query = '...' keyword argument if present (for DDL / arbitrary query mode).
+        if (!is_cluster_function)
+        {
+            for (auto it = args.begin(); it != args.end(); ++it)
+            {
+                const auto * func = (*it)->as<ASTFunction>();
+                if (func && func->name == "equals")
+                {
+                    const auto * func_args = func->arguments->as<ASTExpressionList>();
+                    if (func_args && func_args->children.size() == 2)
+                    {
+                        String key;
+                        if (tryGetIdentifierNameInto(func_args->children[0], key) && key == "query")
+                        {
+                            auto literal = evaluateConstantExpressionOrIdentifierAsLiteral(func_args->children[1], context);
+                            remote_query = checkAndGetLiteralArgument<String>(literal, "query");
+                            args.erase(it);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
 
         if ((!is_cluster_function && args.empty()) || args.size() > max_args)
             throw Exception(help_message, ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
@@ -161,50 +210,84 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
 
         ++arg_num;
 
-        /// Names of database and table is not necessary.
-        if (arg_num < args.size())
+        /// When query parameter is set, skip db/table parsing — remaining args are [user [, password]].
+        if (!remote_query.empty())
         {
-            const auto * function = args[arg_num]->as<ASTFunction>();
-            if (function && TableFunctionFactory::instance().isTableFunctionName(function->name))
+            if (!is_cluster_function)
             {
-                remote_table_function_ptr = args[arg_num];
-                ++arg_num;
-            }
-            else
-            {
-                args[arg_num] = evaluateConstantExpressionForDatabaseName(args[arg_num], context);
-                database = checkAndGetLiteralArgument<String>(args[arg_num], "database");
-
-                ++arg_num;
-
-                auto qualified_name = QualifiedTableName::parseFromString(database);
-                if (qualified_name.database.empty())
+                if (arg_num < args.size())
                 {
-                    if (arg_num >= args.size())
+                    String user_candidate;
+                    if (get_string_literal(*args[arg_num], user_candidate))
                     {
-                        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Table name was not found in function arguments. {}", static_cast<const std::string>(help_message));
+                        username = user_candidate;
+                        ++arg_num;
                     }
-
-                    std::swap(qualified_name.database, qualified_name.table);
-                    args[arg_num] = evaluateConstantExpressionOrIdentifierAsLiteral(args[arg_num], context);
-                    qualified_name.table = checkAndGetLiteralArgument<String>(args[arg_num], "table");
-                    ++arg_num;
                 }
 
-                database = std::move(qualified_name.database);
-                table = std::move(qualified_name.table);
-
-                /// Cluster function may have sharding key for insert
-                if (is_cluster_function && arg_num < args.size())
+                if (arg_num < args.size())
                 {
-                    sharding_key = args[arg_num];
+                    String pass_candidate;
+                    if (get_string_literal(*args[arg_num], pass_candidate))
+                    {
+                        password = pass_candidate;
+                        ++arg_num;
+                    }
+                }
+            }
+
+            if (arg_num < args.size())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Too many arguments for remote() with query parameter. "
+                    "Expected: remote('host', query = 'SQL' [, 'user' [, 'password']])");
+        }
+        else
+        {
+            /// Names of database and table is not necessary.
+            if (arg_num < args.size())
+            {
+                const auto * function = args[arg_num]->as<ASTFunction>();
+                if (function && TableFunctionFactory::instance().isTableFunctionName(function->name))
+                {
+                    remote_table_function_ptr = args[arg_num];
                     ++arg_num;
+                }
+                else
+                {
+                    args[arg_num] = evaluateConstantExpressionForDatabaseName(args[arg_num], context);
+                    database = checkAndGetLiteralArgument<String>(args[arg_num], "database");
+
+                    ++arg_num;
+
+                    auto qualified_name = QualifiedTableName::parseFromString(database);
+                    if (qualified_name.database.empty())
+                    {
+                        if (arg_num >= args.size())
+                        {
+                            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Table name was not found in function arguments. {}", static_cast<const std::string>(help_message));
+                        }
+
+                        std::swap(qualified_name.database, qualified_name.table);
+                        args[arg_num] = evaluateConstantExpressionOrIdentifierAsLiteral(args[arg_num], context);
+                        qualified_name.table = checkAndGetLiteralArgument<String>(args[arg_num], "table");
+                        ++arg_num;
+                    }
+
+                    database = std::move(qualified_name.database);
+                    table = std::move(qualified_name.table);
+
+                    /// Cluster function may have sharding key for insert
+                    if (is_cluster_function && arg_num < args.size())
+                    {
+                        sharding_key = args[arg_num];
+                        ++arg_num;
+                    }
                 }
             }
         }
 
         /// Username and password parameters are prohibited in cluster version of the function
-        if (!is_cluster_function)
+        if (!is_cluster_function && remote_query.empty())
         {
             if (arg_num < args.size())
             {
@@ -301,7 +384,7 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
         cluster = std::make_shared<Cluster>(context->getSettingsRef(), names, params);
     }
 
-    if (!remote_table_function_ptr && table.empty())
+    if (remote_query.empty() && !remote_table_function_ptr && table.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "The name of remote table cannot be empty");
 
     remote_table_id.database_name = database;
@@ -310,12 +393,72 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
 
 StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const
 {
+    assert(cluster);
+
+    /// DDL / arbitrary query execution mode.
+    if (!remote_query.empty())
+    {
+        auto type_uint32 = std::make_shared<DataTypeUInt32>();
+        auto type_string = std::make_shared<DataTypeString>();
+
+        auto col_shard = ColumnUInt32::create();
+        auto col_host = ColumnString::create();
+        auto col_status = ColumnString::create();
+
+        const auto & shards_info = cluster->getShardsInfo();
+        const auto & addresses_with_failover = cluster->getShardsAddresses();
+
+        for (size_t shard_index = 0; shard_index < shards_info.size(); ++shard_index)
+        {
+            const auto & shard_info = shards_info[shard_index];
+
+            auto new_context = ClusterProxy::updateSettingsForCluster(
+                *cluster, context, context->getSettingsRef(), remote_table_id);
+            auto empty_header = std::make_shared<const Block>(Block{});
+
+            RemoteQueryExecutor executor(shard_info.pool, remote_query, empty_header, new_context);
+            executor.setPoolMode(PoolMode::GET_ONE);
+
+            while (true)
+            {
+                Block block = executor.readBlock();
+                if (block.rows() == 0)
+                    break;
+            }
+            executor.finish();
+
+            String host_name;
+            if (shard_index < addresses_with_failover.size() && !addresses_with_failover[shard_index].empty())
+                host_name = addresses_with_failover[shard_index].front().host_name
+                    + ":" + toString(addresses_with_failover[shard_index].front().port);
+            else
+                host_name = "localhost";
+
+            col_shard->insert(shard_info.shard_num);
+            col_host->insert(host_name);
+            col_status->insert(String("OK"));
+        }
+
+        Block result_block;
+        result_block.insert({std::move(col_shard), type_uint32, "shard_num"});
+        result_block.insert({std::move(col_host), type_string, "host"});
+        result_block.insert({std::move(col_status), type_string, "status"});
+
+        ColumnsDescription result_columns;
+        result_columns.add(ColumnDescription("shard_num", type_uint32));
+        result_columns.add(ColumnDescription("host", type_string));
+        result_columns.add(ColumnDescription("status", type_string));
+
+        return std::make_shared<StorageValues>(
+            StorageID(getDatabaseName(), table_name),
+            result_columns,
+            std::move(result_block));
+    }
+
     /// StorageDistributed supports mismatching structure of remote table, so we can use outdated structure for CREATE ... AS remote(...)
     /// without additional conversion in StorageTableFunctionProxy
     if (cached_columns.empty())
         cached_columns = getActualTableStructure(context, is_insert_query);
-
-    assert(cluster);
 
     bool has_local_shard = false;
     for (const auto & shard_info : cluster->getShardsInfo())
@@ -357,6 +500,16 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
 ColumnsDescription TableFunctionRemote::getActualTableStructure(ContextPtr context, bool /*is_insert_query*/) const
 {
     assert(cluster);
+
+    if (!remote_query.empty())
+    {
+        ColumnsDescription result_columns;
+        result_columns.add(ColumnDescription("shard_num", std::make_shared<DataTypeUInt32>()));
+        result_columns.add(ColumnDescription("host", std::make_shared<DataTypeString>()));
+        result_columns.add(ColumnDescription("status", std::make_shared<DataTypeString>()));
+        return result_columns;
+    }
+
     return getStructureOfRemoteTable(*cluster, remote_table_id, context, remote_table_function_ptr);
 }
 

--- a/src/TableFunctions/TableFunctionRemote.h
+++ b/src/TableFunctions/TableFunctionRemote.h
@@ -42,6 +42,11 @@ private:
     StorageID remote_table_id = StorageID::createEmpty();
     ASTPtr remote_table_function_ptr;
     ASTPtr sharding_key = nullptr;
+
+    /// Arbitrary SQL (including DDL) to execute on the remote server(s).
+    /// When set, the table function sends this query directly instead of
+    /// creating a StorageDistributed for SELECT/INSERT.
+    String remote_query;
 };
 
 }

--- a/tests/test_remote_query.py
+++ b/tests/test_remote_query.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Tests for remote() / remoteSecure() table function with query parameter.
+
+Requires:
+  1. A rebuilt chdb with the query= parameter support in remote().
+  2. Environment variables:
+       REMOTE_HOST     - e.g. "xiaozhe-yu-dev-vm:9000"
+       REMOTE_USER     - e.g. "remote_user"
+       REMOTE_PASSWORD - e.g. "test123"
+       TEST_DB         - (optional) database name for test artifacts, default "test_remote_query"
+
+Run:
+    REMOTE_HOST=host:9000 REMOTE_USER=user REMOTE_PASSWORD=pwd \
+        python -m pytest tests/test_remote_query.py -v
+"""
+
+import os
+import unittest
+import uuid
+
+import pytest
+
+REMOTE_HOST = os.environ.get("REMOTE_HOST")
+REMOTE_USER = os.environ.get("REMOTE_USER")
+REMOTE_PASSWORD = os.environ.get("REMOTE_PASSWORD")
+
+if not all([REMOTE_HOST, REMOTE_USER, REMOTE_PASSWORD]):
+    pytest.skip(
+        "Skipping remote query tests: REMOTE_HOST, REMOTE_USER, and REMOTE_PASSWORD must be set",
+        allow_module_level=True,
+    )
+
+import chdb
+
+TEST_DB = os.environ.get("TEST_DB", "test_remote_query")
+TEST_SUFFIX = uuid.uuid4().hex[:8]
+
+
+def _check_query_param_support():
+    """Check if current chdb binary supports remote(query=...) syntax."""
+    try:
+        chdb.query(
+            f"SELECT * FROM remote('{REMOTE_HOST}', "
+            f"query = 'SELECT 1', "
+            f"'{REMOTE_USER}', '{REMOTE_PASSWORD}')",
+            "TabSeparated",
+        )
+        return True
+    except RuntimeError as e:
+        if "UNKNOWN_IDENTIFIER" in str(e) or "Unknown expression" in str(e):
+            return False
+        # Other errors (e.g., connection refused) still mean the syntax is recognized
+        return True
+
+
+QUERY_PARAM_SUPPORTED = _check_query_param_support()
+SKIP_MSG = "Current chdb binary does not support remote(query=...). Rebuild libchdb first."
+
+
+def remote_exec(query_sql):
+    """Execute an arbitrary SQL on the remote server via remote(query=...).
+    Returns the chdb result object.
+    Single quotes inside query_sql must be escaped as \\\\' by the caller.
+    """
+    sql = (
+        f"SELECT * FROM remote('{REMOTE_HOST}', "
+        f"query = '{query_sql}', "
+        f"'{REMOTE_USER}', '{REMOTE_PASSWORD}')"
+    )
+    return chdb.query(sql, "TabSeparated")
+
+
+def remote_table_select(db, table, extra=""):
+    """Use original remote('host', 'db', 'table') path to SELECT."""
+    sql = (
+        f"SELECT * FROM remote('{REMOTE_HOST}', '{db}', '{table}', "
+        f"'{REMOTE_USER}', '{REMOTE_PASSWORD}') {extra}"
+    )
+    return chdb.query(sql, "TabSeparated")
+
+
+def remote_table_insert(db, table, values_sql):
+    """Use original remote('host', 'db', 'table') path to INSERT."""
+    sql = (
+        f"INSERT INTO FUNCTION remote('{REMOTE_HOST}', '{db}', '{table}', "
+        f"'{REMOTE_USER}', '{REMOTE_PASSWORD}') VALUES {values_sql}"
+    )
+    return chdb.query(sql, "TabSeparated")
+
+
+def get_status(res):
+    """Parse the status column from remote(query=...) result."""
+    text = res.bytes().decode().strip()
+    if not text:
+        return ""
+    # Format: shard_num \t host \t status
+    parts = text.split("\n")
+    statuses = []
+    for line in parts:
+        cols = line.split("\t")
+        statuses.append(cols[2] if len(cols) >= 3 else line)
+    return statuses
+
+
+# ---------------------------------------------------------------------------
+# Test: basic connectivity
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(QUERY_PARAM_SUPPORTED, SKIP_MSG)
+class TestRemoteConnectivity(unittest.TestCase):
+    """Verify basic connectivity to the remote ClickHouse server."""
+
+    def test_select_1_via_query_param(self):
+        res = remote_exec("SELECT 1")
+        self.assertFalse(res.has_error(), f"Query failed: {res.error_message()}")
+        statuses = get_status(res)
+        self.assertEqual(len(statuses), 1)
+        self.assertEqual(statuses[0], "OK")
+
+
+# ---------------------------------------------------------------------------
+# Test: DDL operations
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(QUERY_PARAM_SUPPORTED, SKIP_MSG)
+class TestRemoteDDL(unittest.TestCase):
+    """Test DDL operations via remote(query=...) on the remote server."""
+
+    @classmethod
+    def setUpClass(cls):
+        remote_exec(f"CREATE DATABASE IF NOT EXISTS {TEST_DB}")
+
+    @classmethod
+    def tearDownClass(cls):
+        remote_exec(f"DROP DATABASE IF EXISTS {TEST_DB}")
+
+    def test_create_and_drop_table(self):
+        tbl = f"{TEST_DB}.ddl_create_{TEST_SUFFIX}"
+        res = remote_exec(
+            f"CREATE TABLE {tbl} (id UInt32, name String) ENGINE = MergeTree() ORDER BY id"
+        )
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK", f"CREATE TABLE failed: {res.bytes()}")
+
+        res = remote_exec(f"DROP TABLE {tbl}")
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK", f"DROP TABLE failed: {res.bytes()}")
+
+    def test_create_table_if_not_exists_is_idempotent(self):
+        tbl = f"{TEST_DB}.ddl_ifne_{TEST_SUFFIX}"
+        remote_exec(f"CREATE TABLE {tbl} (x UInt32) ENGINE = Memory")
+
+        res = remote_exec(f"CREATE TABLE IF NOT EXISTS {tbl} (x UInt32) ENGINE = Memory")
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK")
+
+        remote_exec(f"DROP TABLE IF EXISTS {tbl}")
+
+    def test_alter_table_add_column(self):
+        tbl = f"{TEST_DB}.ddl_alter_{TEST_SUFFIX}"
+        remote_exec(f"CREATE TABLE {tbl} (id UInt32) ENGINE = MergeTree() ORDER BY id")
+
+        res = remote_exec(f"ALTER TABLE {tbl} ADD COLUMN value Float64 DEFAULT 0")
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK", f"ALTER TABLE failed: {res.bytes()}")
+
+        remote_exec(f"DROP TABLE IF EXISTS {tbl}")
+
+    def test_truncate_table(self):
+        tbl = f"{TEST_DB}.ddl_trunc_{TEST_SUFFIX}"
+        remote_exec(f"CREATE TABLE {tbl} (x UInt32) ENGINE = Memory")
+
+        res = remote_exec(f"TRUNCATE TABLE {tbl}")
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK", f"TRUNCATE failed: {res.bytes()}")
+
+        remote_exec(f"DROP TABLE IF EXISTS {tbl}")
+
+    def test_drop_nonexistent_table_raises_exception(self):
+        """Dropping a non-existent table should raise an exception, same as the original remote() path."""
+        tbl = f"{TEST_DB}.nonexistent_{TEST_SUFFIX}"
+        with self.assertRaises(RuntimeError) as ctx:
+            remote_exec(f"DROP TABLE {tbl}")
+        self.assertIn("UNKNOWN_TABLE", str(ctx.exception))
+
+    def test_syntax_error_raises_exception(self):
+        """SQL syntax errors should raise an exception."""
+        with self.assertRaises(RuntimeError) as ctx:
+            remote_exec("CREAT TABLE bad_syntax")
+        self.assertIn("SYNTAX_ERROR", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Test: DML via query= mode and original remote() path
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(QUERY_PARAM_SUPPORTED, SKIP_MSG)
+class TestRemoteDML(unittest.TestCase):
+    """Test DML (INSERT/SELECT) via both query= mode and the original remote() path."""
+
+    tbl_short = f"dml_{TEST_SUFFIX}"
+    tbl_full = f"{TEST_DB}.{tbl_short}"
+
+    @classmethod
+    def setUpClass(cls):
+        remote_exec(f"CREATE DATABASE IF NOT EXISTS {TEST_DB}")
+        res = remote_exec(
+            f"CREATE TABLE {cls.tbl_full} "
+            f"(id UInt32, value Float64) ENGINE = MergeTree() ORDER BY id"
+        )
+        statuses = get_status(res)
+        assert statuses and statuses[0] == "OK", f"Setup failed: {res.bytes()}"
+
+    @classmethod
+    def tearDownClass(cls):
+        remote_exec(f"DROP TABLE IF EXISTS {cls.tbl_full}")
+
+    def test_01_insert_via_query_param(self):
+        """INSERT numeric-only data via remote(query=...) mode."""
+        res = remote_exec(
+            f"INSERT INTO {self.tbl_full} VALUES (1, 10.5), (2, 20.3), (3, 30.1)"
+        )
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK", f"INSERT via query= failed: {res.bytes()}")
+
+    def test_02_select_via_original_remote_returns_actual_data(self):
+        """SELECT via original remote('host','db','table') returns actual row data."""
+        res = remote_table_select(TEST_DB, self.tbl_short, "ORDER BY id")
+        self.assertFalse(res.has_error(), f"SELECT error: {res.error_message()}")
+        output = res.bytes().decode().strip()
+        lines = [l for l in output.split("\n") if l]
+        self.assertEqual(len(lines), 3, f"Expected 3 rows, got: {output}")
+        self.assertIn("10.5", lines[0])
+        self.assertIn("20.3", lines[1])
+        self.assertIn("30.1", lines[2])
+
+    def test_03_insert_via_original_remote(self):
+        """INSERT via original remote('host','db','table') path still works."""
+        remote_table_insert(TEST_DB, self.tbl_short, "(4, 40.0)")
+        res = remote_table_select(TEST_DB, self.tbl_short, "WHERE id = 4")
+        output = res.bytes().decode().strip()
+        self.assertIn("40", output)
+
+    def test_04_select_via_query_param_returns_status_not_data(self):
+        """SELECT via remote(query='SELECT ...') returns execution status, NOT the query result rows."""
+        res = remote_exec(f"SELECT count() FROM {self.tbl_full}")
+        statuses = get_status(res)
+        self.assertEqual(statuses[0], "OK")
+        # The actual count value is NOT returned — only execution status
+        raw = res.bytes().decode().strip()
+        self.assertNotIn("4", raw.split("\t")[2] if "\t" in raw else "")
+
+    def test_05_verify_final_row_count(self):
+        """Verify total row count after all inserts via original remote() path."""
+        res = remote_table_select(TEST_DB, self.tbl_short, "")
+        output = res.bytes().decode().strip()
+        lines = [l for l in output.split("\n") if l]
+        self.assertEqual(len(lines), 4, f"Expected 4 rows, got {len(lines)}: {output}")
+
+
+# ---------------------------------------------------------------------------
+# Test: original remote() paths remain fully functional
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(QUERY_PARAM_SUPPORTED, SKIP_MSG)
+class TestOriginalRemoteUnchanged(unittest.TestCase):
+    """Verify that the original remote() SELECT/INSERT paths work identically to before."""
+
+    tbl_short = f"orig_{TEST_SUFFIX}"
+    tbl_full = f"{TEST_DB}.{tbl_short}"
+
+    @classmethod
+    def setUpClass(cls):
+        remote_exec(f"CREATE DATABASE IF NOT EXISTS {TEST_DB}")
+        remote_exec(f"CREATE TABLE {cls.tbl_full} (val UInt64) ENGINE = Memory")
+
+    @classmethod
+    def tearDownClass(cls):
+        remote_exec(f"DROP TABLE IF EXISTS {cls.tbl_full}")
+
+    def test_original_select_from_system_one(self):
+        """Original remote() can read system.one on the remote server."""
+        sql = (
+            f"SELECT dummy FROM remote('{REMOTE_HOST}', 'system', 'one', "
+            f"'{REMOTE_USER}', '{REMOTE_PASSWORD}')"
+        )
+        res = chdb.query(sql, "TabSeparated")
+        self.assertFalse(res.has_error(), f"Error: {res.error_message()}")
+        self.assertEqual(res.bytes().decode().strip(), "0")
+
+    def test_original_insert_and_select_roundtrip(self):
+        """Original remote() INSERT → SELECT roundtrip with value verification."""
+        remote_table_insert(TEST_DB, self.tbl_short, "(100), (200), (300)")
+
+        res = remote_table_select(TEST_DB, self.tbl_short, "ORDER BY val")
+        output = res.bytes().decode().strip()
+        lines = output.split("\n")
+        self.assertEqual(len(lines), 3)
+        self.assertEqual(lines[0], "100")
+        self.assertEqual(lines[1], "200")
+        self.assertEqual(lines[2], "300")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remote_query.py
+++ b/tests/test_remote_query.py
@@ -12,23 +12,20 @@ Requires:
 
 Run:
     REMOTE_HOST=host:9000 REMOTE_USER=user REMOTE_PASSWORD=pwd \
-        python -m pytest tests/test_remote_query.py -v
+        python -m unittest tests/test_remote_query.py -v
 """
 
 import os
 import unittest
 import uuid
 
-import pytest
-
 REMOTE_HOST = os.environ.get("REMOTE_HOST")
 REMOTE_USER = os.environ.get("REMOTE_USER")
 REMOTE_PASSWORD = os.environ.get("REMOTE_PASSWORD")
 
 if not all([REMOTE_HOST, REMOTE_USER, REMOTE_PASSWORD]):
-    pytest.skip(
-        "Skipping remote query tests: REMOTE_HOST, REMOTE_USER, and REMOTE_PASSWORD must be set",
-        allow_module_level=True,
+    raise unittest.SkipTest(
+        "Skipping remote query tests: REMOTE_HOST, REMOTE_USER, and REMOTE_PASSWORD must be set"
     )
 
 import chdb


### PR DESCRIPTION
## Summary

- Add a `query = '...'` parameter to `remote()` and `remoteSecure()` table functions, enabling DDL and arbitrary SQL execution on remote ClickHouse servers.
- When `query=` is provided, the SQL is sent directly to each shard via `RemoteQueryExecutor`. On success, returns a status table (`shard_num`, `host`, `status`); on failure, raises an exception — consistent with the original `remote()` error behavior.
- The original `remote('host', 'db', 'table', ...)` path for SELECT/INSERT remains fully intact.
- Supports both named-collection and positional argument styles.
- Adds `tests/test_remote_query.py` with comprehensive DDL/DML/SELECT tests (requires env vars, cleanly skipped in CI).

Closes #37

## Usage

```sql
-- DDL
SELECT * FROM remote('host:9000', query = 'CREATE TABLE db.t (id UInt32) ENGINE = MergeTree() ORDER BY id', 'user', 'pwd')

-- DML
SELECT * FROM remote('host:9000', query = 'INSERT INTO db.t VALUES (1)', 'user', 'pwd')

-- Original path unchanged
SELECT * FROM remote('host:9000', 'db', 't', 'user', 'pwd')
```