### PR TITLE
Add C API parameter binding (chdb_query_with_params, _n, streaming) — closes #73

### DIFF
--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -21,9 +21,13 @@
         chdb_close_conn;
         chdb_query;
         chdb_query_n;
+        chdb_query_with_params;
+        chdb_query_with_params_n;
         chdb_query_cmdline;
         chdb_stream_query;
         chdb_stream_query_n;
+        chdb_stream_query_with_params;
+        chdb_stream_query_with_params_n;
         chdb_stream_fetch_result;
         chdb_stream_cancel_query;
         chdb_destroy_query_result;

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -17,9 +17,13 @@ _chdb_connect
 _chdb_close_conn
 _chdb_query
 _chdb_query_n
+_chdb_query_with_params
+_chdb_query_with_params_n
 _chdb_query_cmdline
 _chdb_stream_query
 _chdb_stream_query_n
+_chdb_stream_query_with_params
+_chdb_stream_query_with_params_n
 _chdb_stream_fetch_result
 _chdb_stream_cancel_query
 _chdb_destroy_query_result

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -159,7 +159,6 @@ size_t ChdbClient::getStorageBytesRead() const
     return 0;
 }
 
-#if USE_PYTHON
 void ChdbClient::setQueryParameters(const NameToNameMap & params)
 {
     std::lock_guard<std::mutex> lock(client_mutex);
@@ -176,6 +175,7 @@ void ChdbClient::clearQueryParameters()
         client_context->setQueryParameters(query_parameters);
 }
 
+#if USE_PYTHON
 void ChdbClient::findQueryableObjFromPyCache(const String & query_str) const
 {
     python_table_cache->findQueryableObjFromQuery(query_str);

--- a/programs/local/ChdbClient.h
+++ b/programs/local/ChdbClient.h
@@ -43,10 +43,12 @@ public:
     size_t getStorageRowsRead() const;
     size_t getStorageBytesRead() const;
 
-#if USE_PYTHON
+    /// Set named query parameters ({name:Type} placeholders) on the underlying client context.
+    /// Used by both the Python binding (params=...) and the C ABI (chdb_query_with_params).
     void setQueryParameters(const NameToNameMap & params);
     void clearQueryParameters();
 
+#if USE_PYTHON
     void findQueryableObjFromPyCache(const String & query_str) const;
 #endif
 

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -616,6 +616,213 @@ chdb_result * chdb_stream_query_n(chdb_connection conn, const char * query, size
     }
 }
 
