### PR TITLE
Add Arrow C Data Interface output API (chdb_query_arrow / chdb_stream_query_arrow) — closes #15

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -286,6 +286,7 @@ jobs:
           bash -x ./examples/runStub.sh
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
+          bash -x ./examples/runArrowQueryTest.sh
       - name: Check ccache statistics
         run: |
           ccache -s

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -272,6 +272,7 @@ jobs:
           bash -x ./examples/runStub.sh
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
+          bash -x ./examples/runArrowQueryTest.sh
       - name: Check ccache statistics
         run: |
           ccache -s

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -305,6 +305,7 @@ jobs:
           bash -x ./examples/runStub.sh
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
+          bash -x ./examples/runArrowQueryTest.sh
       - name: Build wheels
         run: |
           rm -rf chdb/build/

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -306,6 +306,7 @@ jobs:
           bash -x ./examples/runStub.sh
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
+          bash -x ./examples/runArrowQueryTest.sh
       - name: Build wheels
         run: |
           rm -rf chdb/build/

--- a/base/poco/Foundation/src/Logger.cpp
+++ b/base/poco/Foundation/src/Logger.cpp
@@ -324,7 +324,21 @@ struct LoggerDeleter
 		}
 
 		auto it = _pLoggerMap->find(logger->name());
-		assert(it != _pLoggerMap->end());
+
+		/// The logger may be absent from the current map during shutdown:
+		/// Logger::shutdown() (run from the AutoLoggerShutdown static dtor)
+		/// deletes _pLoggerMap and leaves shared_ptr-owned loggers alive, and
+		/// a later Logger::get() (e.g. from another static/atexit teardown
+		/// path such as ~EmbeddedServer) re-creates a fresh map. When such a
+		/// stale shared_ptr is finally released here, find() returns end().
+		/// Treat it like the "no map" case above: just drop our reference,
+		/// there is no map entry to erase. Without this guard erase(end())
+		/// trips a libc++ hardening assertion and aborts the process.
+		if (it == _pLoggerMap->end())
+		{
+			logger->release();
+			return;
+		}
 
 		/** If reference count is 1, this means this shared pointer owns logger
 		  * and need destroy it.

--- a/chdb/build_mac_on_linux.sh
+++ b/chdb/build_mac_on_linux.sh
@@ -221,8 +221,21 @@ if [ "${CHDB_LITE}" != "1" ]; then
         ${SED_INPLACE} 's/ '${CHDB_PY_MODULE}'/ '${LIBCHDB_SO}'/g' CMakeFiles/libchdb.rsp
     fi
 
-    # For macOS, replace PyInit entry point with exported symbols for libchdb
-    LIBCHDB_CMD=$(echo ${LIBCHDB_CMD} | sed 's/ '${PYINIT_ENTRY}'/ -Wl,-exported_symbol,_query_stable -Wl,-exported_symbol,_free_result -Wl,-exported_symbol,_query_stable_v2 -Wl,-exported_symbol,_free_result_v2/g')
+    # Control exported symbols for libchdb.so — must mirror the native macOS
+    # build (chdb/build.sh) exactly. The old code here only injected four
+    # -Wl,-exported_symbol flags by replacing ${PYINIT_ENTRY}, but the libchdb
+    # link command is derived from the `clickhouse` link line and never carries
+    # ${PYINIT_ENTRY}, so that sed was a no-op: NO symbols were restricted and
+    # the cross-compiled libchdb.so exported its entire transitive closure
+    # (~100k symbols incl. all of bundled abseil/protobuf). When such a
+    # libchdb.so is dlopen'd into a process that already imported a library
+    # carrying its own abseil/protobuf (e.g. pyarrow), libchdb's protobuf
+    # AddDescriptors -> absl OnShutdownRun static initializer binds to the
+    # foreign, already-initialized absl mutex and spins forever
+    # ("[mutex.cc:452] RAW: Lock blocking"). Restricting exports to the
+    # libchdb_export_macos.txt allow-list hides abseil/protobuf and removes the
+    # collision (the native build, which already uses this list, never hangs).
+    LIBCHDB_CMD="${LIBCHDB_CMD} -Wl,-exported_symbols_list,${CHDB_DIR}/libchdb_export_macos.txt"
 
     LIBCHDB_CMD=$(echo ${LIBCHDB_CMD} | sed 's/@CMakeFiles\/clickhouse.rsp/@CMakeFiles\/libchdb.rsp/g')
 

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -40,6 +40,11 @@
         chdb_arrow_scan;
         chdb_arrow_array_scan;
         chdb_arrow_unregister_table;
+        chdb_query_arrow;
+        chdb_query_arrow_n;
+        chdb_stream_query_arrow;
+        chdb_stream_query_arrow_n;
+        chdb_stream_fetch_arrow;
 
         /* Signal Handler Control */
         chdb_set_signal_handlers_enabled;

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -35,6 +35,11 @@ _chdb_result_error
 _chdb_arrow_scan
 _chdb_arrow_array_scan
 _chdb_arrow_unregister_table
+_chdb_query_arrow
+_chdb_query_arrow_n
+_chdb_stream_query_arrow
+_chdb_stream_query_arrow_n
+_chdb_stream_fetch_arrow
 
 _chdb_set_signal_handlers_enabled
 _chdb_reset_signal_handlers

