### PR TITLE
Treat missing cgroups files as a quiet fallback, not a stack-traced error

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -402,6 +402,8 @@ jobs:
       - name: Test chdb DataStore tests against upstream chdb (latest tag)
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -387,6 +387,8 @@ jobs:
       - name: Test chdb DataStore tests against upstream chdb (latest tag)
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -379,6 +379,8 @@ jobs:
       - name: Test chdb DataStore tests against upstream chdb (latest tag)
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -379,6 +379,8 @@ jobs:
       - name: Test chdb DataStore tests against upstream chdb (latest tag)
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -38,8 +38,38 @@ echo "chdb-core engine version: ${CORE_VERSION}"
 
 if [ -z "${CHDB_TAG:-}" ]; then
     echo "Resolving latest chdb release tag from GitHub..."
-    CHDB_TAG=$(curl -fsSL https://api.github.com/repos/chdb-io/chdb/releases/latest \
-        | ${PYTHON} -c "import json, sys; print(json.load(sys.stdin)['tag_name'])")
+    api_url="https://api.github.com/repos/chdb-io/chdb/releases/latest"
+
+    # Authenticate when possible to avoid the 60 req/hr unauthenticated
+    # rate limit, which previously caused intermittent 403s in CI.
+    auth_args=()
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        auth_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+
+    api_response=""
+    for attempt in 1 2 3; do
+        if api_response=$(curl -fsSL --retry 3 --retry-delay 5 \
+                -H "Accept: application/vnd.github+json" \
+                "${auth_args[@]}" \
+                "${api_url}"); then
+            break
+        fi
+        echo "Attempt ${attempt}/3 to fetch ${api_url} failed; retrying..." >&2
+        api_response=""
+        sleep $((attempt * 5))
+    done
+
+    if [ -z "${api_response}" ]; then
+        echo "ERROR: failed to fetch latest chdb release tag from ${api_url}." >&2
+        echo "       Workarounds:" >&2
+        echo "         - export CHDB_TAG=<tag>   # skip this lookup entirely" >&2
+        echo "         - export GITHUB_TOKEN=... # authenticate to bypass the" >&2
+        echo "                                     60 req/hr anonymous limit" >&2
+        exit 1
+    fi
+
+    CHDB_TAG=$(${PYTHON} -c "import json,sys; print(json.loads(sys.stdin.read())['tag_name'])" <<<"${api_response}")
 fi
 echo "Using chdb tag: ${CHDB_TAG}"
 

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -157,18 +157,25 @@ AsynchronousMetrics::AsynchronousMetrics(
     if (!cgroupcpu_stat)
         openFileIfExists("/sys/fs/cgroup/cpuacct/cpuacct.stat", cgroupcpuacct_stat);
 
-    try
+    if (auto cgroups = ICgroupsReader::tryGetCgroupsPath())
     {
-        const auto [cgroup_path, version] = ICgroupsReader::getCgroupsPath();
-        LOG_INFO(getLogger("AsynchronousMetrics"),
-            "Will use cgroup reader from '{}' (cgroups version: {})",
-            cgroup_path,
-            (version == ICgroupsReader::CgroupsVersion::V1) ? "v1" : "v2");
-        cgroupmem_reader = ICgroupsReader::createCgroupsReader(version, cgroup_path);
+        const auto & [cgroup_path, version] = *cgroups;
+        try
+        {
+            LOG_INFO(getLogger("AsynchronousMetrics"),
+                "Will use cgroup reader from '{}' (cgroups version: {})",
+                cgroup_path,
+                (version == ICgroupsReader::CgroupsVersion::V1) ? "v1" : "v2");
+            cgroupmem_reader = ICgroupsReader::createCgroupsReader(version, cgroup_path);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(getLogger("AsynchronousMetrics"), "cgroups are not available");
+        }
     }
-    catch (...)
+    else
     {
-        tryLogCurrentException(getLogger("AsynchronousMetrics"), "cgroups are not available");
+        LOG_DEBUG(getLogger("AsynchronousMetrics"), "Cgroups memory file not available; cgroup-based metrics will be unavailable");
     }
 
 

--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -30,11 +30,6 @@ namespace ProfileEvents
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int FILE_DOESNT_EXIST;
-}
-
 #if defined(OS_LINUX)
 namespace
 {
@@ -217,17 +212,15 @@ std::optional<std::string> getCgroupsV1Path()
 
 }
 