+namespace
+{
+
+/// Build a NameToNameMap from parallel C-ABI arrays of parameter names and values.
+/// On duplicate names the last value wins (NameToNameMap == std::unordered_map).
+DB::NameToNameMap buildParameterMap(
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count)
+{
+    DB::NameToNameMap params;
+    if (param_count == 0)
+        return params;
+
+    if (!param_names || !param_values)
+        throw std::invalid_argument("chdb_query_with_params: param_names/param_values must be non-null when param_count > 0");
+
+    params.reserve(param_count);
+    for (size_t i = 0; i < param_count; ++i)
+    {
+        const char * name = param_names[i];
+        const char * value = param_values[i];
+        if (!name || !value)
+            throw std::invalid_argument("chdb_query_with_params: parameter name/value pointers must be non-null");
+
+        const size_t name_len = param_name_lens ? param_name_lens[i] : std::strlen(name);
+        const size_t value_len = param_value_lens ? param_value_lens[i] : std::strlen(value);
+
+        params.insert_or_assign(std::string(name, name_len), std::string(value, value_len));
+    }
+    return params;
+}
+
+/// RAII guard mirroring the Python binding's QueryParameterGuard (see LocalChdb.cpp): sets named
+/// parameters on the client for the duration of one query, then unconditionally clears them.
+/// This matches Python `chdb.query(..., params=...)` semantics — including for streaming, where
+/// parameters only need to be present during executeStreamingInit (the engine captures values then).
+class CApiQueryParameterGuard
+{
+public:
+    CApiQueryParameterGuard(DB::ChdbClient * client_, const DB::NameToNameMap & params) : client(client_)
+    {
+        if (client && !params.empty())
+        {
+            client->setQueryParameters(params);
+            applied = true;
+        }
+    }
+
+    ~CApiQueryParameterGuard()
+    {
+        if (client && applied)
+            client->clearQueryParameters();
+    }
+
+    CApiQueryParameterGuard(const CApiQueryParameterGuard &) = delete;
+    CApiQueryParameterGuard & operator=(const CApiQueryParameterGuard &) = delete;
+
+private:
+    DB::ChdbClient * client = nullptr;
+    bool applied = false;
+};
+
+} // anonymous namespace
+
+chdb_result * chdb_query_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count)
+{
+    return chdb_query_with_params_n(
+        conn,
+        query,
+        query ? std::strlen(query) : 0,
+        format,
+        format ? std::strlen(format) : 0,
+        param_names,
+        /*param_name_lens=*/nullptr,
+        param_values,
+        /*param_value_lens=*/nullptr,
+        param_count);
+}
+
+chdb_result * chdb_query_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count)
+{
+    if (!conn)
+    {
+        auto * result = new MaterializedQueryResult("Unexpected null connection");
+        return reinterpret_cast<chdb_result *>(result);
+    }
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+    {
+        auto * result = new MaterializedQueryResult("Invalid or closed connection");
+        return reinterpret_cast<chdb_result *>(result);
+    }
+
+    try
+    {
+        auto * client = static_cast<DB::ChdbClient *>(connection->server);
+        const auto params = buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
+        CApiQueryParameterGuard guard(client, params);
+
+        auto query_result = client->executeMaterializedQuery(query, query_len, format, format_len);
+        return reinterpret_cast<chdb_result *>(query_result.release());
+    }
+    catch (const std::exception & e)
+    {
+        auto * result = new MaterializedQueryResult(std::string("Error: ") + e.what());
+        return reinterpret_cast<chdb_result *>(result);
+    }
+    catch (...)
+    {
+        auto * result = new MaterializedQueryResult(DB::getCurrentExceptionMessage(true));
+        return reinterpret_cast<chdb_result *>(result);
+    }
+}
+
+chdb_result * chdb_stream_query_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count)
+{
+    return chdb_stream_query_with_params_n(
+        conn,
+        query,
+        query ? std::strlen(query) : 0,
+        format,
+        format ? std::strlen(format) : 0,
+        param_names,
+        /*param_name_lens=*/nullptr,
+        param_values,
+        /*param_value_lens=*/nullptr,
+        param_count);
+}
+
+chdb_result * chdb_stream_query_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count)
+{
+    if (!conn)
+    {
+        auto * result = new StreamQueryResult("Unexpected null connection");
+        return reinterpret_cast<chdb_result *>(result);
+    }
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+    {
+        auto * result = new StreamQueryResult("Invalid or closed connection");
+        return reinterpret_cast<chdb_result *>(result);
+    }
+
+    try
+    {
+        auto * client = static_cast<DB::ChdbClient *>(connection->server);
+        const auto params = buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
+        CApiQueryParameterGuard guard(client, params);
+
+        auto query_result = client->executeStreamingInit(query, query_len, format, format_len);
+        if (!query_result)
+        {
+            auto * result = new StreamQueryResult("Query processing failed");
+            return reinterpret_cast<chdb_result *>(result);
+        }
+
+        return reinterpret_cast<chdb_result *>(query_result.release());
+    }
+    catch (const std::exception & e)
+    {
+        auto * result = new StreamQueryResult(std::string("Error: ") + e.what());
+        return reinterpret_cast<chdb_result *>(result);
+    }
+    catch (...)
+    {
+        auto * result = new StreamQueryResult(DB::getCurrentExceptionMessage(true));
+        return reinterpret_cast<chdb_result *>(result);
+    }
+}
+
 chdb_result * chdb_stream_fetch_result(chdb_connection conn, chdb_result * result)
 {
     if (!conn)

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -306,6 +306,107 @@ CHDB_EXPORT chdb_result *
 chdb_stream_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
 
 /**
+ * Executes a query with server-side named parameter binding.
+ * @brief Binds {name:Type} placeholders before query execution; values are NOT interpolated into SQL.
+ * @param conn Connection to execute query on
+ * @param query SQL query string (NUL-terminated, e.g. "SELECT {x:Int64} AS v")
+ * @param format Output format string (e.g. "CSV", "JSON")
+ * @param param_names Array of param_count NUL-terminated parameter names (must match {name:Type} placeholders)
+ * @param param_values Array of param_count NUL-terminated parameter values
+ * @param param_count Number of name/value pairs in the arrays
+ * @return Query result structure containing output or error message
+ * @note Parameter values are passed to the engine as strings; the engine resolves the type from the
+ *       {name:Type} placeholder. This avoids SQL injection (no string interpolation) and enables
+ *       server-side query-plan caching.
+ * @note On duplicate parameter names, the last value wins (NameToNameMap semantics).
+ * @note Parameters are scoped to this single call and cleared on return (RAII).
+ * @note Use chdb_query_with_params_n for binary-safe values containing NUL bytes.
+ */
+CHDB_EXPORT chdb_result * chdb_query_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Executes a query with server-side named parameter binding and explicit string lengths.
+ * @brief Binary-safe variant of chdb_query_with_params() — values may contain NUL bytes.
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain NUL bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain NUL bytes)
+ * @param format_len Length of format buffer in bytes
+ * @param param_names Array of param_count parameter names (each name_lens[i] bytes long)
+ * @param param_name_lens Array of param_count byte lengths for param_names
+ * @param param_values Array of param_count parameter value buffers (each value_lens[i] bytes long)
+ * @param param_value_lens Array of param_count byte lengths for param_values
+ * @param param_count Number of name/value pairs
+ * @return Query result structure containing output or error message
+ * @note Strings do not need to be NUL-terminated.
+ */
+CHDB_EXPORT chdb_result * chdb_query_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
+ * Executes a streaming query with server-side named parameter binding.
+ * @brief Initializes streaming query execution with parameter binding.
+ * @param conn Connection to execute query on
+ * @param query SQL query string (NUL-terminated)
+ * @param format Output format string (e.g. "CSV", "JSON")
+ * @param param_names Array of param_count NUL-terminated parameter names
+ * @param param_values Array of param_count NUL-terminated parameter values
+ * @param param_count Number of name/value pairs
+ * @return Streaming result handle containing query state or error message
+ * @note Parameters are bound on the connection before streaming starts and cleared once the
+ *       streaming initialization returns (the engine has already captured the parameter values).
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Executes a streaming query with server-side named parameter binding and explicit string lengths.
+ * @brief Binary-safe variant of chdb_stream_query_with_params().
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain NUL bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain NUL bytes)
+ * @param format_len Length of format buffer in bytes
+ * @param param_names Array of param_count parameter names
+ * @param param_name_lens Array of param_count byte lengths for param_names
+ * @param param_values Array of param_count parameter value buffers
+ * @param param_value_lens Array of param_count byte lengths for param_values
+ * @param param_count Number of name/value pairs
+ * @return Streaming result handle containing query state or error message
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
  * Fetches next chunk of streaming results.
  * @brief Iterates through streaming query results
  * @param conn Active connection handle

