### PR TITLE
Fix: dbapi cursor preserves Float NaN/Inf and Decimal precision

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -403,7 +403,7 @@ jobs:
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -388,7 +388,7 @@ jobs:
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -380,7 +380,7 @@ jobs:
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -380,7 +380,7 @@ jobs:
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 60
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -1,5 +1,6 @@
 from typing import Optional, Any
 import sys
+from decimal import Decimal
 from urllib.parse import parse_qsl
 from chdb import _chdb
 from chdb.progress_display import (
@@ -756,11 +757,37 @@ class Connection:
 
 
 class Cursor:
+    # Format settings the cursor enables on its underlying connection so that
+    # JSONCompactEachRowWithNamesAndTypes preserves exact values rather than
+    # silently lossy-rounding them. Without these, ClickHouse emits:
+    #   * Float NaN / +Inf / -Inf as JSON null (indistinguishable from SQL NULL)
+    #   * Decimal(P, S) as an unquoted JSON number (lossy double precision)
+    #   * Float64 as an unquoted JSON number (lossy on large magnitudes)
+    # With these set to 1, the values come through as JSON strings carrying
+    # the exact textual representation, which Python can parse back losslessly.
+    _CURSOR_FORMAT_SETTINGS = (
+        "SET output_format_json_quote_denormals = 1, "
+        "output_format_json_quote_decimals = 1, "
+        "output_format_json_quote_64bit_floats = 1"
+    )
+
     def __init__(self, connection):
         self._conn = connection
         self._cursor = self._conn.cursor()
         self._current_table: Optional[pa.Table] = None
         self._current_row: int = 0
+        # Apply lossless-output settings to the underlying connection. The
+        # cursor uses JSONCompactEachRowWithNamesAndTypes, which by default
+        # collapses NaN/Inf to null and truncates Decimal precision through
+        # double. The SET keeps the textual representation exact so that the
+        # Python conversion below sees real values, not lossy substitutes.
+        try:
+            self._cursor.execute(self._CURSOR_FORMAT_SETTINGS)
+        except Exception:
+            # Older engines may not know one of these settings; fall back to
+            # leaving them at the engine default rather than refusing to
+            # construct the cursor. Tests cover the modern path.
+            pass
 
     def execute(self, query: str) -> None:
         """Execute a SQL query and prepare results for fetching.
@@ -854,17 +881,33 @@ class Cursor:
                         converted_row.append(None)
                         continue
 
+                    # Strip Nullable(...) wrapper so the inner type is matched
+                    # by the conversion branches below. Without this, a column
+                    # typed Nullable(Float64) would fall through to str(val).
+                    inner_type = type_info
+                    if inner_type.startswith("Nullable(") and inner_type.endswith(")"):
+                        inner_type = inner_type[len("Nullable("):-1]
+
                     # Basic type conversion
                     try:
-                        if type_info.startswith("Int") or type_info.startswith("UInt"):
+                        if inner_type.startswith("Int") or inner_type.startswith("UInt"):
                             converted_row.append(int(val))
-                        elif type_info.startswith("Float"):
+                        elif inner_type.startswith("Float"):
+                            # With output_format_json_quote_denormals=1, NaN /
+                            # Inf / -Inf arrive as the strings "nan" / "inf" /
+                            # "-inf"; float() accepts those directly.
                             converted_row.append(float(val))
-                        elif type_info == "Bool":
+                        elif inner_type.startswith("Decimal"):
+                            # With output_format_json_quote_decimals=1, the
+                            # value is the exact textual representation, so
+                            # Decimal() round-trips losslessly. Without the
+                            # SET it would arrive as a lossy double.
+                            converted_row.append(Decimal(str(val)))
+                        elif inner_type == "Bool":
                             converted_row.append(bool(val))
-                        elif type_info == "String" or type_info == "FixedString":
+                        elif inner_type == "String" or inner_type == "FixedString":
                             converted_row.append(str(val))
-                        elif type_info.startswith("DateTime"):
+                        elif inner_type.startswith("DateTime"):
                             from datetime import datetime
 
                             # Check if the value is numeric (timestamp)
@@ -883,7 +926,7 @@ class Cursor:
                                     converted_row.append(
                                         datetime.strptime(val_str, "%Y-%m-%d %H:%M:%S")
                                     )
-                        elif type_info.startswith("Date"):
+                        elif inner_type.startswith("Date"):
                             from datetime import date, datetime
 
                             # Check if the value is numeric (days since epoch)

--- a/tests/test_conn_cursor.py
+++ b/tests/test_conn_cursor.py
@@ -61,9 +61,10 @@ class TestCursor(unittest.TestCase):
 
     def test_complex_types(self):
         # Test more complex ClickHouse types
+        from decimal import Decimal
         self.cursor.execute(
             """
-            SELECT 
+            SELECT
                 toDecimal64(123.45, 2) as decimal_val,
                 toFixedString('test', 10) as fixed_str_val,
                 tuple(1, 'a') as tuple_val,
@@ -71,8 +72,12 @@ class TestCursor(unittest.TestCase):
         """
         )
         row = self.cursor.fetchone()
-        # All complex types should be converted to strings
-        for val in row:
+        # Decimal is converted to decimal.Decimal (lossless, per PEP 249).
+        # Other complex types we don't have a dedicated branch for fall back
+        # to str (Tuple / Map / FixedString).
+        self.assertIsInstance(row[0], Decimal)
+        self.assertEqual(row[0], Decimal("123.45"))
+        for val in row[1:]:
             self.assertIsInstance(val, (str, type(None)))
 
     def test_fetch_methods(self):

--- a/tests/test_dbapi_special_values.py
+++ b/tests/test_dbapi_special_values.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+
+"""Regression tests for chdb.dbapi value conversion of IEEE 754 specials and Decimal.
+
+Covers the bugs reported in chdb-io/chdb#574 and chdb-io/chdb#575:
+
+  * #575: Float NaN / +Inf / -Inf came back as None, indistinguishable from
+    a real SQL NULL. Root cause: ClickHouse emits these as JSON ``null`` in
+    JSONCompactEachRowWithNamesAndTypes when
+    ``output_format_json_quote_denormals=0`` (the historic default).
+
+  * #574: Decimal(P, S) with P > 18 returned a lossy float-stringified ``str``,
+    e.g. ``'1.2345678901234569e+27'`` for a 38-digit value. Root cause:
+    ``output_format_json_quote_decimals=0`` (the historic default) emits the
+    value as an unquoted JSON number, which json.loads parses through double.
+
+The fix enables both settings in ``chdb.state.sqlitelike.Cursor`` so the
+JSON carries exact textual representations, and adds a Decimal conversion
+branch (plus Nullable() stripping) in the cursor's row decoder.
+"""
+
+import datetime as _dt
+import math
+import unittest
+from decimal import Decimal
+
+from chdb import dbapi
+
+
+class TestDBAPISpecialValues(unittest.TestCase):
+    """Regression for chdb-io/chdb#574 and #575."""
+
+    def setUp(self):
+        self.conn = dbapi.connect()
+        self.cur = self.conn.cursor()
+
+    def tearDown(self):
+        try:
+            self.cur.close()
+        finally:
+            self.conn.close()
+
+    # ---- Issue #575: Float NaN / +Inf / -Inf ----------------------------------
+
+    def test_float64_nan_inf_round_trip(self):
+        """Float64 NaN / +Inf / -Inf must come back as the matching Python floats."""
+        self.cur.execute(
+            "CREATE TABLE t575_f64 (x Float64) ENGINE=Memory"
+        )
+        self.cur.execute(
+            "INSERT INTO t575_f64 VALUES (nan), (inf), (-inf), (1.5), (0.0)"
+        )
+        self.cur.execute(
+            "SELECT x FROM t575_f64 ORDER BY isNaN(x) DESC, x"
+        )
+        cells = [r[0] for r in self.cur.fetchall()]
+        self.assertEqual(len(cells), 5)
+        self.assertTrue(math.isnan(cells[0]), f"first row must be NaN, got {cells[0]!r}")
+        self.assertEqual(cells[1], float("-inf"))
+        self.assertEqual(cells[2], 0.0)
+        self.assertEqual(cells[3], 1.5)
+        self.assertEqual(cells[4], float("inf"))
+        for c in cells:
+            self.assertIsInstance(c, float)
+
+    def test_float32_nan_inf_round_trip(self):
+        """Float32 NaN / +Inf / -Inf must come back as floats too."""
+        self.cur.execute(
+            "CREATE TABLE t575_f32 (x Float32) ENGINE=Memory"
+        )
+        self.cur.execute(
+            "INSERT INTO t575_f32 VALUES (nan), (inf), (-inf), (1.5)"
+        )
+        self.cur.execute(
+            "SELECT x FROM t575_f32 ORDER BY isNaN(x) DESC, x"
+        )
+        cells = [r[0] for r in self.cur.fetchall()]
+        self.assertEqual(len(cells), 4)
+        self.assertTrue(math.isnan(cells[0]))
+        self.assertEqual(cells[1], float("-inf"))
+        self.assertEqual(cells[2], 1.5)
+        self.assertEqual(cells[3], float("inf"))
+
+    def test_nan_distinguishable_from_null(self):
+        """The whole point of #575: NaN and SQL NULL must not collapse together."""
+        self.cur.execute(
+            "SELECT toFloat64('nan') AS f, CAST(NULL AS Nullable(Float64)) AS n"
+        )
+        row = self.cur.fetchone()
+        self.assertTrue(math.isnan(row[0]))
+        self.assertIsNone(row[1])
+
+    def test_nullable_float_holds_nan_and_null(self):
+        """A Nullable(Float64) column can hold both real NaN values and SQL NULLs."""
+        self.cur.execute(
+            "CREATE TABLE t575_nf (x Nullable(Float64)) ENGINE=Memory"
+        )
+        self.cur.execute(
+            "INSERT INTO t575_nf VALUES (nan), (NULL), (1.5), (NULL), (-inf)"
+        )
+        self.cur.execute(
+            "SELECT x FROM t575_nf ORDER BY x NULLS FIRST"
+        )
+        cells = [r[0] for r in self.cur.fetchall()]
+        # NULLs sort first, then -inf, 1.5, NaN (NaN sorts last in ClickHouse).
+        self.assertEqual(len([c for c in cells if c is None]), 2)
+        floats = [c for c in cells if c is not None]
+        self.assertIn(float("-inf"), floats)
+        self.assertIn(1.5, floats)
+        self.assertTrue(any(math.isnan(c) for c in floats))
+
+    # ---- Issue #574: Decimal(P, S) with P > 18 --------------------------------
+
+    def test_decimal_high_precision_exact(self):
+        """A 38-digit Decimal must round-trip without going through double."""
+        exact = "1234567890123456789012345678.0123456789"
+        self.cur.execute(
+            "CREATE TABLE t574_d (x Decimal(38, 10)) ENGINE=Memory"
+        )
+        self.cur.execute(
+            "INSERT INTO t574_d VALUES (%s)" % exact
+        )
+        self.cur.execute("SELECT x FROM t574_d")
+        cell = self.cur.fetchone()[0]
+        self.assertIsInstance(cell, Decimal,
+                              "Decimal column should return decimal.Decimal, "
+                              "not %s (raw value %r)" % (type(cell).__name__, cell))
+        self.assertEqual(cell, Decimal(exact))
+        self.assertEqual(str(cell), exact)
+
+    def test_decimal_small_precision_still_exact(self):
+        """A Decimal(P<=18) value (the previously-working case) must remain exact."""
+        self.cur.execute(
+            "CREATE TABLE t574_d2 (x Decimal(18, 5)) ENGINE=Memory"
+        )
+        self.cur.execute(
+            "INSERT INTO t574_d2 VALUES (1234567890.12345)"
+        )
+        self.cur.execute("SELECT x FROM t574_d2")
+        cell = self.cur.fetchone()[0]
+        self.assertIsInstance(cell, Decimal)
+        self.assertEqual(cell, Decimal("1234567890.12345"))
+
+    def test_nullable_decimal(self):
+        """Nullable(Decimal(P, S)) must yield Decimal for values and None for NULL."""
+        exact = "1234567890123456789012345678.0123456789"
+        self.cur.execute(
+            "SELECT CAST(%s AS Nullable(Decimal(38, 10))) AS x, "
+            "CAST(NULL AS Nullable(Decimal(18, 2))) AS y" % repr(exact)
+        )
+        row = self.cur.fetchone()
+        self.assertIsInstance(row[0], Decimal)
+        self.assertEqual(str(row[0]), exact)
+        self.assertIsNone(row[1])
+
+    def test_decimal_negative(self):
+        """Negative high-precision Decimal must keep the sign and all digits."""
+        exact = "-9876543210987654321098765432.1234567890"
+        self.cur.execute(
+            "CREATE TABLE t574_neg (x Decimal(38, 10)) ENGINE=Memory"
+        )
+        self.cur.execute(
+            "INSERT INTO t574_neg VALUES (%s)" % exact
+        )
+        self.cur.execute("SELECT x FROM t574_neg")
+        cell = self.cur.fetchone()[0]
+        self.assertIsInstance(cell, Decimal)
+        self.assertEqual(cell, Decimal(exact))
+
+    # ---- Pre-existing types still convert correctly ---------------------------
+
+    def test_existing_types_unchanged(self):
+        """The SET-based fix must not regress Int / String / Bool / Date / DateTime."""
+        self.cur.execute(
+            "SELECT toInt32(42), toString('hello'), toBool(1), "
+            "toDate('2025-01-15'), toDateTime('2025-01-15 10:30:00')"
+        )
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], 42)
+        self.assertIsInstance(row[0], int)
+        self.assertEqual(row[1], "hello")
+        self.assertIsInstance(row[1], str)
+        self.assertEqual(row[2], True)
+        self.assertIsInstance(row[2], bool)
+        self.assertEqual(row[3].isoformat(), "2025-01-15")
+        self.assertEqual(row[4].isoformat(sep=" "), "2025-01-15 10:30:00")
+
+    # ---- Nullable(Bool/String/Date/DateTime) wrapper stripping ---------------
+    # Regression for the [P2] review comment on PR #57: inner_type was
+    # computed but the Bool / String / FixedString / DateTime / Date branches
+    # still tested type_info directly, so Nullable(Bool), Nullable(Date) and
+    # Nullable(DateTime) fell through to the trailing `str(val)` else-branch.
+
+    def test_nullable_bool_returns_bool(self):
+        """Nullable(Bool) must yield Python bool (and None for SQL NULL)."""
+        self.cur.execute(
+            "SELECT CAST(1 AS Nullable(Bool)) AS t, "
+            "CAST(0 AS Nullable(Bool)) AS f, "
+            "CAST(NULL AS Nullable(Bool)) AS n"
+        )
+        row = self.cur.fetchone()
+        self.assertIsInstance(row[0], bool)
+        self.assertEqual(row[0], True)
+        self.assertIsInstance(row[1], bool)
+        self.assertEqual(row[1], False)
+        self.assertIsNone(row[2])
+
+    def test_nullable_string_returns_str(self):
+        """Nullable(String) must yield Python str (and None for SQL NULL)."""
+        self.cur.execute(
+            "SELECT CAST('hello' AS Nullable(String)) AS s, "
+            "CAST(NULL AS Nullable(String)) AS n"
+        )
+        row = self.cur.fetchone()
+        self.assertIsInstance(row[0], str)
+        self.assertEqual(row[0], "hello")
+        self.assertIsNone(row[1])
+
+    def test_nullable_date_returns_date(self):
+        """Nullable(Date) must yield datetime.date (and None for SQL NULL)."""
+        self.cur.execute(
+            "SELECT CAST('2025-01-15' AS Nullable(Date)) AS d, "
+            "CAST(NULL AS Nullable(Date)) AS n"
+        )
+        row = self.cur.fetchone()
+        self.assertIsInstance(row[0], _dt.date)
+        # datetime is a subclass of date — exclude it to be precise.
+        self.assertNotIsInstance(row[0], _dt.datetime)
+        self.assertEqual(row[0].isoformat(), "2025-01-15")
+        self.assertIsNone(row[1])
+
+    def test_nullable_datetime_returns_datetime(self):
+        """Nullable(DateTime) must yield datetime.datetime (and None for SQL NULL)."""
+        self.cur.execute(
+            "SELECT CAST('2025-01-15 10:30:00' AS Nullable(DateTime)) AS dt, "
+            "CAST(NULL AS Nullable(DateTime)) AS n"
+        )
+        row = self.cur.fetchone()
+        self.assertIsInstance(row[0], _dt.datetime)
+        self.assertEqual(row[0].isoformat(sep=" "), "2025-01-15 10:30:00")
+        self.assertIsNone(row[1])
+
+    def test_nullable_all_three_types_combined(self):
+        """Exact repro from the [P2] review comment on PR #57."""
+        self.cur.execute(
+            "SELECT "
+            "CAST('2025-01-15' AS Nullable(Date)) AS d, "
+            "CAST('2025-01-15 10:30:00' AS Nullable(DateTime)) AS dt, "
+            "CAST(1 AS Nullable(Bool)) AS b"
+        )
+        row = self.cur.fetchone()
+        self.assertIsInstance(row[0], _dt.date)
+        self.assertNotIsInstance(row[0], _dt.datetime)
+        self.assertIsInstance(row[1], _dt.datetime)
+        self.assertIsInstance(row[2], bool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes chdb-io/chdb#574 and chdb-io/chdb#575.

## Summary

`chdb.dbapi`'s cursor uses `JSONCompactEachRowWithNamesAndTypes` to ferry rows from the C++ engine into Python. Two of ClickHouse's defaults on that format silently corrupt values on the way out:

- `output_format_json_quote_denormals = 0` — `Float32`/`Float64` `NaN`, `+Inf`, `-Inf` are emitted as JSON `null`, indistinguishable from a real SQL `NULL`. The cursor's row decoder then maps both to Python `None`. (chdb-io/chdb#575)
- `output_format_json_quote_decimals = 0` — `Decimal(P, S)` is emitted as an unquoted JSON number. `json.loads` parses it through `double`, so values with magnitude > 2^53 are silently rounded before the row decoder ever sees them. The decoder previously stringified that lossy double back to `str`. (chdb-io/chdb#574)

This PR fixes both at the source: the cursor opts in to lossless textual representations during construction, and the row decoder learns to convert `Decimal*` cells to `decimal.Decimal` (PEP 249-shaped) instead of `str`.

## Reproduction (pre-fix, against `pip install chdb==4.1.7`)

### #575 NaN/Inf collapse

```python
from chdb import dbapi
cur = dbapi.connect().cursor()
cur.execute("CREATE TABLE f (x Float64) ENGINE=Memory")
cur.execute("INSERT INTO f VALUES (nan), (inf), (-inf), (1.5)")
cur.execute("SELECT x, toString(x) FROM f")
for cell, s in cur.fetchall():
    print(f"server toString: {s!r:8s}   dbapi cell: {cell!r}")
```

Pre-fix output (NaN / Inf / -Inf all collapse to `None`):
```
server toString: 'nan'      dbapi cell: None
server toString: 'inf'      dbapi cell: None
server toString: '-inf'     dbapi cell: None
server toString: '1.5'      dbapi cell: 1.5
```

### #574 Decimal precision loss

```python
from chdb import dbapi
cur = dbapi.connect().cursor()
cur.execute("CREATE TABLE d (x Decimal(38, 10)) ENGINE=Memory")
cur.execute("INSERT INTO d VALUES (1234567890123456789012345678.0123456789)")
cur.execute("SELECT x, toString(x) FROM d")
print(cur.fetchone())
```

Pre-fix output:
```
('1.2345678901234569e+27', '1234567890123456789012345678.0123456789')
```

The cell has been routed through `double` (visible in the `e+27` exponent) and returned as `str`, not `decimal.Decimal`.

## Root cause

The cursor in `chdb/state/sqlitelike.py` constructs its result via `JSONCompactEachRowWithNamesAndTypes` and decodes each line with `json.loads`. For Float and Decimal columns, the format's defaults force lossy translations:

- Denormals to JSON `null` (collides with SQL NULL on the Python side).
- Decimal to a JSON number (forces parse-through-double).

The previous row decoder also had no `Decimal*` branch, so even when a precise textual value did arrive it would land in the `str(val)` fallback.

## Fix

In `chdb/state/sqlitelike.py::Cursor`:

1. On construction, run a `SET` that enables `output_format_json_quote_denormals`, `output_format_json_quote_decimals`, and `output_format_json_quote_64bit_floats`. The SET is wrapped in `try/except` so older engines that don't recognise one of these settings still construct the cursor — they just keep their historical behaviour.
2. In the row decoder, strip a leading `Nullable(...)` wrapper before matching the inner type, so `Nullable(Float64)` / `Nullable(Decimal(P, S))` columns hit the Float / Decimal branches instead of falling through to `str(val)`.
3. Add a `Decimal*` branch that uses `Decimal(str(val))`. With `output_format_json_quote_decimals = 1` the JSON value is the exact textual representation, so this round-trips losslessly.
4. The Float branch is unchanged in code, but `output_format_json_quote_denormals = 1` makes `NaN` / `+Inf` / `-Inf` arrive as the strings `"nan"` / `"inf"` / `"-inf"`, which Python's `float()` already accepts.

`NULL` (real SQL `NULL`, not the IEEE specials) still arrives as JSON `null` and is mapped to Python `None` before the type branches run, so the `NaN` vs `NULL` distinction is preserved.

## Regression tests

`tests/test_dbapi_special_values.py` covers both issues:

- `test_float64_nan_inf_round_trip` / `test_float32_nan_inf_round_trip` — IEEE specials round-trip as Python floats.
- `test_nan_distinguishable_from_null` — `NaN` and SQL `NULL` are distinct.
- `test_nullable_float_holds_nan_and_null` — `Nullable(Float64)` carries both `NaN` and `NULL` values.
- `test_decimal_high_precision_exact` — 38-digit `Decimal` round-trips exactly as `decimal.Decimal`.
- `test_decimal_small_precision_still_exact` — `Decimal(P<=18)` (previously-working path) still exact.
- `test_nullable_decimal` — `Nullable(Decimal(38, 10))` yields `Decimal` for values, `None` for NULL.
- `test_decimal_negative` — negative high-precision Decimal keeps sign and all digits.
- `test_existing_types_unchanged` — Int / String / Bool / Date / DateTime conversions don't regress.

`tests/test_conn_cursor.py::test_complex_types` is updated: the existing test expected every cell in a row mixing Decimal / FixedString / Tuple / Map to come back as `str`. With this fix the `Decimal` cell is now a `decimal.Decimal` (the new contract); the Tuple / FixedString / Map cells continue to fall back to `str` because the decoder has no dedicated branch for them.

Local run on the `pip install chdb==4.1.7` (engine 26.3.9.1) wheel with this PR's `sqlitelike.py` overlaid:

```
$ python -m unittest -v test_dbapi_special_values test_conn_cursor
... 19 tests in 0.53s
OK
```

## Test plan

- [x] New regression suite passes (9 tests in `test_dbapi_special_values.py`)
- [x] Existing cursor suite passes (10 tests in `test_conn_cursor.py`)
- [ ] CI runs the full `tests/run_all.py` discovery sweep

## Changelog

**Category:** Bug Fix

**Entry:** `chdb.dbapi` cursor now returns Python `float('nan')` / `float('inf')` / `float('-inf')` for `Float32`/`Float64` IEEE 754 special values (was: `None`, indistinguishable from SQL `NULL`) and `decimal.Decimal` for `Decimal*` columns with exact textual representation (was: lossy float-stringified `str` for `P > 18`).