--- a/examples/chdbArrowQueryTest.c
+++ b/examples/chdbArrowQueryTest.c
@@ -1,0 +1,344 @@
+/**
+ * chdbArrowQueryTest.c
+ *
+ * End-to-end smoke test for the Arrow C Data Interface output API
+ * (chdb_query_arrow / chdb_stream_query_arrow / chdb_stream_fetch_arrow).
+ *
+ * Unlike chdbArrowStreamParse.c — which goes through ArrowStream IPC
+ * serialization and decodes with nanoarrow — this test gets the Arrow
+ * C Data Interface stream directly, skipping the IPC layer entirely.
+ *
+ * Build (Linux, against an already-built libchdb.so and nanoarrow):
+ *   clang -O2 -I./examples -I./examples/nanoarrow-0.8.0 \
+ *         examples/chdbArrowQueryTest.c \
+ *         examples/nanoarrow-0.8.0/nanoarrow.c \
+ *         -L. -lchdb -o examples/chdbArrowQueryTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbArrowQueryTest
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nanoarrow/nanoarrow.h"
+#include "chdb.h"
+
+static int g_failed_assertions = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "  ASSERT FAIL: %s (%s:%d)\n",                 \
+                    (msg), __FILE__, __LINE__);                            \
+            g_failed_assertions += 1;                                      \
+        }                                                                  \
+    } while (0)
+
+static void print_schema(const struct ArrowSchema * schema)
+{
+    printf("  Schema (%lld columns):\n", (long long)schema->n_children);
+    for (int64_t i = 0; i < schema->n_children; i++) {
+        const struct ArrowSchema * child = schema->children[i];
+        printf("    [%lld] %-20s format=%s\n",
+               (long long)i,
+               child->name ? child->name : "(null)",
+               child->format ? child->format : "?");
+    }
+}
+
+static int read_one_batch_into_view(
+    struct ArrowArrayStream * stream,
+    struct ArrowSchema * schema_out,
+    struct ArrowArray * array_out)
+{
+    int rc = stream->get_schema(stream, schema_out);
+    if (rc != 0) {
+        fprintf(stderr, "  get_schema failed: rc=%d msg=%s\n", rc,
+                stream->get_last_error ? stream->get_last_error(stream) : "?");
+        return rc;
+    }
+    rc = stream->get_next(stream, array_out);
+    if (rc != 0) {
+        fprintf(stderr, "  get_next failed: rc=%d msg=%s\n", rc,
+                stream->get_last_error ? stream->get_last_error(stream) : "?");
+        return rc;
+    }
+    return 0;
+}
+
+/* Test 1: chdb_query_arrow (materialized) — basic SELECT, default options. */
+static void test_basic_select(chdb_connection conn)
+{
+    printf("== test_basic_select ==\n");
+    struct ArrowArrayStream stream;
+    memset(&stream, 0, sizeof(stream));
+
+    chdb_result * result = chdb_query_arrow(
+        conn,
+        "SELECT number AS n, toString(number) AS s FROM numbers(5)",
+        (chdb_arrow_stream)&stream,
+        NULL);
+
+    const char * err = chdb_result_error(result);
+    if (err) {
+        fprintf(stderr, "  ERROR: %s\n", err);
+        CHECK(0, "chdb_query_arrow returned error");
+        chdb_destroy_query_result(result);
+        return;
+    }
+
+    CHECK(stream.release != NULL, "out_stream release must be set");
+
+    struct ArrowSchema schema;
+    struct ArrowArray array;
+    memset(&schema, 0, sizeof(schema));
+    memset(&array, 0, sizeof(array));
+
+    int rc = read_one_batch_into_view(&stream, &schema, &array);
+    CHECK(rc == 0, "read_one_batch_into_view");
+
+    print_schema(&schema);
+
+    CHECK(schema.n_children == 2, "two columns");
+    CHECK(array.length == 5, "five rows");
+
+    /* Inspect first column values via nanoarrow view. */
+    struct ArrowArrayView view;
+    ArrowArrayViewInitFromSchema(&view, schema.children[0], NULL);
+    ArrowArrayViewSetArray(&view, array.children[0], NULL);
+    for (int64_t i = 0; i < array.length; i++) {
+        int64_t v = ArrowArrayViewGetIntUnsafe(&view, i);
+        if (v != i) {
+            fprintf(stderr, "  row %lld expected %lld got %lld\n",
+                    (long long)i, (long long)i, (long long)v);
+            CHECK(0, "value mismatch");
+            break;
+        }
+    }
+    ArrowArrayViewReset(&view);
+
+    if (array.release) array.release(&array);
+    if (schema.release) schema.release(&schema);
+    if (stream.release) stream.release(&stream);
+
+    printf("  -> elapsed=%.4fs rows_read=%llu\n",
+           chdb_result_elapsed(result),
+           (unsigned long long)chdb_result_rows_read(result));
+
+    chdb_destroy_query_result(result);
+}
+
+/* Test 2: chdb_query_arrow with empty result (LIMIT 0). */
+static void test_empty_result(chdb_connection conn)
+{
+    printf("== test_empty_result ==\n");
+    struct ArrowArrayStream stream;
+    memset(&stream, 0, sizeof(stream));
+
+    chdb_result * result = chdb_query_arrow(
+        conn,
+        "SELECT number FROM numbers(10) LIMIT 0",
+        (chdb_arrow_stream)&stream,
+        NULL);
+
+    const char * err = chdb_result_error(result);
+    if (err) {
+        fprintf(stderr, "  ERROR: %s\n", err);
+        CHECK(0, "chdb_query_arrow returned error on empty result");
+        chdb_destroy_query_result(result);
+        return;
+    }
+    CHECK(stream.release != NULL, "stream filled for empty result");
+
+    struct ArrowSchema schema;
+    memset(&schema, 0, sizeof(schema));
+    int rc = stream.get_schema(&stream, &schema);
+    CHECK(rc == 0, "schema available even for empty result");
+    print_schema(&schema);
+    if (schema.release) schema.release(&schema);
+
+    /* get_next on an empty result should return either zero-length batch or released. */
+    struct ArrowArray array;
+    memset(&array, 0, sizeof(array));
+    rc = stream.get_next(&stream, &array);
+    CHECK(rc == 0, "get_next on empty result succeeds");
+    /* Could be a 0-row batch or a released-callback signal. Both are valid. */
+    if (array.release) array.release(&array);
+
+    if (stream.release) stream.release(&stream);
+    chdb_destroy_query_result(result);
+}
+
+/* Test 3: chdb_stream_query_arrow + repeated chdb_stream_fetch_arrow. */
+static void test_streaming(chdb_connection conn)
+{
+    printf("== test_streaming ==\n");
+
+    chdb_result * stream_result = chdb_stream_query_arrow(
+        conn,
+        "SELECT number AS n FROM numbers(7)",
+        NULL);
+
+    const char * err = chdb_result_error(stream_result);
+    if (err) {
+        fprintf(stderr, "  ERROR: %s\n", err);
+        CHECK(0, "chdb_stream_query_arrow returned error");
+        chdb_destroy_query_result(stream_result);
+        return;
+    }
+
+    int64_t total_rows = 0;
+    int fetched_batches = 0;
+    for (int i = 0; i < 100; i++) {
+        struct ArrowArrayStream batch;
+        memset(&batch, 0, sizeof(batch));
+
+        chdb_state st = chdb_stream_fetch_arrow(conn, stream_result,
+                                                (chdb_arrow_stream)&batch);
+        if (st != CHDBSuccess) {
+            fprintf(stderr, "  fetch returned non-success at iter %d\n", i);
+            break;
+        }
+
+        struct ArrowSchema schema;
+        struct ArrowArray array;
+        memset(&schema, 0, sizeof(schema));
+        memset(&array, 0, sizeof(array));
+
+        int rc = batch.get_schema(&batch, &schema);
+        if (rc != 0) {
+            /* End of stream — no schema cached or stream empty. */
+            if (batch.release) batch.release(&batch);
+            break;
+        }
+
+        rc = batch.get_next(&batch, &array);
+        if (rc != 0 || array.release == NULL) {
+            /* End of stream marker. */
+            if (schema.release) schema.release(&schema);
+            if (batch.release) batch.release(&batch);
+            break;
+        }
+
+        fetched_batches += 1;
+        total_rows += array.length;
+
+        if (array.release) array.release(&array);
+        if (schema.release) schema.release(&schema);
+        if (batch.release) batch.release(&batch);
+    }
+
+    printf("  fetched %d batches, total %lld rows\n", fetched_batches, (long long)total_rows);
+    CHECK(total_rows == 7, "streaming got expected total rows");
+    CHECK(fetched_batches >= 1, "streaming yielded at least one batch");
+
+    chdb_destroy_query_result(stream_result);
+}
+
+/* Test 4: Custom options — string_as_string=0 (binary instead of utf8). */
+static void test_string_as_binary(chdb_connection conn)
+{
+    printf("== test_string_as_binary ==\n");
+    struct ArrowArrayStream stream;
+    memset(&stream, 0, sizeof(stream));
+
+    chdb_arrow_options opts;
+    opts.unsupported_as_binary = 0;
+    opts.low_cardinality_as_dictionary = 0;
+    opts.string_as_string = 0; /* binary, not utf8 */
+
+    chdb_result * result = chdb_query_arrow(
+        conn,
+        "SELECT 'hello' AS s",
+        (chdb_arrow_stream)&stream,
+        &opts);
+
+    const char * err = chdb_result_error(result);
+    if (err) {
+        fprintf(stderr, "  ERROR: %s\n", err);
+        CHECK(0, "chdb_query_arrow returned error");
+        chdb_destroy_query_result(result);
+        return;
+    }
+
+    struct ArrowSchema schema;
+    memset(&schema, 0, sizeof(schema));
+    int rc = stream.get_schema(&stream, &schema);
+    CHECK(rc == 0, "got schema");
+
+    if (schema.n_children >= 1) {
+        const char * fmt = schema.children[0]->format;
+        printf("  column format: %s\n", fmt ? fmt : "(null)");
+        /* "z" = binary; "u" = utf8. We expect binary with this option. */
+        CHECK(fmt && fmt[0] == 'z', "string_as_string=0 yields arrow binary");
+    }
+
+    if (schema.release) schema.release(&schema);
+    if (stream.release) stream.release(&stream);
+    chdb_destroy_query_result(result);
+}
+
+/* Test 5: DateTime maps to Arrow uint32 (ClickHouse ArrowStream parity). */
+static void test_datetime_is_uint32(chdb_connection conn)
+{
+    printf("== test_datetime_is_uint32 ==\n");
+    struct ArrowArrayStream stream;
+    memset(&stream, 0, sizeof(stream));
+
+    chdb_result * result = chdb_query_arrow(
+        conn,
+        "SELECT toDateTime('2024-01-02 03:04:05', 'UTC') AS dt",
+        (chdb_arrow_stream)&stream,
+        NULL);
+
+    const char * err = chdb_result_error(result);
+    if (err) {
+        fprintf(stderr, "  ERROR: %s\n", err);
+        CHECK(0, "datetime query failed");
+        chdb_destroy_query_result(result);
+        return;
+    }
+
+    struct ArrowSchema schema;
+    memset(&schema, 0, sizeof(schema));
+    int rc = stream.get_schema(&stream, &schema);
+    CHECK(rc == 0, "got schema");
+
+    if (schema.n_children >= 1) {
+        const char * fmt = schema.children[0]->format;
+        printf("  column format: %s\n", fmt ? fmt : "(null)");
+        /* "I" = uint32. ClickHouse maps DateTime -> arrow::uint32 (seconds). */
+        CHECK(fmt && fmt[0] == 'I' && fmt[1] == '\0',
+              "DateTime maps to arrow uint32 (matches ArrowStream)");
+    }
+
+    if (schema.release) schema.release(&schema);
+    if (stream.release) stream.release(&stream);
+    chdb_destroy_query_result(result);
+}
+
+int main(int argc, char ** argv)
+{
+    (void)argc; (void)argv;
+
+    /* Standard chdb connection on :memory:. */
+    char arg0[] = "clickhouse";
+    char arg1[] = "--multiquery";
+    char * args[] = {arg0, arg1};
+    chdb_connection * conn = chdb_connect(2, args);
+    if (!conn) {
+        fprintf(stderr, "chdb_connect failed\n");
+        return 1;
+    }
+
+    test_basic_select(*conn);
+    test_empty_result(*conn);
+    test_streaming(*conn);
+    test_string_as_binary(*conn);
+    test_datetime_is_uint32(*conn);
+
+    chdb_close_conn(conn);
+
+    printf("\n== summary: %d failed assertions ==\n", g_failed_assertions);
+    return g_failed_assertions == 0 ? 0 : 1;
+}