--- a/tests/test_c_api_query_with_params.py
+++ b/tests/test_c_api_query_with_params.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Regression tests for the C ABI parameter-binding surface (Issue #73).
+
+Exercises:
+  * chdb_query_with_params         (NUL-terminated params)
+  * chdb_query_with_params_n       (length-prefixed; binary-safe String params)
+  * chdb_stream_query_with_params  (streaming variant)
+  * chdb_stream_query_with_params_n
+
+These call the same engine plumbing as Python's ``chdb.query(..., params={...})``
+(``ChdbClient::setQueryParameters``/``clearQueryParameters`` + ``QueryParameterGuard``);
+they're the C-ABI siblings used by chdb-node / chdb-go / chdb-rust.
+
+Loads libchdb.so / libchdb.dylib directly via ctypes (those binaries export the
+C ABI; the Python wheel's ``_chdb.abi3.so`` only exports ``PyInit__chdb``). When
+no standalone library is found (e.g. running against an installed wheel without
+the source tree) the whole suite is skipped.
+"""
+
+import ctypes
+import os
+import platform
+import sys
+import unittest
+
+
+def _find_libchdb():
+    """Locate libchdb.so / libchdb.dylib. Returns the path or None."""
+    candidates = []
+    if os.environ.get("CHDB_LIB_PATH"):
+        candidates.append(os.environ["CHDB_LIB_PATH"])
+
+    # tests/ → repo root → buildlib/
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    lib_name = "libchdb.dylib" if platform.system() == "Darwin" else "libchdb.so"
+    candidates.append(os.path.join(repo_root, "buildlib", lib_name))
+
+    for path in candidates:
+        if path and os.path.isfile(path):
+            return path
+    return None
+
+
+_LIB_PATH = _find_libchdb()
+
+
+@unittest.skipIf(
+    _LIB_PATH is None,
+    "libchdb.so/dylib not found; build chdb-core or set CHDB_LIB_PATH to run",
+)
+class TestCApiQueryWithParams(unittest.TestCase):
+    """Verify the C-ABI parameter-binding entry points."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.lib = ctypes.CDLL(_LIB_PATH)
+
+        # chdb_connect(int argc, char ** argv) -> chdb_connection *
+        cls.lib.chdb_connect.restype = ctypes.c_void_p
+        cls.lib.chdb_connect.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+
+        cls.lib.chdb_close_conn.restype = None
+        cls.lib.chdb_close_conn.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+
+        cls.lib.chdb_query_with_params.restype = ctypes.c_void_p
+        cls.lib.chdb_query_with_params.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.c_size_t,
+        ]
+        cls.lib.chdb_query_with_params_n.restype = ctypes.c_void_p
+        cls.lib.chdb_query_with_params_n.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_char_p,
+            ctypes.c_size_t,
+            ctypes.c_char_p,
+            ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.c_size_t,
+        ]
+        cls.lib.chdb_stream_query_with_params.restype = ctypes.c_void_p
+        cls.lib.chdb_stream_query_with_params.argtypes = (
+            cls.lib.chdb_query_with_params.argtypes
+        )
+        cls.lib.chdb_stream_query_with_params_n.restype = ctypes.c_void_p
+        cls.lib.chdb_stream_query_with_params_n.argtypes = (
+            cls.lib.chdb_query_with_params_n.argtypes
+        )
+
+        # Result accessors
+        cls.lib.chdb_result_buffer.restype = ctypes.POINTER(ctypes.c_char)
+        cls.lib.chdb_result_buffer.argtypes = [ctypes.c_void_p]
+        cls.lib.chdb_result_length.restype = ctypes.c_size_t
+        cls.lib.chdb_result_length.argtypes = [ctypes.c_void_p]
+        cls.lib.chdb_result_error.restype = ctypes.c_char_p
+        cls.lib.chdb_result_error.argtypes = [ctypes.c_void_p]
+        cls.lib.chdb_destroy_query_result.restype = None
+        cls.lib.chdb_destroy_query_result.argtypes = [ctypes.c_void_p]
+
+        # Streaming
+        cls.lib.chdb_stream_fetch_result.restype = ctypes.c_void_p
+        cls.lib.chdb_stream_fetch_result.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        cls.lib.chdb_stream_cancel_query.restype = None
+        cls.lib.chdb_stream_cancel_query.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        # Build a memory-only connection. ``chdb.state.connect(":memory:")`` collapses
+        # to argv = ["clickhouse"] (no --path), so do the same here.
+        argv = (ctypes.c_char_p * 1)(b"clickhouse")
+        cls.conn_ptr = cls.lib.chdb_connect(1, argv)
+        if not cls.conn_ptr:
+            raise RuntimeError("chdb_connect returned NULL")
+        # chdb_connect returns chdb_connection*; deref once to get the chdb_connection
+        # value the *query* functions expect.
+        cls.conn = ctypes.c_void_p.from_address(cls.conn_ptr).value
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "conn_ptr", None):
+            cls.lib.chdb_close_conn(ctypes.cast(cls.conn_ptr, ctypes.POINTER(ctypes.c_void_p)))
+
+    # ------------------------------------------------------------------ helpers
+
+    def _result_bytes(self, result_ptr):
+        """Pull (error_msg, buffer_bytes) from a chdb_result*. Caller destroys."""
+        err = self.lib.chdb_result_error(result_ptr)
+        if err:
+            return err.decode("utf-8", errors="replace"), b""
+        n = self.lib.chdb_result_length(result_ptr)
+        buf = self.lib.chdb_result_buffer(result_ptr)
+        if not buf or n == 0:
+            return None, b""
+        return None, ctypes.string_at(buf, n)
+
+    def _materialized_query(self, sql, names, values, fmt=b"CSV"):
+        c_names = (ctypes.c_char_p * len(names))(*names)
+        c_values = (ctypes.c_char_p * len(values))(*values)
+        result = self.lib.chdb_query_with_params(
+            self.conn, sql, fmt, c_names, c_values, len(names)
+        )
+        try:
+            return self._result_bytes(result)
+        finally:
+            self.lib.chdb_destroy_query_result(result)
+
+    def _materialized_query_n(self, sql, names, values, fmt=b"CSV"):
+        c_names = (ctypes.c_char_p * len(names))(*names)
+        c_values = (ctypes.c_char_p * len(values))(*values)
+        c_name_lens = (ctypes.c_size_t * len(names))(*(len(n) for n in names))
+        c_value_lens = (ctypes.c_size_t * len(values))(*(len(v) for v in values))
+        result = self.lib.chdb_query_with_params_n(
+            self.conn,
+            sql,
+            len(sql),
+            fmt,
+            len(fmt),
+            c_names,
+            c_name_lens,
+            c_values,
+            c_value_lens,
+            len(names),
+        )
+        try:
+            return self._result_bytes(result)
+        finally:
+            self.lib.chdb_destroy_query_result(result)
+
+    # ------------------------------------------------------------------- tests
+
+    def test_int64_param_returns_bound_value(self):
+        err, body = self._materialized_query(
+            b"SELECT {x:Int64} AS v",
+            names=[b"x"],
+            values=[b"42"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(body, b"42\n")
+
+    def test_string_param_returns_bound_value(self):
+        err, body = self._materialized_query(
+            b"SELECT {s:String} AS v",
+            names=[b"s"],
+            values=[b"hello"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(body, b'"hello"\n')
+
+    def test_date_param_arithmetic_returns_expected_value(self):
+        # Mirrors test_query_params.test_connection_query_with_params but via the C ABI.
+        err, body = self._materialized_query(
+            b"SELECT toDate({d:Date}) + 1 AS d",
+            names=[b"d"],
+            values=[b"2025-01-01"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(body, b'"2025-01-02"\n')
+
+    def test_multiple_params_match_python_semantics(self):
+        err, body = self._materialized_query(
+            b"SELECT {x:UInt64} + {y:UInt64} AS total",
+            names=[b"x", b"y"],
+            values=[b"5", b"7"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(body, b"12\n")
+
+    def test_missing_param_returns_error_not_crash(self):
+        err, body = self._materialized_query(
+            b"SELECT {x:UInt64} AS v",
+            names=[],
+            values=[],
+        )
+        self.assertIsNotNone(err)
+        self.assertIn("Substitution", err)
+        self.assertEqual(body, b"")
+
+    def test_invalid_type_returns_error_not_crash(self):
+        err, body = self._materialized_query(
+            b"SELECT {x:UInt64} AS v",
+            names=[b"x"],
+            values=[b"not-a-number"],
+        )
+        self.assertIsNotNone(err)
+        self.assertIn("cannot be parsed as UInt64", err)
+        self.assertEqual(body, b"")
+
+    def test_params_cleared_after_call(self):
+        # First call binds {x}; second call uses the same param name with a different
+        # value. If RAII cleanup ran, this works. If parameters leaked, the second
+        # call's behavior would depend on residual state from the first.
+        err1, body1 = self._materialized_query(
+            b"SELECT {x:Int64} AS v", names=[b"x"], values=[b"1"]
+        )
+        err2, body2 = self._materialized_query(
+            b"SELECT {x:Int64} AS v", names=[b"x"], values=[b"99"]
+        )
+        self.assertIsNone(err1)
+        self.assertIsNone(err2)
+        self.assertEqual(body1, b"1\n")
+        self.assertEqual(body2, b"99\n")
+
+        # Now call WITHOUT params — if cleanup didn't run, leftover {x} from the
+        # previous call would still satisfy the substitution. Expect an error.
+        err3, body3 = self._materialized_query(
+            b"SELECT {x:Int64} AS v", names=[], values=[]
+        )
+        self.assertIsNotNone(err3, "expected 'Substitution `x` is not set' after RAII cleanup")
+        self.assertIn("Substitution", err3)
+        self.assertEqual(body3, b"")
+
+    def test_binary_safe_string_param_via_n_variant(self):
+        # String param contains an embedded NUL — exercises the _n variant's
+        # binary-safe path. Use base64 to make the assertion deterministic
+        # without dragging UTF-8 / CSV-escape rules into the test.
+        raw = b"ab\x00cd"
+        err, body = self._materialized_query_n(
+            b"SELECT base64Encode({s:String}) AS v",
+            names=[b"s"],
+            values=[raw],
+        )
+        self.assertIsNone(err)
+        # base64("ab\x00cd") = "YWIAY2Q="
+        self.assertEqual(body, b'"YWIAY2Q="\n')
+
+    def test_zero_param_count_falls_through_to_plain_query(self):
+        # Passing NULL arrays + count=0 should behave like chdb_query.
+        result = self.lib.chdb_query_with_params(
+            self.conn, b"SELECT 1 AS v", b"CSV", None, None, 0
+        )
+        try:
+            err, body = self._result_bytes(result)
+        finally:
+            self.lib.chdb_destroy_query_result(result)
+        self.assertIsNone(err)
+        self.assertEqual(body, b"1\n")
+
+    def test_null_param_pointers_with_nonzero_count_returns_error_not_crash(self):
+        # Defensive: param_count > 0 with NULL arrays must not segfault.
+        result = self.lib.chdb_query_with_params(
+            self.conn, b"SELECT {x:Int64}", b"CSV", None, None, 1
+        )
+        try:
+            err, body = self._result_bytes(result)
+        finally:
+            self.lib.chdb_destroy_query_result(result)
+        self.assertIsNotNone(err)
+        self.assertEqual(body, b"")
+
+    def test_duplicate_param_names_last_wins(self):
+        # NameToNameMap == std::unordered_map, so the last occurrence of a key wins.
+        # This matches the documented Python behavior (dict-merge semantics).
+        err, body = self._materialized_query(
+            b"SELECT {x:Int64} AS v",
+            names=[b"x", b"x"],
+            values=[b"1", b"42"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(body, b"42\n")
+
+    # ------------------------------------------------------------- streaming
+
+    def _stream_to_bytes(self, sql, names, values, fmt=b"CSV"):
+        c_names = (ctypes.c_char_p * len(names))(*names)
+        c_values = (ctypes.c_char_p * len(values))(*values)
+        stream = self.lib.chdb_stream_query_with_params(
+            self.conn, sql, fmt, c_names, c_values, len(names)
+        )
+        err = self.lib.chdb_result_error(stream)
+        if err:
+            err_str = err.decode("utf-8", errors="replace")
+            self.lib.chdb_destroy_query_result(stream)
+            return err_str, b""
+
+        chunks = []
+        try:
+            while True:
+                chunk = self.lib.chdb_stream_fetch_result(self.conn, stream)
+                chunk_err = self.lib.chdb_result_error(chunk)
+                if chunk_err:
+                    self.lib.chdb_destroy_query_result(chunk)
+                    break
+                n = self.lib.chdb_result_length(chunk)
+                if n == 0:
+                    self.lib.chdb_destroy_query_result(chunk)
+                    break
+                buf = self.lib.chdb_result_buffer(chunk)
+                chunks.append(ctypes.string_at(buf, n))
+                self.lib.chdb_destroy_query_result(chunk)
+        finally:
+            self.lib.chdb_stream_cancel_query(self.conn, stream)
+            self.lib.chdb_destroy_query_result(stream)
+
+        return None, b"".join(chunks)
+
+    def test_streaming_param_binding_matches_materialized(self):
+        err, body = self._stream_to_bytes(
+            b"SELECT {x:UInt64} AS v",
+            names=[b"x"],
+            values=[b"11"],
+        )
+        self.assertIsNone(err)
+        self.assertEqual(body, b"11\n")
+
+
+if __name__ == "__main__":
+    if _LIB_PATH is None:
+        print(
+            "libchdb.so/dylib not found; build chdb-core (or set CHDB_LIB_PATH) to run this suite.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+    unittest.main()


### PR DESCRIPTION
### Changelog category

- New Feature

### Changelog entry

C ABI gains `chdb_query_with_params` / `chdb_query_with_params_n` and streaming counterparts so non-Python bindings (chdb-node, chdb-go, chdb-rust) can use server-side `{name:Type}` parameter binding instead of escaping values into SQL.

### Documentation entry

The new C ABI surface in `programs/local/chdb.h` is fully Doxygen-commented; no separate user-docs page needed for this round.

---

## Closes

Closes #73. Shape and `_n` variants ack'd by @ShawnChen-Sirius in [chdb-io/chdb-core#73 (comment)](https://github.com/chdb-io/chdb-core/issues/73#issuecomment-4598601761).

## Reproduction (before the change)

Confirmed against `chdb-io/chdb-core@10e35571`:

- `programs/local/chdb.h` (lines 257–306) exposes `chdb_query` / `chdb_query_n` / `chdb_stream_query` / `chdb_stream_query_n` — none accept query parameters.
- `git grep -n 'param' programs/local/chdb.h` → no parameter-bearing entry point.
- The engine plumbing already exists: Python's `connection_wrapper::query` builds a `NameToNameMap` via `parseParametersDict`, wraps the call in `QueryParameterGuard`, and that guard calls `ChdbClient::setQueryParameters` → `client_context->setQueryParameters`. The C ABI just doesn't surface it.
- C-ABI consumers therefore interpolate values into SQL by hand (see [chdb-node `queryBind`](https://github.com/chdb-io/chdb-node) for an example that, as Issue #73 notes, fails to escape backslashes).

## Root cause

C ABI omission, not a missing engine capability. The engine accepts a `NameToNameMap` via the existing `ChdbClient::setQueryParameters` path; the C header simply didn't expose any way to pass one in.

## Fix

Wrapper-layer only — `programs/local/` and `chdb/` export maps. No `src/` (engine) changes.

**1. `programs/local/ChdbClient.{h,cpp}` — make parameter setters Python-build-independent.**
   `setQueryParameters` / `clearQueryParameters` were nested under `#if USE_PYTHON`, but neither uses any Python API; they only call `ClientBase::query_parameters` and `Context::setQueryParameters` (both engine-level). Moved out of the guard so the no-Python `libchdb.so` build (which is what chdb-node/go/rust dlopen) sees them. `findQueryableObjFromPyCache` stays inside `#if USE_PYTHON` — that one really is Python-specific.

**2. `programs/local/chdb.h` — add four new symbols.**
   Shape matches the ack'd proposal exactly:

   ```c
   chdb_result * chdb_query_with_params(
       chdb_connection conn,
       const char * query,                         // NUL-terminated
       const char * format,
       const char * const * param_names,           // array of param_count C strings
       const char * const * param_values,
       size_t param_count);

   chdb_result * chdb_query_with_params_n(
       chdb_connection conn,
       const char * query, size_t query_len,       // binary-safe
       const char * format, size_t format_len,
       const char * const * param_names,
       const size_t * param_name_lens,             // pass NULL ⇒ strlen each
       const char * const * param_values,
       const size_t * param_value_lens,            // pass NULL ⇒ strlen each
       size_t param_count);

   chdb_result * chdb_stream_query_with_params(...);     // same shape, streaming
   chdb_result * chdb_stream_query_with_params_n(...);   //   "
   ```

   - Existing `chdb_query` / `chdb_query_n` / `chdb_stream_query` / `chdb_stream_query_n` are untouched — no ABI break.
   - `*_n` variants make `String` parameters with embedded NUL binary-safe (mirrors how `query_n` mirrors `query` today).
   - Values are pushed to the engine as strings; the engine resolves the type from the `{name:Type}` placeholder. Same contract as Python.
   - On duplicate parameter names the last value wins (`NameToNameMap` is a `std::unordered_map`, matches Python `dict` merge semantics).

**3. `programs/local/chdb.cpp` — implementations + RAII guard.**
   A small anonymous-namespace `CApiQueryParameterGuard` mirrors the Python binding's `QueryParameterGuard` (LocalChdb.cpp lines 80–101) — `setQueryParameters` on construction, `clearQueryParameters` on destruction. This guarantees parameters are scoped to one C-ABI call even if the caller throws or the query errors, matching Python `params=` semantics exactly. For streaming, the guard's lifetime covers `executeStreamingInit` (the engine captures the values at init time, so we don't need to keep parameters alive across `chdb_stream_fetch_result` calls).

   `buildParameterMap` accepts both the NUL-terminated and length-prefixed forms via a single helper — pass `nullptr` for the length arrays and it falls back to `strlen`.

**4. `chdb/libchdb_export.map` and `chdb/libchdb_export_macos.txt` — export the four new symbols** so they're visible from the standalone `libchdb.so` / `libchdb.dylib` consumed by chdb-node/go/rust.

## Regression test

New file: `tests/test_c_api_query_with_params.py`. Uses `ctypes.CDLL` to load `buildlib/libchdb.{so,dylib}` (set `CHDB_LIB_PATH` to override; whole suite skips with a clear message if the standalone library isn't built) and exercises:

| # | Test | Covers |
|---|------|--------|
| 1 | `test_int64_param_returns_bound_value` | `{x:Int64}` basic case via `chdb_query_with_params` |
| 2 | `test_string_param_returns_bound_value` | `{s:String}` (CSV quoting) |
| 3 | `test_date_param_arithmetic_returns_expected_value` | `{d:Date}` — mirrors the existing Python `test_query_params.test_connection_query_with_params` shape |
| 4 | `test_multiple_params_match_python_semantics` | 2 params, addition |
| 5 | `test_missing_param_returns_error_not_crash` | `Substitution \`x\` is not set` surfaces as a result error, not a segfault |
| 6 | `test_invalid_type_returns_error_not_crash` | `cannot be parsed as UInt64` likewise |
| 7 | `test_params_cleared_after_call` | **RAII**: after a parameterized call, the next call with no params reports `Substitution not set` — proves `clearQueryParameters` ran |
| 8 | `test_binary_safe_string_param_via_n_variant` | `{s:String}` with embedded `\0`, asserted via `base64Encode` round-trip — exercises `chdb_query_with_params_n` |
| 9 | `test_zero_param_count_falls_through_to_plain_query` | `param_count=0` + `NULL` arrays behaves like `chdb_query` |
| 10 | `test_null_param_pointers_with_nonzero_count_returns_error_not_crash` | Defensive: bad inputs surface as a result error, not a crash |
| 11 | `test_duplicate_param_names_last_wins` | Documents the `unordered_map` last-wins behavior |
| 12 | `test_streaming_param_binding_matches_materialized` | `chdb_stream_query_with_params` end-to-end, including chunked fetch |

The suite drains and destroys every `chdb_result *` it creates and cancels the streaming query before destroying the stream handle.

## Notes for the reviewer

- **No engine (`src/`) changes** — confined to `programs/local/` and the export-map files, as Issue #73 scoped.
- **No change to existing symbols.** `chdb_query` / `chdb_query_n` / `chdb_stream_query` / `chdb_stream_query_n` signatures are byte-identical to `main`.
- **Local CI status:** chdb-core requires clang-21 + initialized submodules; my host has clang-21 available but submodules aren't pre-initialized (the `~/code/chdb` checkout that does is the maintainer's working tree, which I don't touch). Pushing here so CI can run the four-platform build matrix and validate; happy to push fixups for any platform-specific issues that surface.