### PR TITLE
Fix: Parquet V3 nullable+filter LOGICAL_ERROR (cherry-pick ClickHouse#102628)

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -1337,11 +1337,20 @@ void Reader::decodePrimitiveColumn(ColumnChunk & column, const PrimitiveColumnIn
     /// use_filter_in_decoder path reads ALL pages sequentially, so it would crash trying to access
     /// those reset handles. Only use this optimization when reading the whole column chunk
     /// sequentially (no offset index, i.e. data_pages is empty).
+    ///
+    /// Also disabled for nullable columns (need_null_map): the filter-in-decoder path processes
+    /// ALL rows (passing + non-passing) through processDefLevelsForInnermostColumn, so the
+    /// null_map ends up with entries for all rows rather than just filtered rows. Additionally,
+    /// the decoder applies the filter at consecutive encoded-value indices, but with nulls the
+    /// encoded values don't correspond 1:1 to rows (null rows have no encoded values), causing
+    /// the filter to be applied at wrong positions. The standard row-range iteration path
+    /// correctly handles both issues by only reading rows in passing filter ranges.
     const bool use_filter_in_decoder = (column_info.levels.back().rep == 0) &&
         !row_subgroup.filter.filter.empty() &&
         column.page.initialized &&
         !column.page.is_dictionary_encoded &&
-        column.data_pages.empty();
+        column.data_pages.empty() &&
+        !column.need_null_map;
     const size_t subgroup_end_row_idx = row_subgroup.start_row_idx + row_subgroup.filter.rows_total;
 
     if (use_filter_in_decoder)
@@ -1420,7 +1429,9 @@ void Reader::decodePrimitiveColumn(ColumnChunk & column, const PrimitiveColumnIn
     if (subchunk.null_map && !column_info.output_nullable && !options.format.null_as_default)
     {
         const auto & null_map = assert_cast<const ColumnUInt8 &>(*subchunk.null_map).getData();
-        if (memchr(null_map.data(), 0, null_map.size()) != nullptr)
+        /// null_map uses standard ClickHouse convention: 1 = NULL, 0 = NOT NULL.
+        /// Check if any values are null — those can't be inserted into a non-Nullable column.
+        if (memchr(null_map.data(), 1, null_map.size()) != nullptr)
             throw Exception(ErrorCodes::CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN, "Cannot convert NULL value to non-Nullable type for column {}", column_info.name);
         subchunk.null_map = nullptr;
     }

--- a/tests/test_parquet_nullable_filter.py
+++ b/tests/test_parquet_nullable_filter.py
@@ -1,0 +1,216 @@
+#!python3
+"""
+Regression test for LOGICAL_ERROR crash in Parquet V3 reader with nullable columns
+and WHERE filter.
+
+Two bugs fixed in src/Processors/Formats/Impl/Parquet/Reader.cpp:
+
+1. Inverted null_map memchr check: searched for byte 0 (non-null) instead of byte 1
+   (null). When a filter left only NULL rows in a subchunk for a non-nullable output
+   column with null_as_default=0, the check incorrectly cleared null_map, leaving 0
+   rows while rows_pass=1 → LOGICAL_ERROR "Unexpected number of rows in column subchunk".
+
+2. use_filter_in_decoder enabled for nullable columns: the optimization processes ALL
+   rows through processDefLevelsForInnermostColumn (null_map gets entries for all rows,
+   not just filtered rows) then hands the filter to the decoder. With nullable columns
+   the decoder applies the filter at consecutive encoded-value indices, but null rows
+   have no encoded values, so the filter maps to wrong positions →
+   LOGICAL_ERROR "Too many bytes in mask".
+
+Cherry-pick of ClickHouse/ClickHouse#102628 (commit 8e7137b625ec56d40af3a06b24dd01bbc8df4005).
+
+Reported as chdb-core issue #53 (windowFunnel against file('*.parquet') fails with
+LOGICAL_ERROR "Too many bytes in mask").
+"""
+
+import os
+import tempfile
+import unittest
+
+import chdb
+from chdb import session as chdb_session
+
+
+def _make_nullable_parquet(path: str) -> None:
+    """
+    Create a Parquet file with id UInt64 and val Nullable(String).
+    Every row where id % 3 == 0 has val = NULL.
+    Uses output_format_parquet_use_custom_encoder=0 to exercise the V3 reader path.
+    """
+    chdb.query(
+        f"""
+        INSERT INTO FUNCTION file('{path}', Parquet)
+        SELECT number AS id, if(number % 3 = 0, NULL, toString(number)) AS val
+        FROM numbers(20)
+        SETTINGS output_format_parquet_use_custom_encoder = 0
+        """,
+        "CSV",
+    )
+
+
+class TestParquetNullableFilter(unittest.TestCase):
+    """
+    Regression tests for LOGICAL_ERROR crash in the Parquet V3 reader when
+    applying WHERE filters over nullable columns.
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._parquet = os.path.join(self._tmpdir, "nullable_test.parquet")
+        _make_nullable_parquet(self._parquet)
+
+    # ------------------------------------------------------------------
+    # 1. Nullable output — NULLs preserved, filter on NULL rows should work
+    # ------------------------------------------------------------------
+    def test_nullable_output_filter_on_null_rows(self):
+        """Reading Nullable output with WHERE filter on NULL rows should succeed."""
+        result = chdb.query(
+            f"""
+            SELECT id, val
+            FROM file('{self._parquet}', Parquet, 'id UInt64, val Nullable(String)')
+            WHERE id IN (0, 3, 6)
+            ORDER BY id
+            """,
+            "CSV",
+        )
+        self.assertFalse(result.has_error(), result.error_message())
+        lines = result.bytes().decode().strip().splitlines()
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            self.assertIn(r"\N", line)
+
+    # ------------------------------------------------------------------
+    # 2. Non-nullable + null_as_default=1 — NULLs become empty strings
+    # ------------------------------------------------------------------
+    def test_non_nullable_null_as_default_filter_on_null_rows(self):
+        """null_as_default=1: NULL rows become empty string; no error expected."""
+        result = chdb.query(
+            f"""
+            SELECT id, val
+            FROM file('{self._parquet}', Parquet, 'id UInt64, val String')
+            WHERE id IN (0, 3, 6)
+            ORDER BY id
+            SETTINGS input_format_null_as_default = 1
+            """,
+            "CSV",
+        )
+        self.assertFalse(result.has_error(), result.error_message())
+        lines = result.bytes().decode().strip().splitlines()
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            # val should be the empty string, not \N
+            self.assertTrue(line.endswith(","), f"expected empty val, got: {line}")
+
+    # ------------------------------------------------------------------
+    # 3. Non-nullable + null_as_default=0 + filter hits ONLY NULL rows →
+    #    must throw CANNOT_INSERT_NULL, NOT a LOGICAL_ERROR
+    # ------------------------------------------------------------------
+    def test_non_nullable_no_default_filter_only_null_rows_raises_correctly(self):
+        """Filter on a row whose value is NULL must raise CANNOT_INSERT_NULL, not crash."""
+        with self.assertRaises(Exception) as ctx:
+            chdb.query(
+                f"""
+                SELECT id, val
+                FROM file('{self._parquet}', Parquet, 'id UInt64, val String')
+                WHERE id = 0
+                SETTINGS input_format_null_as_default = 0
+                """,
+                "CSV",
+            )
+        err = str(ctx.exception)
+        # Before fix: LOGICAL_ERROR ("Too many bytes in mask" or
+        #   "Unexpected number of rows in column subchunk").
+        # After fix: CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN.
+        self.assertNotIn(
+            "LOGICAL_ERROR",
+            err,
+            f"Got LOGICAL_ERROR instead of CANNOT_INSERT_NULL: {err}",
+        )
+        # Should be a proper user-facing error, not a crash
+        self.assertTrue(
+            "CANNOT_INSERT_NULL" in err or "Cannot convert NULL" in err,
+            f"Expected CANNOT_INSERT_NULL error, got: {err}",
+        )
+
+    # ------------------------------------------------------------------
+    # 4. Non-nullable + null_as_default=0 + filter hits ONLY non-null rows →
+    #    should succeed
+    # ------------------------------------------------------------------
+    def test_non_nullable_no_default_filter_non_null_rows_succeeds(self):
+        """Filter on rows where val IS NOT NULL must succeed without error."""
+        result = chdb.query(
+            f"""
+            SELECT id, val
+            FROM file('{self._parquet}', Parquet, 'id UInt64, val String')
+            WHERE id IN (1, 2, 4)
+            ORDER BY id
+            SETTINGS input_format_null_as_default = 0
+            """,
+            "CSV",
+        )
+        self.assertFalse(result.has_error(), result.error_message())
+        self.assertIn("1", result.bytes().decode())
+        self.assertIn("2", result.bytes().decode())
+        self.assertIn("4", result.bytes().decode())
+
+    # ------------------------------------------------------------------
+    # 5. windowFunnel over Parquet with nullable timestamp — original report
+    #    (simplified, no network download required)
+    # ------------------------------------------------------------------
+    def test_window_funnel_over_parquet_nullable_column(self):
+        """
+        windowFunnel over a Parquet file with a nullable timestamp column
+        must not crash with LOGICAL_ERROR "Too many bytes in mask".
+
+        This is the exact usage pattern reported in chdb-core issue #53.
+        """
+        tmpdir = tempfile.mkdtemp()
+        parquet = os.path.join(tmpdir, "funnel_test.parquet")
+
+        # Build a small dataset: user_id, event_time (nullable), fare (<15 or >50)
+        chdb.query(
+            f"""
+            INSERT INTO FUNCTION file('{parquet}', Parquet)
+            SELECT
+                number % 5                                          AS user_id,
+                if(number % 7 = 0, NULL,
+                   toDateTime('2024-01-01') + toIntervalSecond(number * 60))
+                                                                    AS event_time,
+                if(number % 2 = 0, toFloat64(number % 20),
+                   toFloat64(number % 20 + 55))                    AS fare_amount
+            FROM numbers(100)
+            SETTINGS output_format_parquet_use_custom_encoder = 0
+            """,
+            "CSV",
+        )
+
+        # This triggered "Too many bytes in mask" before the fix because the
+        # use_filter_in_decoder optimization was incorrectly applied to nullable
+        # columns.
+        result = chdb.query(
+            f"""
+            SELECT funnel_level, count(*) AS cnt
+            FROM (
+                SELECT user_id,
+                       windowFunnel(3600)(
+                           event_time,
+                           fare_amount < 15,
+                           fare_amount > 50
+                       ) AS funnel_level
+                FROM file('{parquet}', Parquet)
+                WHERE fare_amount < 15 OR fare_amount > 50
+                GROUP BY user_id
+            )
+            WHERE funnel_level > 0
+            GROUP BY funnel_level
+            ORDER BY funnel_level
+            """,
+            "CSV",
+        )
+        self.assertFalse(result.has_error(), result.error_message())
+        # Just verify we get results — exact values depend on engine internals
+        self.assertGreater(len(result.bytes()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parquet_nullable_filter.py
+++ b/tests/test_parquet_nullable_filter.py
@@ -23,6 +23,8 @@ Reported as chdb-core issue #53 (windowFunnel against file('*.parquet') fails wi
 LOGICAL_ERROR "Too many bytes in mask").
 """
 
+import csv
+import io
 import os
 import tempfile
 import unittest
@@ -95,11 +97,23 @@ class TestParquetNullableFilter(unittest.TestCase):
             "CSV",
         )
         self.assertFalse(result.has_error(), result.error_message())
-        lines = result.bytes().decode().strip().splitlines()
-        self.assertEqual(len(lines), 3)
-        for line in lines:
-            # val should be the empty string, not \N
-            self.assertTrue(line.endswith(","), f"expected empty val, got: {line}")
+        # ClickHouse CSV quotes empty strings, so the val field renders as
+        # `""` (not bare `,`). Parse the result with csv.reader and inspect
+        # the second field directly instead of doing a fragile string-suffix
+        # check on the raw line.
+        rows = list(csv.reader(io.StringIO(result.bytes().decode())))
+        self.assertEqual(len(rows), 3)
+        expected_ids = ["0", "3", "6"]
+        for row, expected_id in zip(rows, expected_ids):
+            self.assertEqual(
+                len(row), 2, f"expected 2 fields, got: {row!r}"
+            )
+            self.assertEqual(row[0], expected_id, f"unexpected id in row: {row!r}")
+            self.assertEqual(
+                row[1],
+                "",
+                f"expected empty val (NULL→default), got: {row[1]!r} (row={row!r})",
+            )
 
     # ------------------------------------------------------------------
     # 3. Non-nullable + null_as_default=0 + filter hits ONLY NULL rows →


### PR DESCRIPTION
## Changelog category

Bug Fix

## Changelog entry

Fix `LOGICAL_ERROR` crash (`Too many bytes in mask` / `Unexpected number of rows in column subchunk`) when running any aggregate function (including `windowFunnel`) against a Parquet file via `file()` when the column is Nullable and a WHERE filter is active.

---

## Closes

Fixes #53

---

## Reproduction

```python
from chdb import session as chdb_session

sess = chdb_session.Session()

# Fails before fix with: LOGICAL_ERROR "Too many bytes in mask"
print(sess.query("""
    SELECT funnel_level, count(*) AS zones
    FROM (
        SELECT PULocationID AS zone,
               windowFunnel(3600)(
                   toDateTime(tpep_pickup_datetime),
                   fare_amount < 15,
                   fare_amount > 50,
                   Airport_fee > 0
               ) AS funnel_level
        FROM file('yellow_tripdata_2024-01.parquet', 'Parquet')
        WHERE fare_amount < 15 OR fare_amount > 50 OR Airport_fee > 0
        GROUP BY zone
    )
    WHERE funnel_level > 0
    GROUP BY funnel_level
    ORDER BY funnel_level
""", "CSV"))
```

Minimal reproducer (no external data needed):

```python
import chdb, tempfile, os
tmpdir = tempfile.mkdtemp()
p = os.path.join(tmpdir, "t.parquet")
chdb.query(f"""
    INSERT INTO FUNCTION file('{p}', Parquet)
    SELECT number AS id, if(number%3=0, NULL, toString(number)) AS val
    FROM numbers(20) SETTINGS output_format_parquet_use_custom_encoder=0
""")

# Bug 1 — inverted memchr: filter hitting only-NULL rows with non-nullable output
# Before fix: LOGICAL_ERROR "Unexpected number of rows in column subchunk 0 1"
# After fix:  CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN (correct user error)
chdb.query(f"""
    SELECT id, val FROM file('{p}', Parquet, 'id UInt64, val String')
    WHERE id = 0 SETTINGS input_format_null_as_default = 0
""")

# Bug 2 — filter-in-decoder enabled for nullable: LOGICAL_ERROR "Too many bytes in mask"
# After fix: succeeds
chdb.query(f"""
    SELECT id, val FROM file('{p}', Parquet, 'id UInt64, val Nullable(String)')
    WHERE id IN (0, 3, 6) ORDER BY id
""")
```

---

## Root cause

Two bugs in `src/Processors/Formats/Impl/Parquet/Reader.cpp` (V3 native Parquet reader, introduced with the 26.x upgrade):

### Bug 1 — Inverted `null_map` check (primary)

At the point where we decide whether a non-nullable output column has any real NULLs, `memchr` was searching for byte **`0`** (the NOT-NULL marker) instead of byte **`1`** (the NULL marker). ClickHouse's `null_map` convention: `1 = NULL, 0 = NOT NULL`.

- When a WHERE filter left **only NULL rows** in a subchunk: all null_map bytes are `1`. `memchr(..., 0, ...)` finds **no** `0`, so the condition is false, the check incorrectly clears `null_map`, leaving `subchunk.column` with 0 rows while `rows_pass == 1` → **LOGICAL_ERROR** "Unexpected number of rows in column subchunk 0 1".
- Inverse bug: reading non-null data from a Nullable Parquet column into a non-Nullable ClickHouse column with `null_as_default=0` would find a `0` byte and incorrectly throw CANNOT_INSERT_NULL even when no NULLs are present.

Fix: `memchr(null_map.data(), 0, ...)` → `memchr(null_map.data(), 1, ...)`

### Bug 2 — `use_filter_in_decoder` enabled for nullable columns

The `use_filter_in_decoder` optimization reads all rows through `processDefLevelsForInnermostColumn` (populating `null_map` with entries for **all** rows, not just filtered rows) and then passes the filter to the decoder. With nullable columns the decoder applies the filter at consecutive encoded-value indices, but null rows have no encoded values, so the filter-to-row mapping is wrong → **LOGICAL_ERROR** "Too many bytes in mask".

Fix: add `&& !column.need_null_map` to the `use_filter_in_decoder` condition, falling back to the correct row-range iteration path.

---

## Fix

Cherry-pick of [ClickHouse/ClickHouse#102628](https://github.com/ClickHouse/ClickHouse/pull/102628) (commit [`8e7137b625ec`](https://github.com/ClickHouse/ClickHouse/commit/8e7137b625ec56d40af3a06b24dd01bbc8df4005), merged 2026-04-20 into ClickHouse master).

Changes:
1. `Reader.cpp` line ~1423: `memchr(..., 0, ...)` → `memchr(..., 1, ...)`
2. `Reader.cpp` `use_filter_in_decoder` condition: add `&& !column.need_null_map`

---

## Regression test

`tests/test_parquet_nullable_filter.py` — five test cases covering:
1. Nullable output + filter on NULL rows → succeeds
2. Non-nullable + `null_as_default=1` + filter on NULL rows → succeeds (NULLs → empty string)
3. Non-nullable + `null_as_default=0` + filter on **only** NULL rows → raises `CANNOT_INSERT_NULL` (not LOGICAL_ERROR)
4. Non-nullable + `null_as_default=0` + filter on non-null rows → succeeds
5. `windowFunnel` over Parquet with nullable timestamp column → no crash (the original user report)

> **Local build note:** The installed chdb on this host is 4.0.1 (ClickHouse 25.8), which predates the V3 Parquet reader added in 26.x. Full local reproduction requires building the chdb-core 26.3 wheel (`bash ./chdb/build.sh`; ~45 min). The fix is a verified cherry-pick of upstream commit `8e7137b625ec` which is fully tested in ClickHouse CI.

---

## Documentation entry

No documentation change needed — this is a bug fix with no API surface change.