--- a/examples/runArrowQueryTest.sh
+++ b/examples/runArrowQueryTest.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"
+
+NANOARROW_VER="0.8.0"
+NANOARROW_DIR="nanoarrow-${NANOARROW_VER}"
+NANOARROW_TAR="apache-arrow-nanoarrow-${NANOARROW_VER}.tar.gz"
+NANOARROW_URL="https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-${NANOARROW_VER}/${NANOARROW_TAR}"
+
+# ---- Step 1: Download & extract nanoarrow if needed ----
+if [ ! -d "$NANOARROW_DIR" ]; then
+    echo "Downloading nanoarrow ${NANOARROW_VER}..."
+    curl -fSL -o "$NANOARROW_TAR" "$NANOARROW_URL"
+    mkdir -p "$NANOARROW_DIR"
+    tar xzf "$NANOARROW_TAR" -C "$NANOARROW_DIR" --strip-components=1
+    rm -f "$NANOARROW_TAR"
+fi
+
+NA_SRC="$NANOARROW_DIR/src"
+
+# ---- Step 2: Generate nanoarrow_config.h from template ----
+CONFIG_H="$NA_SRC/nanoarrow/nanoarrow_config.h"
+if [ ! -f "$CONFIG_H" ]; then
+    echo "Generating nanoarrow_config.h..."
+    sed -e 's/@NANOARROW_VERSION_MAJOR@/0/g' \
+        -e 's/@NANOARROW_VERSION_MINOR@/8/g' \
+        -e 's/@NANOARROW_VERSION_PATCH@/0/g' \
+        -e 's/@NANOARROW_VERSION@/0.8.0/g' \
+        -e 's/@NANOARROW_NAMESPACE_DEFINE@//g' \
+        "$NA_SRC/nanoarrow/nanoarrow_config.h.in" > "$CONFIG_H"
+fi
+
+# ---- Step 3: Compile ----
+echo "Compiling chdbArrowQueryTest..."
+
+CC="${CC:-cc}"
+CFLAGS="-std=c99 -O2 -Wall -Wno-unused-function"
+
+if [ "$(uname)" = "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH_VAR="DYLD_LIBRARY_PATH"
+else
+    LDD="ldd"
+    LIB_PATH_VAR="LD_LIBRARY_PATH"
+fi
+
+# Unlike chdbArrowStreamParse, this binary does NOT use the IPC path —
+# the new C ABI returns an ArrowArrayStream directly. nanoarrow IPC code
+# is therefore not needed; we only link the lightweight array/schema/view
+# helpers for value inspection.
+$CC $CFLAGS \
+    -I"$NA_SRC" \
+    -I../programs/local/ \
+    chdbArrowQueryTest.c \
+    "$NA_SRC/nanoarrow/common/array.c" \
+    "$NA_SRC/nanoarrow/common/schema.c" \
+    "$NA_SRC/nanoarrow/common/utils.c" \
+    -L.. -lchdb \
+    -o chdbArrowQueryTest
+
+echo "Build OK"
+export ${LIB_PATH_VAR}="$DIR/.."
+$LDD ./chdbArrowQueryTest
+
+echo ""
+echo "=== Run ==="
+./chdbArrowQueryTest

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -3,6 +3,7 @@ set (CLICKHOUSE_LOCAL_SOURCES
     ArrowSchema.cpp
     ArrowStreamWrapper.cpp
     ArrowTableReader.cpp
+    ChunkCollectorOutputFormat.cpp
     LocalServer.cpp
     EmbeddedServer.cpp
     ChdbClient.cpp
@@ -11,6 +12,7 @@ set (CLICKHOUSE_LOCAL_SOURCES
 if (NOT USE_PYTHON)
     set (CHDB_ARROW_SOURCES
         chdb-arrow.cpp
+        chdb-arrow-output.cpp
         ArrowStreamSource.cpp
         StorageArrowStream.cpp
         TableFunctionArrowStream.cpp
@@ -29,7 +31,6 @@ if (USE_PYTHON)
 
     set (CHDB_SOURCES
         chdb.cpp
-        ChunkCollectorOutputFormat.cpp
         FieldToPython.cpp
         ListScan.cpp
         LocalChdb.cpp

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -14,6 +14,7 @@
 #include <Common/Exception.h>
 
 #if USE_PYTHON
+#include <DataFrameQueryResult.h>
 #include <PythonTableCache.h>
 #include <PandasDataFrameBuilder.h>
 #include <pybind11/pybind11.h>
@@ -235,8 +236,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
         size_t storage_rows_read = local_connection->getCHDBProgress().read_rows;
         size_t storage_bytes_read = local_connection->getCHDBProgress().read_bytes;
 
-#if USE_PYTHON
-        if (format_str == "dataframe")
+        if (format_str == CHUNK_COLLECT_FORMAT_NAME)
         {
             auto res = std::make_unique<CHDB::ChunkQueryResult>(
                 std::move(collected_chunks),
@@ -246,10 +246,11 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
                 getProcessedBytes(),
                 storage_rows_read,
                 storage_bytes_read);
+#if USE_PYTHON
             python_table_cache->clear();
+#endif
             return res;
         }
-#endif
 
         auto res = std::make_unique<CHDB::MaterializedQueryResult>(
             CHDB::ResultBuffer(stealQueryOutputVector()),
@@ -350,8 +351,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
             size_t storage_bytes_read = local_connection->getCHDBProgress().read_bytes;
             const auto elapsed_time = getElapsedTime();
 
-#if USE_PYTHON
-            if (Poco::toLower(default_output_format) == "dataframe")
+            if (Poco::toLower(default_output_format) == CHUNK_COLLECT_FORMAT_NAME)
             {
                 auto rows_read = processed_rows - old_processed_rows;
                 auto chunk_result = std::make_unique<CHDB::ChunkQueryResult>(
@@ -363,14 +363,20 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
                     storage_rows_read - old_storage_rows_read,
                     storage_bytes_read - old_storage_bytes_read);
 
+#if USE_PYTHON
                 py::gil_scoped_acquire acquire;
                 CHDB::PandasDataFrameBuilder builder(*chunk_result);
                 py::handle df = builder.getDataFrame().release();
 
                 res = std::make_unique<CHDB::DataFrameQueryResult>(df, rows_read);
+#else
+                /// Non-Python build: hand raw chunks back so the Arrow C
+                /// Data Interface output path can export them without
+                /// IPC serialization.
+                res = std::move(chunk_result);
+#endif
             }
             else
-#endif
             {
                 auto * output_vec = stealQueryOutputVector();
                 bool has_output_data = output_vec && !output_vec->empty();

--- a/programs/local/DataFrameQueryResult.h
+++ b/programs/local/DataFrameQueryResult.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_PYTHON
+
+#include "QueryResult.h"
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace CHDB
+{
+
+/// pandas DataFrame-backed query result. Only built into USE_PYTHON wheels.
+/// Kept in its own header so QueryResult.h stays pybind11-free and can be
+/// included from non-Python translation units (e.g. chdb-arrow-output.cpp)
+/// without dragging Python.h into them.
+class DataFrameQueryResult : public QueryResult
+{
+public:
+    explicit DataFrameQueryResult(py::handle dataframe_, uint64_t rows_read)
+        : QueryResult(QueryResultType::RESULT_TYPE_DATAFRAME),
+        dataframe(dataframe_),
+        is_empty(rows_read == 0)
+    {}
+
+    bool isEmpty() const override { return is_empty; }
+
+    py::handle dataframe;
+    bool is_empty;
+};
+
+using DataFrameQueryResultPtr = std::unique_ptr<DataFrameQueryResult>;
+
+} // namespace CHDB
+
+#endif

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -1,8 +1,8 @@
 #include "EmbeddedServer.h"
 
+#include "ChunkCollectorOutputFormat.h"
 #if USE_PYTHON
 #include "TableFunctionPython.h"
-#include "ChunkCollectorOutputFormat.h"
 #else
 #include "StorageArrowStream.h"
 #include "TableFunctionArrowStream.h"
@@ -620,9 +620,8 @@ try
 
             registerDatabases();
             registerStorages();
-#if USE_PYTHON
             CHDB::registerDataFrameOutputFormat();
-#else
+#if !USE_PYTHON
             auto & storage_factory = StorageFactory::instance();
             registerStorageArrowStream(storage_factory);
 #endif

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -1,5 +1,6 @@
 #include "LocalChdb.h"
 #include "chdb-internal.h"
+#include "DataFrameQueryResult.h"
 #include "PandasDataFrameBuilder.h"
 #include "PythonImporter.h"
 #include "ChdbPyType.h"

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1,8 +1,8 @@
 #include "LocalServer.h"
 #include "chdb-internal.h"
 #include <Common/SignalHandlers.h>
-#if USE_PYTHON
 #include "ChunkCollectorOutputFormat.h"
+#if USE_PYTHON
 #include "TableFunctionPython.h"
 #else
 #include "StorageArrowStream.h"
@@ -728,9 +728,7 @@ try
             registerDatabases();
 
             registerStorages();
-#if USE_PYTHON
             CHDB::registerDataFrameOutputFormat();
-#endif
 
             registerDictionaries();
             registerDisks(/* global_skip_access_check= */ true);

--- a/programs/local/QueryResult.h
+++ b/programs/local/QueryResult.h
@@ -7,15 +7,11 @@
 #include "config.h"
 #include <base/types.h>
 
-#if USE_PYTHON
 #include <Processors/Chunk.h>
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
 namespace DB
 {
     class Block;
 }
-#endif
 
 namespace CHDB
 {
@@ -26,7 +22,8 @@ enum class QueryResultType : uint8_t
     RESULT_TYPE_STREAMING = 1,
     RESULT_TYPE_CHUNK = 2,
     RESULT_TYPE_DATAFRAME = 3,
-    RESULT_TYPE_NONE = 4
+    RESULT_TYPE_ARROW = 4,
+    RESULT_TYPE_NONE = 5
 };
 
 class QueryResult
@@ -58,6 +55,13 @@ public:
     {
         return false;
     }
+
+    /// Opaque per-stream state slot used by streaming-output binding code
+    /// (currently the Arrow C Data Interface output path) to persist a
+    /// converter, schema, and dictionary cache across fetches. The shared
+    /// pointer carries its own deleter so the StreamQueryResult destructor
+    /// releases the state without knowing its concrete type.
+    std::shared_ptr<void> private_data;
 };
 
 using ResultBuffer = std::unique_ptr<std::vector<char>>;
@@ -107,7 +111,9 @@ public:
     uint64_t storage_bytes_read;
 };
 
-#if USE_PYTHON
+/// Raw Chunk-bag query result. Produced by ChunkCollectorOutputFormat-backed
+/// runs, consumed by both the USE_PYTHON DataFrame builder and the libchdb
+/// Arrow C Data Interface output path. Available in both builds.
 class ChunkQueryResult : public QueryResult
 {
 public:
@@ -148,33 +154,9 @@ public:
     uint64_t storage_bytes_read;
 };
 
-class DataFrameQueryResult : public QueryResult
-{
-public:
-    explicit DataFrameQueryResult(
-        py::handle dataframe_,
-        uint64_t rows_read)
-        : QueryResult(QueryResultType::RESULT_TYPE_DATAFRAME),
-        dataframe(dataframe_),
-        is_empty(rows_read == 0)
-    {}
-
-    bool isEmpty() const override
-    {
-        return is_empty;
-    }
-
-    py::handle dataframe;
-    bool is_empty;
-};
-#endif
-
 using QueryResultPtr = std::unique_ptr<QueryResult>;
 using MaterializedQueryResultPtr = std::unique_ptr<MaterializedQueryResult>;
 using StreamQueryResultPtr = std::unique_ptr<StreamQueryResult>;
-#if USE_PYTHON
 using ChunkQueryResultPtr = std::unique_ptr<ChunkQueryResult>;
-using DataFrameQueryResultPtr = std::unique_ptr<DataFrameQueryResult>;
-#endif
 
 } // namespace CHDB

--- a/programs/local/chdb-arrow-output.cpp
+++ b/programs/local/chdb-arrow-output.cpp
@@ -1,0 +1,483 @@
+#include "chdb.h"
+#include "chdb-internal.h"
+#include "ChdbClient.h"
+#include "QueryResult.h"
+
+#include <Columns/IColumn.h>
+#include <Core/Block.h>
+#include <Core/ColumnsWithTypeAndName.h>
+#include <Processors/Chunk.h>
+#include <Processors/Formats/Impl/CHColumnToArrowColumn.h>
+
+#include <Common/Exception.h>
+
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+using namespace DB;
+
+namespace
+{
+
+/// Format name we pass to ChdbClient/ClientBase to divert query output
+/// into chunk-collection mode. Single source of truth lives in
+/// src/Client/ClientBase.h as DB::CHUNK_COLLECT_FORMAT_NAME.
+constexpr const char * kArrowConverterFormatName = "Arrow";
+
+CHColumnToArrowColumn::Settings buildConverterSettings(const chdb_arrow_options * options)
+{
+    CHColumnToArrowColumn::Settings settings;
+    /// Defaults align with the Layer-1 type contract (string_as_string=1,
+    /// low_cardinality_as_dictionary=0, unsupported_as_binary=0). DateTime
+    /// is left untouched on purpose: we keep the engine's native
+    /// DateTime -> arrow::uint32(seconds, tz-dropped) mapping so the new C
+    /// ABI behaves identically to format="ArrowStream" — bindings that
+    /// already consume ArrowStream don't need a second code path.
+    /// Callers that want timestamp(SECOND, tz) semantics can express that
+    /// in SQL via toDateTime64(col, 0, 'UTC').
+    settings.output_string_as_string = true;
+    settings.output_fixed_string_as_fixed_byte_array = true;
+    settings.low_cardinality_as_dictionary = false;
+    settings.use_signed_indexes_for_dictionary = false;
+    settings.use_64_bit_indexes_for_dictionary = false;
+    settings.output_date_as_uint16 = false;
+    settings.output_unsupported_types_as_binary = false;
+
+    if (options)
+    {
+        settings.output_string_as_string = options->string_as_string != 0;
+        settings.low_cardinality_as_dictionary = options->low_cardinality_as_dictionary != 0;
+        settings.output_unsupported_types_as_binary = options->unsupported_as_binary != 0;
+    }
+    return settings;
+}
+
+/// Build a chdb_result that exposes only metrics + error (no buffer payload).
+/// Out-of-band data is delivered through the Arrow stream the caller owns.
+chdb_result * makeMetricsResult(
+    double elapsed,
+    uint64_t rows_read,
+    uint64_t bytes_read,
+    uint64_t storage_rows_read,
+    uint64_t storage_bytes_read)
+{
+    auto * res = new CHDB::MaterializedQueryResult(
+        CHDB::ResultBuffer(),
+        elapsed,
+        rows_read,
+        bytes_read,
+        storage_rows_read,
+        storage_bytes_read);
+    return reinterpret_cast<chdb_result *>(res);
+}
+
+chdb_result * makeErrorResult(String message)
+{
+    return reinterpret_cast<chdb_result *>(new CHDB::MaterializedQueryResult(std::move(message)));
+}
+
+/// Releases for an ArrowArrayStream we synthesize for the one-batch fetch path.
+struct OneBatchPrivate
+{
+    std::shared_ptr<arrow::Schema> schema;
+    ArrowArray array{};
+    bool array_consumed = false;
+    String last_error;
+    std::shared_ptr<void> data_keepalive; /// Holds arrow::RecordBatch alive
+};
+
+void OneBatchRelease(ArrowArrayStream * stream)
+{
+    if (!stream)
+        return;
+    auto * priv = static_cast<OneBatchPrivate *>(stream->private_data);
+    if (priv)
+    {
+        if (priv->array.release)
+            priv->array.release(&priv->array);
+        delete priv;
+    }
+    stream->private_data = nullptr;
+    stream->release = nullptr;
+}
+
+int OneBatchGetSchema(ArrowArrayStream * stream, ArrowSchema * out)
+{
+    auto * priv = static_cast<OneBatchPrivate *>(stream->private_data);
+    if (!priv || !priv->schema)
+        return EINVAL;
+    auto status = arrow::ExportSchema(*priv->schema, out);
+    if (!status.ok())
+    {
+        priv->last_error = status.ToString();
+        return EIO;
+    }
+    return 0;
+}
+
+int OneBatchGetNext(ArrowArrayStream * stream, ArrowArray * out)
+{
+    auto * priv = static_cast<OneBatchPrivate *>(stream->private_data);
+    if (!priv)
+        return EINVAL;
+    if (priv->array_consumed || !priv->array.release)
+    {
+        std::memset(out, 0, sizeof(*out));
+        out->release = nullptr;
+        return 0;
+    }
+    /// Hand off ownership of the cached ArrowArray to the caller.
+    *out = priv->array;
+    std::memset(&priv->array, 0, sizeof(priv->array));
+    priv->array_consumed = true;
+    return 0;
+}
+
+const char * OneBatchGetLastError(ArrowArrayStream * stream)
+{
+    auto * priv = static_cast<OneBatchPrivate *>(stream->private_data);
+    return (priv && !priv->last_error.empty()) ? priv->last_error.c_str() : nullptr;
+}
+
+void initOneBatchStream(ArrowArrayStream * stream, std::unique_ptr<OneBatchPrivate> priv)
+{
+    stream->get_schema = OneBatchGetSchema;
+    stream->get_next = OneBatchGetNext;
+    stream->get_last_error = OneBatchGetLastError;
+    stream->release = OneBatchRelease;
+    stream->private_data = priv.release();
+}
+
+/// Streaming context held by StreamQueryResult::private_data to persist
+/// the converter, schema, and dictionary cache across chdb_stream_fetch_arrow
+/// calls. Required for schema/dict stability per Arrow C Data Interface.
+struct ArrowStreamingState
+{
+    chdb_arrow_options options;
+    std::unique_ptr<CHColumnToArrowColumn> converter;
+    std::shared_ptr<arrow::Schema> schema;
+    ColumnsWithTypeAndName header_columns;
+    bool header_initialized = false;
+    /// Cached dictionary values shared across batches. Only used when
+    /// low_cardinality_as_dictionary=1; required for cross-chunk stability.
+    std::unordered_map<std::string, MutableColumnPtr> cached_dictionary_values;
+    std::mutex mutex;
+};
+
+void ensureConverterInitialized(
+    ArrowStreamingState & state,
+    const ColumnsWithTypeAndName & header,
+    const Chunk * first_chunk)
+{
+    if (state.header_initialized)
+        return;
+
+    state.header_columns = header;
+    auto settings = buildConverterSettings(&state.options);
+    state.converter = std::make_unique<CHColumnToArrowColumn>(
+        state.header_columns,
+        kArrowConverterFormatName,
+        settings);
+    state.converter->initializeArrowSchema(first_chunk);
+    state.schema = state.converter->getArrowSchema();
+    state.header_initialized = true;
+}
+
+/// Materialized path: collect all chunks, build a single arrow::Table, and
+/// export it as a RecordBatchReader-backed ArrowArrayStream.
+chdb_result * runMaterializedArrowQuery(
+    chdb_conn * connection,
+    const char * query,
+    size_t query_len,
+    ArrowArrayStream * out_stream,
+    const chdb_arrow_options * options)
+{
+    if (!out_stream)
+        return makeErrorResult("Unexpected null out_stream");
+    if (!query)
+        return makeErrorResult("Unexpected null query");
+
+    /// Ensure caller-supplied stream is zeroed; on error we leave it released.
+    std::memset(out_stream, 0, sizeof(*out_stream));
+
+    auto * client = static_cast<DB::ChdbClient *>(connection->server);
+    auto query_result = client->executeMaterializedQuery(
+        query, query_len,
+        CHUNK_COLLECT_FORMAT_NAME, std::strlen(CHUNK_COLLECT_FORMAT_NAME));
+
+    if (!query_result)
+        return makeErrorResult("Query processing failed");
+
+    if (!query_result->getError().empty())
+        return makeErrorResult(query_result->getError());
+
+    if (query_result->getType() != CHDB::QueryResultType::RESULT_TYPE_CHUNK)
+        return makeErrorResult("Expected chunk-collecting result for Arrow output");
+
+    auto * chunk_result = static_cast<CHDB::ChunkQueryResult *>(query_result.get());
+    if (!chunk_result->header)
+        return makeErrorResult("Missing result header for Arrow output");
+
+    const auto & header_columns = chunk_result->header->getColumnsWithTypeAndName();
+
+    auto settings = buildConverterSettings(options);
+    auto converter = std::make_unique<CHColumnToArrowColumn>(
+        header_columns,
+        kArrowConverterFormatName,
+        settings);
+
+    /// Chunks pass through untouched — no DateTime widening, no
+    /// per-chunk castColumn allocation. Engine column types map 1:1
+    /// onto the CHColumnToArrowColumn kernel just like format="ArrowStream".
+    std::vector<Chunk> chunks_for_export = std::move(chunk_result->chunks);
+
+    std::shared_ptr<arrow::Table> table;
+    try
+    {
+        if (chunks_for_export.empty())
+        {
+            /// Empty result: pass a single zero-row probe chunk so the
+            /// converter can derive the arrow schema, then use Table::MakeEmpty
+            /// to synthesize a properly-shaped zero-row table.
+            MutableColumns empty_cols;
+            empty_cols.reserve(header_columns.size());
+            for (const auto & h : header_columns)
+                empty_cols.emplace_back(h.type->createColumn());
+            std::vector<Chunk> probe;
+            probe.emplace_back(std::move(empty_cols), 0);
+            converter->initializeArrowSchema(&probe.front());
+            auto schema = converter->getArrowSchema();
+            auto empty_table = arrow::Table::MakeEmpty(schema);
+            if (!empty_table.ok())
+                return makeErrorResult(empty_table.status().ToString());
+            table = std::move(empty_table).ValueOrDie();
+        }
+        else
+        {
+            converter->chChunkToArrowTable(table, chunks_for_export, header_columns.size());
+        }
+    }
+    catch (const Exception & e)
+    {
+        return makeErrorResult(getExceptionMessage(e, false));
+    }
+    catch (const std::exception & e)
+    {
+        return makeErrorResult(e.what());
+    }
+
+    if (!table)
+        return makeErrorResult("CHColumnToArrowColumn returned null table");
+
+    auto reader = std::make_shared<arrow::TableBatchReader>(table);
+
+    auto status = arrow::ExportRecordBatchReader(reader, out_stream);
+    if (!status.ok())
+        return makeErrorResult(status.ToString());
+
+    return makeMetricsResult(
+        chunk_result->elapsed,
+        chunk_result->rows_read,
+        chunk_result->bytes_read,
+        chunk_result->storage_rows_read,
+        chunk_result->storage_bytes_read);
+}
+
+} // namespace
+
+extern "C" {
+
+chdb_result * chdb_query_arrow(
+    chdb_connection conn, const char * query,
+    chdb_arrow_stream out_stream, const chdb_arrow_options * options)
+{
+    return chdb_query_arrow_n(conn, query, query ? std::strlen(query) : 0, out_stream, options);
+}
+
+chdb_result * chdb_query_arrow_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    chdb_arrow_stream out_stream, const chdb_arrow_options * options)
+{
+    if (!conn)
+        return makeErrorResult("Unexpected null connection");
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return makeErrorResult("Invalid or closed connection");
+
+    try
+    {
+        auto * raw_stream = reinterpret_cast<ArrowArrayStream *>(out_stream);
+        return runMaterializedArrowQuery(connection, query, query_len, raw_stream, options);
+    }
+    catch (const Exception & e)
+    {
+        return makeErrorResult(getExceptionMessage(e, false));
+    }
+    catch (const std::exception & e)
+    {
+        return makeErrorResult(e.what());
+    }
+    catch (...)
+    {
+        return makeErrorResult(DB::getCurrentExceptionMessage(true));
+    }
+}
+
+chdb_result * chdb_stream_query_arrow(
+    chdb_connection conn, const char * query,
+    const chdb_arrow_options * options)
+{
+    return chdb_stream_query_arrow_n(conn, query, query ? std::strlen(query) : 0, options);
+}
+
+chdb_result * chdb_stream_query_arrow_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    const chdb_arrow_options * options)
+{
+    if (!conn)
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Unexpected null connection"));
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Invalid or closed connection"));
+
+    try
+    {
+        auto * client = static_cast<DB::ChdbClient *>(connection->server);
+        auto query_result = client->executeStreamingInit(
+            query, query_len,
+            CHUNK_COLLECT_FORMAT_NAME, std::strlen(CHUNK_COLLECT_FORMAT_NAME));
+        if (!query_result)
+            return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Streaming init failed"));
+
+        if (query_result->getType() != CHDB::QueryResultType::RESULT_TYPE_STREAMING)
+            return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Unexpected non-streaming result for Arrow streaming"));
+
+        auto state = std::make_shared<ArrowStreamingState>();
+        if (options)
+            state->options = *options;
+        else
+            state->options = chdb_arrow_options{0, 0, 1};
+
+        auto * stream_result = static_cast<CHDB::StreamQueryResult *>(query_result.get());
+        stream_result->private_data = std::static_pointer_cast<void>(state);
+
+        return reinterpret_cast<chdb_result *>(query_result.release());
+    }
+    catch (const Exception & e)
+    {
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult(getExceptionMessage(e, false)));
+    }
+    catch (const std::exception & e)
+    {
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult(e.what()));
+    }
+    catch (...)
+    {
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult(DB::getCurrentExceptionMessage(true)));
+    }
+}
+
+chdb_state chdb_stream_fetch_arrow(
+    chdb_connection conn, chdb_result * stream_result, chdb_arrow_stream out_batch)
+{
+    if (!conn || !stream_result || !out_batch)
+        return CHDBError;
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return CHDBError;
+
+    auto * raw_out = reinterpret_cast<ArrowArrayStream *>(out_batch);
+    std::memset(raw_out, 0, sizeof(*raw_out));
+
+    auto * generic_result = reinterpret_cast<CHDB::QueryResult *>(stream_result);
+    if (generic_result->getType() != CHDB::QueryResultType::RESULT_TYPE_STREAMING)
+        return CHDBError;
+
+    auto * stream = static_cast<CHDB::StreamQueryResult *>(generic_result);
+    auto state = std::static_pointer_cast<ArrowStreamingState>(stream->private_data);
+    if (!state)
+        return CHDBError;
+
+    auto * client = static_cast<DB::ChdbClient *>(connection->server);
+    if (!client->hasStreamingQuery())
+        return CHDBError;
+
+    try
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+
+        auto iter_result = client->executeStreamingIterate(stream, false);
+        if (!iter_result)
+            return CHDBError;
+
+        if (!iter_result->getError().empty())
+            return CHDBError;
+
+        if (iter_result->getType() != CHDB::QueryResultType::RESULT_TYPE_CHUNK)
+        {
+            /// End of stream: emit an empty one-batch stream. If a schema
+            /// has been observed already, expose it via get_schema so the
+            /// consumer can still inspect column metadata after EOS.
+            auto priv = std::make_unique<OneBatchPrivate>();
+            priv->schema = state->schema;
+            initOneBatchStream(raw_out, std::move(priv));
+            return CHDBSuccess;
+        }
+
+        auto * chunk_iter = static_cast<CHDB::ChunkQueryResult *>(iter_result.get());
+        if (!chunk_iter->header || chunk_iter->chunks.empty())
+        {
+            auto priv = std::make_unique<OneBatchPrivate>();
+            priv->schema = state->schema;
+            initOneBatchStream(raw_out, std::move(priv));
+            return CHDBSuccess;
+        }
+
+        const auto & src_header = chunk_iter->header->getColumnsWithTypeAndName();
+        ensureConverterInitialized(*state, src_header, &chunk_iter->chunks.front());
+
+        std::vector<Chunk> batch_chunks = std::move(chunk_iter->chunks);
+
+        std::shared_ptr<arrow::Table> table;
+        state->converter->chChunkToArrowTable(table, batch_chunks, state->header_columns.size());
+        if (!table)
+            return CHDBError;
+
+        /// Combine into a single record batch for one fetch == one batch.
+        auto batches_result = table->CombineChunksToBatch();
+        if (!batches_result.ok())
+            return CHDBError;
+        auto batch = std::move(batches_result).ValueOrDie();
+
+        auto priv = std::make_unique<OneBatchPrivate>();
+        priv->schema = state->schema;
+        auto status = arrow::ExportRecordBatch(*batch, &priv->array, nullptr);
+        if (!status.ok())
+            return CHDBError;
+        /// Keep the batch alive so the exported buffers stay valid until the
+        /// caller releases the one-batch stream. ExportRecordBatch already
+        /// keeps the underlying buffers alive via the array release callback,
+        /// but holding the RecordBatch shared_ptr is a defensive belt-and-braces.
+        priv->data_keepalive = batch;
+
+        initOneBatchStream(raw_out, std::move(priv));
+        return CHDBSuccess;
+    }
+    catch (...)
+    {
+        DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+        return CHDBError;
+    }
+}
+
+} // extern "C"

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -47,10 +47,25 @@ namespace CHDB
 extern "C"
 {
     extern chdb_state chdb_arrow_scan(chdb_connection, const char *, chdb_arrow_stream);
+    extern chdb_result * chdb_query_arrow(chdb_connection, const char *, chdb_arrow_stream, const chdb_arrow_options *);
+    extern chdb_result * chdb_query_arrow_n(chdb_connection, const char *, size_t, chdb_arrow_stream, const chdb_arrow_options *);
+    extern chdb_result * chdb_stream_query_arrow(chdb_connection, const char *, const chdb_arrow_options *);
+    extern chdb_result * chdb_stream_query_arrow_n(chdb_connection, const char *, size_t, const chdb_arrow_options *);
+    extern chdb_state chdb_stream_fetch_arrow(chdb_connection, chdb_result *, chdb_arrow_stream);
 }
 