-std::pair<std::string, ICgroupsReader::CgroupsVersion> ICgroupsReader::getCgroupsPath()
+std::optional<std::pair<std::string, ICgroupsReader::CgroupsVersion>> ICgroupsReader::tryGetCgroupsPath()
 {
-    auto v2_path = getCgroupsV2PathContainingFile("memory.current");
-    if (v2_path.has_value())
-        return {*v2_path, ICgroupsReader::CgroupsVersion::V2};
+    if (auto v2_path = getCgroupsV2PathContainingFile("memory.current"))
+        return std::make_pair(*v2_path, ICgroupsReader::CgroupsVersion::V2);
 
-    auto v1_path = getCgroupsV1Path();
-    if (v1_path.has_value())
-        return {*v1_path, ICgroupsReader::CgroupsVersion::V1};
+    if (auto v1_path = getCgroupsV1Path())
+        return std::make_pair(*v1_path, ICgroupsReader::CgroupsVersion::V1);
 
-    throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot find cgroups v1 or v2 current memory file");
+    return std::nullopt;
 }
 
 std::shared_ptr<ICgroupsReader> ICgroupsReader::createCgroupsReader(ICgroupsReader::CgroupsVersion version, const std::filesystem::path & cgroup_path)
@@ -278,27 +271,39 @@ MemoryWorker::MemoryWorker(
     if (config.use_cgroup)
     {
 #if defined(OS_LINUX)
-        try
+        if (auto cgroups = ICgroupsReader::tryGetCgroupsPath())
         {
             static constexpr uint64_t cgroups_memory_usage_tick_ms{50};
 
-            const auto [cgroup_path, version] = ICgroupsReader::getCgroupsPath();
-            LOG_DEBUG(
-                getLogger("CgroupsReader"),
-                "Will create cgroup reader from '{}' (cgroups version: {})",
-                cgroup_path,
-                (version == ICgroupsReader::CgroupsVersion::V1) ? "v1" : "v2");
+            const auto & [cgroup_path, version] = *cgroups;
+            try
+            {
+                LOG_DEBUG(
+                    getLogger("CgroupsReader"),
+                    "Will create cgroup reader from '{}' (cgroups version: {})",
+                    cgroup_path,
+                    (version == ICgroupsReader::CgroupsVersion::V1) ? "v1" : "v2");
 
-            cgroups_reader = ICgroupsReader::createCgroupsReader(version, cgroup_path);
-            source = MemoryUsageSource::Cgroups;
-            if (rss_update_period_ms == 0)
-                rss_update_period_ms = cgroups_memory_usage_tick_ms;
+                cgroups_reader = ICgroupsReader::createCgroupsReader(version, cgroup_path);
+                source = MemoryUsageSource::Cgroups;
+                if (rss_update_period_ms == 0)
+                    rss_update_period_ms = cgroups_memory_usage_tick_ms;
 
-            return;
+                return;
+            }
+            catch (...)
+            {
+                /// Path was visible but the reader failed to initialize (e.g. file disappeared,
+                /// permission denied). This is unexpected, so keep the full diagnostic.
+                tryLogCurrentException(log, "Cannot use cgroups reader");
+            }
         }
-        catch (...)
+        else
         {
-            tryLogCurrentException(log, "Cannot use cgroups reader");
+            /// No cgroups v1/v2 hierarchy is visible. This is the normal case in sandboxed or
+            /// strictly-restricted containers (e.g. some k8s pods, distroless images, FaaS
+            /// runtimes); fall through to the next memory source quietly without a stack trace.
+            LOG_DEBUG(log, "Cgroups memory file not available, falling back to other memory source");
         }
 #endif
     }

--- a/src/Common/MemoryWorker.h
+++ b/src/Common/MemoryWorker.h
@@ -6,6 +6,7 @@
 #include <Common/PageCache.h>
 
 #include <filesystem>
+#include <optional>
 
 namespace DB
 {
@@ -22,8 +23,12 @@ struct ICgroupsReader
     static std::shared_ptr<ICgroupsReader>
     createCgroupsReader(ICgroupsReader::CgroupsVersion version, const std::filesystem::path & cgroup_path);
 
-    /// Return <path, version>
-    static std::pair<std::string, CgroupsVersion> getCgroupsPath();
+    /// Probe for cgroups v2 / v1 memory pseudo-files.
+    /// Returns <path, version> if a usable hierarchy is found, or std::nullopt if neither is
+    /// available (e.g. inside a sandboxed/restricted container without cgroupfs mounted).
+    /// This is intentionally non-throwing: cgroups absence is an expected fallback condition,
+    /// not an error worth a stack trace.
+    static std::optional<std::pair<std::string, CgroupsVersion>> tryGetCgroupsPath();
 #endif
 
     virtual ~ICgroupsReader() = default;


### PR DESCRIPTION
## Summary

Fixes #51.

In strictly restricted containers (k8s pods with hidden `/sys/fs/cgroup`, distroless images, FaaS sandboxes, …) neither cgroups v1 `memory/memory.stat` nor cgroups v2 `memory.current` is accessible. The previous code modeled this expected condition as a `FILE_DOESNT_EXIST` exception, which ended up dumping a full C++ stack trace via `tryLogCurrentException` on every embedded server construction — i.e. essentially every chDB query in short-lived sessions:

```
stderr:
Cannot use cgroups reader: Code: 107. DB::Exception: Cannot find cgroups v1 or v2 current memory file. (FILE_DOESNT_EXIST), Stack trace ...
 0. ? @ 0x000000001cf32cf3
 1. ? @ 0x000000000fbd529e
 ...
```

The query still completed (Jemalloc fallback) but the noise on stderr was alarming, broke log monitoring, and made users think their queries had failed.

## Approach

Reshape `ICgroupsReader::getCgroupsPath()` to express what it really is: a probe that may or may not find a usable cgroup hierarchy. The new `tryGetCgroupsPath()` returns `std::optional<std::pair<std::string, CgroupsVersion>>`, so callers can distinguish:

- **Cgroups absent** (the normal case in restricted containers) — take the empty branch and emit a single `LOG_DEBUG` line. No stack trace, no exception machinery.
- **Cgroups present but reader construction fails** (file vanished, permissions, parsing error, …) — still log the full diagnostic via `tryLogCurrentException`. Genuinely unexpected errors are preserved.

Both call sites in `MemoryWorker` and `AsynchronousMetrics` are updated. The now-unused `FILE_DOESNT_EXIST` ErrorCodes declaration in `MemoryWorker.cpp` is removed.

## Why this shape

Two alternatives were considered:

1. **Catch `FILE_DOESNT_EXIST` inside the existing `catch` and downgrade to `LOG_DEBUG`.** Smallest diff, but still uses exceptions for control flow on a hot path that runs on every embedded session start. Doesn't fix the underlying "this isn't actually an error" mismodeling.
2. **Make `tryGetCgroupsPath()` non-throwing (this PR).** Same diff size at call sites, semantically correct, no exception machinery for the expected case, and existing `createCgroupsReader` failures still surface with their full diagnostic.

The existing `gtest_cgroups_reader.cpp` only exercises `createCgroupsReader` (which is unchanged), so no test surgery is needed.

## Test plan

- [ ] Build on Linux and run `gtest_cgroups_reader` — should still pass unchanged.
- [ ] Run a chDB query in a normal Linux host — `LOG_DEBUG` from `MemoryWorker` shows it picked the cgroups path; behaviour unchanged.
- [ ] Run a chDB query in a container with `/sys/fs/cgroup` not mounted (or `--security-opt=apparmor=unconfined` style hardening that hides it) — `stderr` should be **clean** (no stack trace), and `MemoryWorker` should fall back to Jemalloc as before.
- [ ] Build on macOS — `OS_LINUX`-guarded code is excluded, no API breakage.