### PR TITLE
ci: install hypothesis for DataStore tests

### DIFF
--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -59,8 +59,8 @@ git clone --depth 1 --branch "${CHDB_TAG}" https://github.com/chdb-io/chdb.git "
 echo "Installing chdb wrapper on top of chdb-core (no deps to preserve local chdb-core)..."
 ${PYTHON} -m pip install --no-deps --force-reinstall "${CHDB_SRC}"
 
-echo "Installing test dependencies (pytest, pytest-timeout)..."
-${PYTHON} -m pip install --upgrade pytest pytest-timeout
+echo "Installing test dependencies (pytest, pytest-timeout, hypothesis)..."
+${PYTHON} -m pip install --upgrade pytest pytest-timeout hypothesis
 
 cd "${CHDB_SRC}"
 


### PR DESCRIPTION
## Changelog category

CI Fix or Improvement

## Changelog entry

Install `hypothesis` in the chdb DataStore CI test step so the test suite from chdb v4.1.8+ (which added `test_property_based_chains.py`) can be collected and run.

## Documentation entry

n/a (CI script change only).

---

Fixes #60.

## Reproduction

Two `push`-to-`main` Build & Test runs on `2026-05-22` failed with the same pytest collection error:

- [Build & Test Universal Wheel (Linux x86_64) — run 26272597805](https://github.com/chdb-io/chdb-core/actions/runs/26272597805/job/77329312245)
- [Test on macOS arm64 — run 26272597825](https://github.com/chdb-io/chdb-core/actions/runs/26272597825/job/77339092834)

```
________ ERROR collecting datastore/tests/test_property_based_chains.py ________
ImportError while importing test module
    '.../datastore/tests/test_property_based_chains.py'.
tests/test_property_based_chains.py:29: in <module>
    from hypothesis import HealthCheck, given, settings, strategies as st
E   ModuleNotFoundError: No module named 'hypothesis'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
DataStore tests FAILED (exit code 2) on chdb tag v4.1.8
```

## Root cause

`chdb-io/chdb` release [v4.1.8](https://github.com/chdb-io/chdb/tree/v4.1.8) added [`datastore/tests/test_property_based_chains.py`](https://github.com/chdb-io/chdb/blob/v4.1.8/datastore/tests/test_property_based_chains.py#L29), which imports `hypothesis` at module top level. The chdb-core integration script `chdb/test_chdb_datastore.sh` was installing only `pytest` and `pytest-timeout` (line 63), so pytest's collection phase fails on the missing `hypothesis` module and aborts before running any of the 11106 collected tests.

(For reference, chdb-io/chdb's own four Build & Test workflows were updated in chdb PR #578 to install `hypothesis`. The chdb-core wrapper script needed the same.)

## Fix

Add `hypothesis` to the `pip install --upgrade` line in `chdb/test_chdb_datastore.sh`, plus update the surrounding echo line for clarity.

```diff
-echo "Installing test dependencies (pytest, pytest-timeout)..."
-${PYTHON} -m pip install --upgrade pytest pytest-timeout
+echo "Installing test dependencies (pytest, pytest-timeout, hypothesis)..."
+${PYTHON} -m pip install --upgrade pytest pytest-timeout hypothesis
```

A single change in this script covers all four Build & Test workflows (`build_linux_x86_wheels.yml`, `build_linux_arm64_wheels-gh.yml`, `build_macos_x86_wheels.yml`, `build_macos_arm64_wheels.yml`), which all invoke this script for the DataStore test step.

## Regression test

The change is a one-line CI dependency addition; there is no in-repo unit test that exercises it (the CI run on this PR is itself the regression test — it must successfully collect `test_property_based_chains.py`).

Local end-to-end verification of the dependency change (using the same `pip install` line the CI step uses):

```sh
# Without the fix — reproduces the CI failure
$ python -m venv v1 && v1/bin/pip install --upgrade pytest pytest-timeout
$ v1/bin/python -c "from hypothesis import HealthCheck, given, settings, strategies as st"
ModuleNotFoundError: No module named 'hypothesis'

# With the fix
$ python -m venv v2 && v2/bin/pip install --upgrade pytest pytest-timeout hypothesis
$ v2/bin/python -c "from hypothesis import HealthCheck, given, settings, strategies as st; print(__import__('hypothesis').__version__)"
6.152.9
```

A full local DataStore test run could not be executed on this host because the locally installed chdb-core wheel (a separate concern) is not currently importable in any of the host's Python interpreters; the CI in this PR will exercise the full path.