+/// Force-link references: chdb-arrow.cpp.o and chdb-arrow-output.cpp.o each
+/// live in their own translation unit and have no internal callers, so the
+/// linker would discard them under --gc-sections / .a archive semantics
+/// when libchdb.so is linked from main.cpp's perspective. Taking the
+/// address of one entry point from each .o keeps the whole .o alive.
 [[maybe_unused]] void * force_link_arrow_functions[] = {
-    reinterpret_cast<void*>(chdb_arrow_scan)
+    reinterpret_cast<void*>(chdb_arrow_scan),
+    reinterpret_cast<void*>(chdb_query_arrow),
+    reinterpret_cast<void*>(chdb_query_arrow_n),
+    reinterpret_cast<void*>(chdb_stream_query_arrow),
+    reinterpret_cast<void*>(chdb_stream_query_arrow_n),
+    reinterpret_cast<void*>(chdb_stream_fetch_arrow)
 };
 #endif
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -390,6 +390,97 @@ CHDB_EXPORT const char * chdb_result_error(chdb_result * result);
 //===--------------------------------------------------------------------===//
 
 /**
+ * Options controlling Arrow C Data Interface output (chdb_query_arrow family).
+ * Pass NULL to any chdb_query_arrow / chdb_stream_query_arrow variant for
+ * the default contract (unsupported_as_binary=0,
+ * low_cardinality_as_dictionary=0, string_as_string=1).
+ *
+ * Type mapping note: DateTime columns export as Arrow uint32 (Unix
+ * seconds), matching ClickHouse's format="ArrowStream" behavior — the
+ * timezone is not carried on the Arrow type. Callers that want a
+ * timezone-tagged Arrow timestamp should request DateTime64 in SQL,
+ * e.g. `SELECT toDateTime64(col, 0, 'UTC')`, which the kernel maps to
+ * arrow::timestamp(SECOND, 'UTC').
+ *
+ * - unsupported_as_binary: 0 (default) throws UNKNOWN_TYPE for types with
+ *   no faithful Arrow mapping (JSON/Object, Dynamic, AggregateFunction).
+ *   1 silently degrades them to arrow::binary() like the engine default.
+ * - low_cardinality_as_dictionary: 0 (default) materializes LowCardinality
+ *   columns to their base type T. 1 emits an Arrow dictionary array
+ *   (requires consumer to handle cross-batch dictionary stability).
+ * - string_as_string: 1 (default) emits Arrow utf8 for String columns.
+ *   0 emits Arrow binary.
+ */
+typedef struct chdb_arrow_options
+{
+    int unsupported_as_binary;
+    int low_cardinality_as_dictionary;
+    int string_as_string;
+} chdb_arrow_options;
+
+/**
+ * Executes a query and exports the entire result as an Arrow C Data
+ * Interface stream into the caller-allocated out_stream. Zero-copy where
+ * possible (no IPC serialization, no lz4 round-trip).
+ *
+ * Ownership: out_stream is filled and ownership of its release() callback
+ * transfers to the caller. The underlying ClickHouse buffers are kept
+ * alive by the stream's private_data and are released atomically when the
+ * caller invokes out_stream->release(out_stream).
+ *
+ * @param conn Active connection
+ * @param query Null-terminated SQL query
+ * @param out_stream Caller-allocated ArrowArrayStream (struct from arrow/c/abi.h)
+ * @param options Knobs controlling type mapping; pass NULL for defaults
+ * @return chdb_result with elapsed/rows_read/bytes_read/storage_* metrics or
+ *         an error (buffer/length are NULL/0 — the data is in out_stream)
+ */
+CHDB_EXPORT chdb_result * chdb_query_arrow(
+    chdb_connection conn, const char * query,
+    chdb_arrow_stream out_stream, const chdb_arrow_options * options);
+
+/**
+ * Binary-safe variant of chdb_query_arrow with explicit query length.
+ */
+CHDB_EXPORT chdb_result * chdb_query_arrow_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    chdb_arrow_stream out_stream, const chdb_arrow_options * options);
+
+/**
+ * Initializes a streaming Arrow query and returns a stream handle. Each
+ * subsequent chdb_stream_fetch_arrow() call pulls one record batch with a
+ * stable schema across the lifetime of the stream. Cancel/destroy via the
+ * shared chdb_stream_cancel_query / chdb_destroy_query_result functions.
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow(
+    chdb_connection conn, const char * query,
+    const chdb_arrow_options * options);
+
+/**
+ * Binary-safe variant of chdb_stream_query_arrow with explicit query length.
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    const chdb_arrow_options * options);
+
+/**
+ * Pulls the next record batch from a streaming Arrow query into the
+ * caller-allocated out_batch (a single-batch ArrowArrayStream). When the
+ * stream is exhausted out_batch->get_next() will return a released array
+ * on first call. Schema and (if enabled) LowCardinality dictionaries stay
+ * stable across all fetches because the converter and cached dictionary
+ * values are persisted on the stream handle.
+ *
+ * @param conn Active connection
+ * @param stream_result Stream handle from chdb_stream_query_arrow{,_n}
+ * @param out_batch Caller-allocated ArrowArrayStream filled with one batch
+ * @return CHDBSuccess on success, CHDBError on protocol error
+ */
+CHDB_EXPORT chdb_state chdb_stream_fetch_arrow(
+    chdb_connection conn, chdb_result * stream_result,
+    chdb_arrow_stream out_batch);
+
+/**
  * Registers an Arrow stream as an arrow stream table function with the given name
  * @param conn The connection on which to execute the registration
  * @param table_name Name to register for the arrow stream table function

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -173,10 +173,13 @@ namespace ErrorCodes
     extern const int TIMEOUT_EXCEEDED;
 }
 
-#if USE_PYTHON
-/// Custom DataFrame format creator function pointer
+/// Chunk-collecting output-format creator: registered by the wrapper
+/// (programs/local/) so that ClientBase can dispatch the magic
+/// "dataframe" output format to a raw Chunk-collection sink instead of
+/// any serializing IOutputFormat. Both USE_PYTHON=1 (DataFrame) and
+/// USE_PYTHON=0 (Arrow C Data Interface) consumers register the same
+/// ChunkCollectorOutputFormat creator here.
 static CustomOutputFormatCreator g_dataframe_format_creator = nullptr;
-#endif
 
 }
 
@@ -678,8 +681,7 @@ try
 {
     if (!output_format)
     {
-#if USE_PYTHON
-        if (Poco::toLower(default_output_format) == "dataframe")
+        if (Poco::toLower(default_output_format) == CHUNK_COLLECT_FORMAT_NAME)
         {
             auto creator = getDataFrameFormatCreator();
             if (creator)
@@ -693,7 +695,6 @@ try
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "DataFrame output format creator not set");
             }
         }
-#endif
 
         /// Ignore all results when fuzzing as they can be huge.
         if (query_fuzzer_runs)
@@ -4322,7 +4323,6 @@ void ClientBase::showClientVersion()
     output_stream << VERSION_NAME << " " + getName() + " version " << VERSION_STRING << VERSION_OFFICIAL << "." << std::endl;
 }
 
-#if USE_PYTHON
 void ClientBase::setDataFrameFormatCreator(CustomOutputFormatCreator creator)
 {
     g_dataframe_format_creator = std::move(creator);
@@ -4332,6 +4332,5 @@ CustomOutputFormatCreator ClientBase::getDataFrameFormatCreator()
 {
     return g_dataframe_format_creator;
 }
-#endif
 
 }

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -105,10 +105,28 @@ struct StreamingQueryContext
     StreamingQueryContext() = default;
 };
 
-#if USE_PYTHON
-/// Function pointer type for creating custom output formats (e.g. DataFrame)
+/// Function pointer type for creating custom output formats that intercept
+/// query output and hand the raw Chunks back to the caller (e.g. DataFrame
+/// builder for USE_PYTHON, Arrow C Data Interface for the non-Python
+/// libchdb). Always declared so that both builds share a single seam.
 using CustomOutputFormatCreator = std::function<std::shared_ptr<IOutputFormat>(SharedHeader, std::vector<Chunk> &)>;
-#endif
+
+/// Magic output-format name that diverts a query's output away from
+/// FormatFactory serialization and into ClientBase::collected_chunks for
+/// in-memory consumption by the wrapper layer.
+///
+/// The string value is "dataframe" purely for historical reasons: when
+/// chdb first added this seam it had only one consumer — the Python
+/// pandas DataFrame builder, and the user-facing `chdb.query(sql,
+/// "dataframe")` contract has shipped under that name. The mechanism
+/// itself has nothing to do with DataFrames: it merely hands the
+/// already-typed std::vector<Chunk> back to the caller, who then
+/// decides what to render — pandas DataFrame for the Python wheel,
+/// Arrow C Data Interface stream for libchdb's chdb_query_arrow.
+///
+/// All ClientBase / ChdbClient / libchdb call sites must reference this
+/// constant rather than embedding the literal "dataframe" string.
+inline constexpr const char * CHUNK_COLLECT_FORMAT_NAME = "dataframe";
 
 /**
  * The base class which encapsulates the core functionality of a client.
@@ -378,13 +396,13 @@ public:
 
     String appendSmileyIfNeeded(const String & prompt);
 
-#if USE_PYTHON
-    /// Set custom DataFrame format creator
+    /// Register the Chunk-collecting output-format creator that backs both
+    /// the Python DataFrame path and the C-ABI Arrow output path. When a
+    /// creator is registered, queries whose default output format is the
+    /// magic CustomOutputFormatName() string skip serialization and route
+    /// raw Chunks into collected_chunks via the creator-returned format.
     static void setDataFrameFormatCreator(CustomOutputFormatCreator creator);
-
-    /// Get custom DataFrame format creator
     static CustomOutputFormatCreator getDataFrameFormatCreator();
-#endif
 
     /// Should be one of the first, to be destroyed the last,
     /// since other members can use them.

--- a/tests/test_arrow_c_data_output.py
+++ b/tests/test_arrow_c_data_output.py
@@ -1,0 +1,224 @@
+#!python3
+"""
+Tests for chdb_query_arrow / chdb_stream_query_arrow / chdb_stream_fetch_arrow.
+
+These tests call the non-Python libchdb.so directly via ctypes, decode the
+Arrow C Data Interface stream with pyarrow's `_import_from_c`, and value-check
+the result.
+
+Requires libchdb.so built from a NOT USE_PYTHON configuration with the new
+arrow symbols. If libchdb.so is missing or built without them, the tests are
+skipped.
+"""
+
+import ctypes
+import os
+import shutil
+import unittest
+
+import pyarrow as pa
+
+
+def _candidate_libchdb_paths():
+    here = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(here)
+    names = ["libchdb.so", "libchdb.dylib"]
+    yield from (os.path.join(project_root, n) for n in names)
+    yield from (os.path.join(project_root, "buildlib", n) for n in names)
+    on_path = shutil.which("libchdb.so")
+    if on_path:
+        yield on_path
+
+
+def _find_libchdb_path():
+    for path in _candidate_libchdb_paths():
+        if os.path.exists(path):
+            return path
+    return None
+
+
+_LIBCHDB_PATH = _find_libchdb_path()
+
+
+class ArrowArrayStruct(ctypes.Structure):
+    pass
+
+
+# ArrowArrayStream from arrow/c/abi.h — opaque to ctypes; we only need its
+# address. pyarrow will dereference it via _import_from_c.
+class ArrowArrayStream(ctypes.Structure):
+    _fields_ = [
+        # Callbacks (pointers). Treated as opaque void*.
+        ("get_schema", ctypes.c_void_p),
+        ("get_next", ctypes.c_void_p),
+        ("get_last_error", ctypes.c_void_p),
+        ("release", ctypes.c_void_p),
+        ("private_data", ctypes.c_void_p),
+    ]
+
+
+class ChdbArrowOptions(ctypes.Structure):
+    _fields_ = [
+        ("unsupported_as_binary", ctypes.c_int),
+        ("low_cardinality_as_dictionary", ctypes.c_int),
+        ("string_as_string", ctypes.c_int),
+    ]
+
+
+def _bind(lib):
+    """Bind argtypes/restypes for the symbols we use."""
+    lib.chdb_connect.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+    lib.chdb_connect.restype = ctypes.c_void_p
+    lib.chdb_close_conn.argtypes = [ctypes.c_void_p]
+    lib.chdb_close_conn.restype = None
+
+    lib.chdb_query_arrow.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_void_p
+    ]
+    lib.chdb_query_arrow.restype = ctypes.c_void_p
+
+    lib.chdb_stream_query_arrow.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p
+    ]
+    lib.chdb_stream_query_arrow.restype = ctypes.c_void_p
+    lib.chdb_stream_fetch_arrow.argtypes = [
+        ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
+    ]
+    lib.chdb_stream_fetch_arrow.restype = ctypes.c_int
+
+    lib.chdb_destroy_query_result.argtypes = [ctypes.c_void_p]
+    lib.chdb_destroy_query_result.restype = None
+    lib.chdb_result_error.argtypes = [ctypes.c_void_p]
+    lib.chdb_result_error.restype = ctypes.c_char_p
+
+
+LIBCHDB = None
+if _LIBCHDB_PATH is not None:
+    _lib = ctypes.CDLL(_LIBCHDB_PATH)
+    if hasattr(_lib, "chdb_query_arrow"):
+        LIBCHDB = _lib
+        _bind(LIBCHDB)
+
+
+@unittest.skipUnless(LIBCHDB is not None,
+                     f"libchdb.so with chdb_query_arrow not found "
+                     f"(searched {_LIBCHDB_PATH!r})")
+class TestArrowCDataOutput(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # chdb_connect() returns chdb_connection* (i.e. chdb_conn**).
+        # All other APIs take chdb_connection (chdb_conn*), so we dereference
+        # one level when calling them.
+        argv = (ctypes.c_char_p * 2)(b"clickhouse", b"--multiquery")
+        cls.conn_pp = LIBCHDB.chdb_connect(2, argv)
+        assert cls.conn_pp, "chdb_connect failed"
+        # Read the inner chdb_connection out of the chdb_connection* slot.
+        cls.conn = ctypes.c_void_p.from_address(cls.conn_pp).value
+
+    @classmethod
+    def tearDownClass(cls):
+        LIBCHDB.chdb_close_conn(cls.conn_pp)
+
+    def _query_arrow_table(self, sql, opts=None):
+        """Run sql via the new C ABI and return a pyarrow.Table."""
+        stream = ArrowArrayStream()
+        # `conn` is a chdb_connection* (pointer-to-pointer-to-struct). We
+        # pass it through as-is — the C side dereferences once internally.
+        opts_ptr = ctypes.byref(opts) if opts else None
+        result = LIBCHDB.chdb_query_arrow(
+            self.conn,
+            sql.encode("utf-8"),
+            ctypes.byref(stream),
+            opts_ptr,
+        )
+        err = LIBCHDB.chdb_result_error(result)
+        if err:
+            LIBCHDB.chdb_destroy_query_result(result)
+            raise RuntimeError(err.decode())
+
+        try:
+            stream_ptr = ctypes.addressof(stream)
+            reader = pa.RecordBatchReader._import_from_c(stream_ptr)
+            return reader.read_all()
+        finally:
+            LIBCHDB.chdb_destroy_query_result(result)
+
+    def test_integers_value_correctness(self):
+        sql = "SELECT number AS n FROM numbers(100)"
+        tbl = self._query_arrow_table(sql)
+        self.assertEqual(tbl.schema.names, ["n"])
+        self.assertEqual(tbl.num_rows, 100)
+        flat = tbl.column("n").combine_chunks().to_pylist()
+        self.assertEqual(flat, list(range(100)))
+
+    def test_string_default_is_utf8(self):
+        sql = "SELECT 'hello' AS s"
+        tbl = self._query_arrow_table(sql)
+        self.assertEqual(tbl.schema.field(0).type, pa.string())
+
+    def test_string_as_binary_when_disabled(self):
+        opts = ChdbArrowOptions(0, 0, 0)  # string_as_string=0
+        tbl = self._query_arrow_table("SELECT 'hello' AS s", opts)
+        self.assertEqual(tbl.schema.field(0).type, pa.binary())
+
+    def test_datetime_is_uint32(self):
+        # The new C ABI matches ClickHouse format="ArrowStream" — DateTime
+        # exports as raw uint32 (Unix seconds). Callers that want a
+        # timezone-tagged timestamp should write toDateTime64 in SQL.
+        sql = "SELECT toDateTime('2024-01-02 03:04:05','UTC') AS dt"
+        tbl = self._query_arrow_table(sql)
+        self.assertEqual(tbl.schema.field(0).type, pa.uint32())
+
+    def test_datetime64_maps_to_timestamp(self):
+        # The kernel's DateTime64 path produces arrow::timestamp(unit, tz).
+        sql = "SELECT toDateTime64('2024-01-02 03:04:05', 0, 'UTC') AS dt"
+        tbl = self._query_arrow_table(sql)
+        ty = tbl.schema.field(0).type
+        self.assertTrue(pa.types.is_timestamp(ty), f"expected timestamp, got {ty}")
+        self.assertEqual(ty.unit, "s")
+        self.assertEqual(ty.tz, "UTC")
+
+    def test_empty_result(self):
+        tbl = self._query_arrow_table(
+            "SELECT number FROM numbers(10) WHERE number > 100")
+        self.assertEqual(tbl.num_rows, 0)
+        self.assertEqual(tbl.schema.names, ["number"])
+
+    def test_low_cardinality_materialized_by_default(self):
+        sql = "SELECT toLowCardinality(toString(number % 3)) AS lc FROM numbers(10)"
+        tbl = self._query_arrow_table(sql)
+        # Default low_cardinality_as_dictionary=0 -> materialized to utf8
+        self.assertEqual(tbl.schema.field(0).type, pa.string())
+
+    def test_streaming_total_rows_match(self):
+        # Use the streaming API and assert total row count equals materialized path.
+        sql = "SELECT number FROM numbers(1000)"
+        stream_result = LIBCHDB.chdb_stream_query_arrow(
+            self.conn, sql.encode("utf-8"), None)
+        err = LIBCHDB.chdb_result_error(stream_result)
+        if err:
+            LIBCHDB.chdb_destroy_query_result(stream_result)
+            self.fail(err.decode())
+
+        try:
+            total_rows = 0
+            for _ in range(2048):  # safety bound
+                batch = ArrowArrayStream()
+                state = LIBCHDB.chdb_stream_fetch_arrow(
+                    self.conn, stream_result, ctypes.byref(batch))
+                if state != 0:
+                    break
+                ptr = ctypes.addressof(batch)
+                reader = pa.RecordBatchReader._import_from_c(ptr)
+                tbl = reader.read_all()
+                if tbl.num_rows == 0:
+                    break
+                total_rows += tbl.num_rows
+        finally:
+            LIBCHDB.chdb_destroy_query_result(stream_result)
+
+        self.assertEqual(total_rows, 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an **Arrow C Data Interface** output API to the C ABI (closes #15), so language bindings (chdb-node, chdb-go, chdb-rust, pg_clickhouse) can get query results as a zero-copy Arrow C Data Interface stream instead of going through `ArrowStream` IPC serialization.

New symbols (existing ABI untouched):
- `chdb_query_arrow` / `chdb_query_arrow_n`
- `chdb_stream_query_arrow` / `chdb_stream_query_arrow_n` / `chdb_stream_fetch_arrow`
- `chdb_arrow_options` (knobs below)

The same `CHColumnToArrowColumn` kernel is reused — only the tail switches from the IPC writer to `arrow::ExportRecordBatchReader` / `ExportRecordBatch`.

## Type mapping (matches `format="ArrowStream"` exactly)

Bindings that already consume `ArrowStream` need no second code path:

- `String` → `utf8` (`string_as_string=1` default; pass `0` for binary)
- `LowCardinality` → base type `T` materialized (`low_cardinality_as_dictionary=0` default; pass `1` for an Arrow dictionary)
- Unmappable types → throw `UNKNOWN_TYPE` by default (`unsupported_as_binary=0`; pass `1` to degrade to `arrow::binary()`)
- `DateTime` → `uint32` (Unix seconds; tz dropped by the kernel). For a tz-tagged timestamp request `DateTime64` in SQL, e.g. `toDateTime64(col, 0, 'UTC')` → `timestamp(SECOND, tz)`.

## Wrapper-layer changes (`programs/local/`, `src/Client/`)

- Generalize the `CustomOutputFormatCreator` seam in `ClientBase` out of `#if USE_PYTHON` so the chunk-collecting output format works in the `libchdb` (non-Python) build too. Introduce `DB::CHUNK_COLLECT_FORMAT_NAME` (`"dataframe"`) as the single source of truth for the magic format name (literal kept for `chdb.query` API compatibility).
- Move `ChunkCollectorOutputFormat.cpp` to the always-built source set; call `registerDataFrameOutputFormat()` from both `LocalServer.cpp` and `EmbeddedServer.cpp` unconditionally.
- Make `ChunkQueryResult` always-available; extract the pybind11-using `DataFrameQueryResult` into its own header so `QueryResult.h` stays Python-free and `chdb-arrow-output.cpp` can include it cleanly.
- Add a `private_data` slot on `StreamQueryResult` to persist the converter, schema, and LowCardinality dictionary cache across fetches.
- Force-link the new symbols from `chdb.cpp` so `ld --gc-sections` does not discard `chdb-arrow-output.cpp.o` from `libchdb.so`.

### Correctness note (found during end-to-end verification)

Empty-result path uses `arrow::Table::MakeEmpty(schema)` — passing a zero-element `ChunkedArray` vector to `Table::Make` yields a malformed table that later trips a libc++ vector hardening assertion in the `RecordBatchReader`. A throw-away probe chunk built from the header is still required so the converter can derive the schema.

## Tests (run end-to-end against a `libchdb.so` built with `ENABLE_PYTHON=0`)

- `examples/chdbArrowQueryTest.c` — 5 tests via `examples/runArrowQueryTest.sh`, wired into all four wheel-build CI workflows: basic SELECT, empty result, multi-batch streaming, `string_as_string=0` (binary vs utf8), `DateTime → uint32` (ArrowStream parity). All pass.
- `tests/test_arrow_c_data_output.py` — 8 ctypes-driven tests, auto-discovered by `tests/run_all.py`: integer correctness, string utf8 default, string-as-binary opt-in, `DateTime` uint32, `DateTime64 → timestamp(SECOND, tz)`, empty result, LowCardinality materialization, streaming row-count match. All pass.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
