### PR TITLE
chore: suppress noisy MemoryWorker dirty-decay INFO log

### DIFF
--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -570,7 +570,9 @@ void MemoryWorker::purgeDirtyPagesThread()
     std::unique_lock purge_dirty_pages_lock(purge_dirty_pages_mutex);
 
     uint64_t default_dirty_decay_ms = dirty_decay_ms_mib.getValue();
-    LOG_INFO(log, "Default dirty pages decay period: {}ms", default_dirty_decay_ms);
+    /// chDB: suppress this startup INFO log to keep embedded usage quiet.
+    /// See https://github.com/chdb-io/chdb-core/issues/55
+    /// LOG_INFO(log, "Default dirty pages decay period: {}ms", default_dirty_decay_ms);
     while (true)
     {
         try


### PR DESCRIPTION
## Summary

Comment out the startup `LOG_INFO` in `MemoryWorker::purgeDirtyPagesThread` (`src/Common/MemoryWorker.cpp:573`). It was printed on every chDB run and surfaced internal background-thread detail to embedded users, hurting UX.

The `default_dirty_decay_ms` variable is still used later in the same function, so only the log line is removed.

Closes #55