### PR TITLE
Run chdb upstream DataStore tests against chdb-core builds

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -399,6 +399,17 @@ jobs:
           python -m pytest tests/test_torch_compatibility.py -v
           pyenv shell --unset
         continue-on-error: false
+      - name: Test chdb DataStore tests against upstream chdb (latest tag)
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        timeout-minutes: 60
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.11
+          python -m pip install dist/*.whl --force-reinstall
+          PYTHON=$(pyenv which python) bash ./chdb/test_chdb_datastore.sh
+          pyenv shell --unset
+        continue-on-error: false
       - name: Run notebook tests
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -384,6 +384,17 @@ jobs:
           python -m pytest tests/test_torch_compatibility.py -v
           pyenv shell --unset
         continue-on-error: false
+      - name: Test chdb DataStore tests against upstream chdb (latest tag)
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        timeout-minutes: 60
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.11
+          python -m pip install dist/*.whl --force-reinstall
+          PYTHON=$(pyenv which python) bash ./chdb/test_chdb_datastore.sh
+          pyenv shell --unset
+        continue-on-error: false
       - name: Run notebook tests
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -376,6 +376,17 @@ jobs:
           python -m pytest tests/test_torch_compatibility.py -v
           pyenv shell --unset
         continue-on-error: false
+      - name: Test chdb DataStore tests against upstream chdb (latest tag)
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        timeout-minutes: 60
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.11
+          python -m pip install dist/*.whl --force-reinstall --no-cache-dir
+          PYTHON=$(pyenv which python) bash ./chdb/test_chdb_datastore.sh
+          pyenv shell --unset
+        continue-on-error: false
       - name: Run notebook tests
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -376,6 +376,17 @@ jobs:
           python -m pytest tests/test_torch_compatibility.py -v
           pyenv shell --unset
         continue-on-error: false
+      - name: Test chdb DataStore tests against upstream chdb (latest tag)
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        timeout-minutes: 60
+        run: |
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          pyenv shell 3.11
+          python -m pip install dist/*.whl --force-reinstall
+          PYTHON=$(pyenv which python) bash ./chdb/test_chdb_datastore.sh
+          pyenv shell --unset
+        continue-on-error: false
       - name: Run notebook tests
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |

--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -67,15 +67,17 @@ ${PYTHON} -c "import chdb; print('chdb pkg version:', getattr(chdb, '__version__
 ${PYTHON} -c "from datastore import DataStore; print('datastore import OK')"
 
 echo "=============================================="
-echo "Running pytest on datastore/tests/"
+echo "Running pytest from datastore/ on tests/"
+echo "(cwd=datastore so 'from tests.test_utils import ...' resolves to datastore/tests/)"
 echo "=============================================="
+cd "${CHDB_SRC}/datastore"
 set +e
-${PYTHON} -m pytest datastore/tests/ ${PYTEST_ARGS}
+${PYTHON} -m pytest tests/ ${PYTEST_ARGS}
 TEST_EXIT_CODE=$?
 set -e
 
 echo "Stopping ClickHouse test server (best effort)..."
-bash datastore/tests/stop_clickhouse_server.sh || true
+bash tests/stop_clickhouse_server.sh || true
 
 if [ ${TEST_EXIT_CODE} -ne 0 ]; then
     echo "DataStore tests FAILED (exit code ${TEST_EXIT_CODE}) on chdb tag ${CHDB_TAG}"

--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Run chdb's DataStore test suite against the freshly-built chdb-core wheel.
+#
+# This script fetches the latest chdb (chdb-io/chdb) release tag, clones the
+# repository at that tag, layers the chdb wrapper package on top of the
+# already-installed chdb-core wheel, and executes datastore/tests/ via pytest.
+# A local ClickHouse server is started automatically by the datastore tests'
+# conftest.py for integration tests that need a remote server.
+#
+# Pre-requisites:
+#   - chdb-core wheel must already be installed in the active Python env
+#     (e.g. via `pip install dist/*.whl`).
+#
+# Optional environment variables:
+#   CHDB_TAG       - pin to a specific chdb tag (default: latest release tag)
+#   PYTHON         - python binary to use (default: python from PATH)
+#   PYTEST_ARGS    - additional pytest args (default: "-v --tb=short")
+#   KEEP_WORKDIR   - if set, do not remove the cloned chdb directory on exit
+
+set -euo pipefail
+
+PYTHON="${PYTHON:-python}"
+PYTEST_ARGS="${PYTEST_ARGS:--v --tb=short}"
+
+echo "=============================================="
+echo "chdb DataStore tests against chdb-core build"
+echo "=============================================="
+echo "Python: $(${PYTHON} --version) ($(command -v ${PYTHON}))"
+
+if ! ${PYTHON} -c "import chdb" 2>/dev/null; then
+    echo "ERROR: chdb (engine from chdb-core) is not importable in this Python." >&2
+    echo "Install the chdb-core wheel first: pip install dist/*.whl" >&2
+    exit 1
+fi
+
+CORE_VERSION=$(${PYTHON} -c "import chdb; print(chdb.query('SELECT version()', 'CSV').bytes().decode().strip())" 2>/dev/null || echo "unknown")
+echo "chdb-core engine version: ${CORE_VERSION}"
+
+if [ -z "${CHDB_TAG:-}" ]; then
+    echo "Resolving latest chdb release tag from GitHub..."
+    CHDB_TAG=$(curl -fsSL https://api.github.com/repos/chdb-io/chdb/releases/latest \
+        | ${PYTHON} -c "import json, sys; print(json.load(sys.stdin)['tag_name'])")
+fi
+echo "Using chdb tag: ${CHDB_TAG}"
+
+WORKDIR=$(mktemp -d -t chdb-tests-XXXXXX)
+if [ -z "${KEEP_WORKDIR:-}" ]; then
+    trap 'rm -rf "${WORKDIR}"' EXIT
+else
+    echo "KEEP_WORKDIR set; workdir will remain at ${WORKDIR}"
+fi
+
+CHDB_SRC="${WORKDIR}/chdb"
+echo "Cloning chdb-io/chdb@${CHDB_TAG} into ${CHDB_SRC}..."
+git clone --depth 1 --branch "${CHDB_TAG}" https://github.com/chdb-io/chdb.git "${CHDB_SRC}"
+
+echo "Installing chdb wrapper on top of chdb-core (no deps to preserve local chdb-core)..."
+${PYTHON} -m pip install --no-deps --force-reinstall "${CHDB_SRC}"
+
+echo "Installing test dependencies (pytest, pytest-timeout)..."
+${PYTHON} -m pip install --upgrade pytest pytest-timeout
+
+cd "${CHDB_SRC}"
+
+echo "Sanity check: chdb wrapper version after install"
+${PYTHON} -c "import chdb; print('chdb pkg version:', getattr(chdb, '__version__', 'unknown'))"
+${PYTHON} -c "from datastore import DataStore; print('datastore import OK')"
+
+echo "=============================================="
+echo "Running pytest on datastore/tests/"
+echo "=============================================="
+set +e
+${PYTHON} -m pytest datastore/tests/ ${PYTEST_ARGS}
+TEST_EXIT_CODE=$?
+set -e
+
+echo "Stopping ClickHouse test server (best effort)..."
+bash datastore/tests/stop_clickhouse_server.sh || true
+
+if [ ${TEST_EXIT_CODE} -ne 0 ]; then
+    echo "DataStore tests FAILED (exit code ${TEST_EXIT_CODE}) on chdb tag ${CHDB_TAG}"
+    exit ${TEST_EXIT_CODE}
+fi
+
+echo "=============================================="
+echo "DataStore tests PASSED on chdb tag ${CHDB_TAG}"
+echo "=============================================="


### PR DESCRIPTION
## Summary
- Add `chdb/test_chdb_datastore.sh` that fetches the latest `chdb-io/chdb` release tag, clones it, layers the chdb wrapper on top of our locally-built chdb-core wheel (`pip install --no-deps`), and runs `pytest datastore/tests/`.
- Wire the helper into all four build workflows (Linux x86_64/arm64, macOS x86_64/arm64) on PR + push to main, so chdb-core changes are validated against chdb's full DataStore test suite.

## Why
The DataStore tests exercise lots of engine behaviour through the high-level pandas-style API. Running them against every chdb-core build catches regressions that the engine smoke tests + torch compat step don't surface. Pinning to chdb's latest release tag (currently `v4.1.6`, resolved dynamically each run) keeps coverage current without us having to mirror tests into this repo.

## Notes
- The helper script accepts `CHDB_TAG`/`PYTHON`/`PYTEST_ARGS`/`KEEP_WORKDIR` env vars for local debugging.
- The new step uses Python 3.11 (matches torch-compat step) and is gated by `if: env.EFFECTIVE_DEBUG_MODE != 'true'`, consistent with the existing notebook test step.
- ClickHouse server lifecycle is handled by chdb's `datastore/tests/conftest.py` via the bundled `setup_clickhouse_server.sh` (downloads the official ClickHouse binary for Linux/macOS x86_64/arm64).

## Test plan
- [ ] Linux x86_64 build pipeline runs the new step and passes.
- [ ] Linux arm64 build pipeline runs the new step and passes.
- [ ] macOS x86_64 build pipeline runs the new step and passes.
- [ ] macOS arm64 build pipeline runs the new step and passes.