### PR TITLE
fix: writeInteger uses unsigned_value for Python uint64 overflow path

### DIFF
--- a/programs/local/PythonConversion.cpp
+++ b/programs/local/PythonConversion.cpp
@@ -114,7 +114,7 @@ static void writeInteger(const py::handle & obj, rapidjson::Value & json_value)
 			uint64_t unsigned_value = PyLong_AsUnsignedLongLong(ptr);
 			if (!PyErr_Occurred())
 			{
-				json_value.SetUint64(value);
+				json_value.SetUint64(unsigned_value);
 				return;
 			}
 

--- a/tests/test_write_integer_uint64.py
+++ b/tests/test_write_integer_uint64.py
@@ -1,0 +1,73 @@
+"""
+Regression test for writeInteger bug: Python ints in (INT64_MAX, UINT64_MAX] were
+serialized as UINT64_MAX (18446744073709551615) instead of their actual value.
+
+Root cause: programs/local/PythonConversion.cpp `writeInteger` called
+json_value.SetUint64(value) where `value` is the int64_t that overflowed (== -1),
+instead of json_value.SetUint64(unsigned_value) which holds the correct uint64 result.
+
+See: https://github.com/chdb-io/chdb-core/issues/46
+"""
+
+import unittest
+import pandas as pd
+import chdb
+
+INT64_MAX = (1 << 63) - 1          # 9223372036854775807 — largest int64
+INT64_MAX_PLUS_1 = 1 << 63         # 9223372036854775808 — first value to overflow int64
+UINT64_NEAR_MAX = (1 << 64) - 2    # 18446744073709551614
+UINT64_MAX = (1 << 64) - 1         # 18446744073709551615
+
+# DataFrame with a dict-typed column whose values contain large Python ints.
+# This exercises the writeInteger → SetUint64 path in PythonConversion.cpp.
+df_large_int_dicts = pd.DataFrame(
+    {
+        "id": [1, 2, 3, 4],
+        "info": [
+            {"val": INT64_MAX},           # just fits in int64 — control row
+            {"val": INT64_MAX_PLUS_1},    # first value that overflows int64
+            {"val": UINT64_NEAR_MAX},     # UINT64_MAX - 1
+            {"val": UINT64_MAX},          # UINT64_MAX — edge
+        ],
+    }
+)
+
+
+class TestWriteIntegerUint64(unittest.TestCase):
+    """
+    writeInteger must use unsigned_value (not value) when serialising Python ints
+    in the range (INT64_MAX, UINT64_MAX] to JSON.
+    """
+
+    def _query_info_val(self, row_id):
+        """Return the 'val' field from the JSON 'info' column for the given id."""
+        res = chdb.query(
+            f"SELECT CAST(info.val AS UInt64) AS v "
+            f"FROM Python(df_large_int_dicts) WHERE id = {row_id}",
+            "CSV",
+        )
+        self.assertFalse(res.has_error(), msg=f"query error: {res.error_message()}")
+        return int(res.bytes().decode().strip())
+
+    def test_int64_max_control(self):
+        """INT64_MAX itself must round-trip correctly (sanity check)."""
+        self.assertEqual(self._query_info_val(1), INT64_MAX)
+
+    def test_int64_max_plus_1(self):
+        """
+        INT64_MAX + 1 = 2^63 must NOT be serialised as UINT64_MAX.
+        Before the fix this returned 18446744073709551615 for every overflow value.
+        """
+        self.assertEqual(self._query_info_val(2), INT64_MAX_PLUS_1)
+
+    def test_uint64_near_max(self):
+        """UINT64_MAX - 1 must round-trip correctly."""
+        self.assertEqual(self._query_info_val(3), UINT64_NEAR_MAX)
+
+    def test_uint64_max(self):
+        """UINT64_MAX itself must round-trip correctly."""
+        self.assertEqual(self._query_info_val(4), UINT64_MAX)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Python ints in the range `(INT64_MAX, UINT64_MAX]` passed through the `Python()` table function (e.g. as values inside dict-typed DataFrame columns) were silently serialized as `18446744073709551615` (UINT64_MAX) instead of their actual value.

### Triggered by

@wudidapaopao requested this fix in chdb-io/chdb-core#46 via a @chibugai mention.

---

## Reproduction

```python
import chdb, pandas as pd

INT64_MAX_PLUS_1 = 1 << 63   # 9223372036854775808
df = pd.DataFrame({
    'id': [1, 2],
    'info': [{'val': INT64_MAX_PLUS_1}, {'val': (1<<64)-2}],
})
res = chdb.query("SELECT id, info FROM Python(df) ORDER BY id", "CSV")
print(res.bytes().decode())
# Buggy output (both rows show UINT64_MAX):
#   1,"{""val"":18446744073709551615}"
#   2,"{""val"":18446744073709551615}"
# Expected:
#   1,"{""val"":9223372036854775808}"
#   2,"{""val"":18446744073709551614}"
```

## Root cause

`writeInteger` in `programs/local/PythonConversion.cpp` (line 117 before this fix):

```cpp
uint64_t unsigned_value = PyLong_AsUnsignedLongLong(ptr);
if (!PyErr_Occurred())
{
    json_value.SetUint64(value);   // BUG: `value` is int64_t == -1 after overflow
    return;
}
```

`PyLong_AsLongLongAndOverflow` sets `overflow = 1` and returns `-1` (as int64_t) for any positive Python int that overflows int64. The code then correctly calls `PyLong_AsUnsignedLongLong` and stores the result in `unsigned_value`, but immediately passes the wrong variable (`value`, not `unsigned_value`) to `SetUint64`. Because `(uint64_t)(-1) == UINT64_MAX`, every overflow value gets clamped to `18446744073709551615`. No compiler warning is issued because `unsigned_value` is used on the happy-path return, not unreferenced.

## Fix

One-line change: `json_value.SetUint64(value)` → `json_value.SetUint64(unsigned_value)`.

## Regression test

`tests/test_write_integer_uint64.py` covers four boundary cases:

| id | val | Before fix | After fix |
|----|-----|-----------|-----------|
| 1 | INT64_MAX (9223372036854775807) | ✅ correct | ✅ correct |
| 2 | INT64_MAX+1 (9223372036854775808) | ❌ 18446744073709551615 | ✅ correct |
| 3 | UINT64_MAX-1 (18446744073709551614) | ❌ 18446744073709551615 | ✅ correct |
| 4 | UINT64_MAX (18446744073709551615) | ✅ coincidentally correct | ✅ correct |

Tests 2 and 3 fail on the buggy code and pass after the fix. Verified locally against the installed chdb 4.0.1 which contains the same bug.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No documentation change required — this is a correctness fix for existing behaviour.