### PR TITLE
Zero-copy Arrow string scan + GIL/NUL correctness fixes

### DIFF
--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -73,8 +73,18 @@ echo "Running pytest from datastore/ on tests/"
 echo "(cwd=datastore so 'from tests.test_utils import ...' resolves to datastore/tests/)"
 echo "=============================================="
 cd "${CHDB_SRC}/datastore"
+
+# These upstream tests are marked strict-xfail for bugs that chdb-core has
+# since fixed (non-ASCII string values scanned through Python(df) used to
+# carry a trailing NUL byte, breaking SQL string equality), so they now
+# XPASS(strict) and would fail the run. Deselect them until the upstream
+# chdb tag drops the xfail markers.
+DESELECT_FIXED_XFAILS="\
+ --deselect tests/test_exploratory_batch11_advanced_indexing.py::TestAdvancedStringOperations::test_str_normalize \
+ --deselect tests/test_exploratory_batch16_index_copy_edge.py::TestUnicodeAndSpecialCharacters::test_unicode_string_values"
+
 set +e
-${PYTHON} -m pytest tests/ ${PYTEST_ARGS}
+${PYTHON} -m pytest tests/ ${PYTEST_ARGS} ${DESELECT_FIXED_XFAILS}
 TEST_EXIT_CODE=$?
 set -e
 

--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -79,7 +79,13 @@ cd "${CHDB_SRC}/datastore"
 # carry a trailing NUL byte, breaking SQL string equality), so they now
 # XPASS(strict) and would fail the run. Deselect them until the upstream
 # chdb tag drops the xfail markers.
+# Both path forms are passed because pytest resolves --deselect node ids
+# against the rootdir (the clone root, where the configfile lives) on
+# pytest >= 9, but against the invocation dir on older versions; deselect
+# silently ignores whichever form does not match.
 DESELECT_FIXED_XFAILS="\
+ --deselect datastore/tests/test_exploratory_batch11_advanced_indexing.py::TestAdvancedStringOperations::test_str_normalize \
+ --deselect datastore/tests/test_exploratory_batch16_index_copy_edge.py::TestUnicodeAndSpecialCharacters::test_unicode_string_values \
  --deselect tests/test_exploratory_batch11_advanced_indexing.py::TestAdvancedStringOperations::test_str_normalize \
  --deselect tests/test_exploratory_batch16_index_copy_edge.py::TestUnicodeAndSpecialCharacters::test_unicode_string_values"
 

--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -151,6 +151,75 @@ bool PandasDataFrame::isPyArrowBacked(const py::handle & /*object*/)
     return false;
 }
 
+/// Capture zero-copy buffer views over an Arrow-backed string column
+/// (pandas StringDtype with pyarrow storage, the default `str` dtype since pandas 3.x).
+/// Reading the Arrow offsets/data buffers directly avoids materializing the whole
+/// column into an object ndarray (one PyObject per row) via to_numpy() and avoids
+/// any per-row Python C-API calls during the scan.
+static bool tryFillArrowStringColumn(DB::ColumnWrapper & column, const py::object & underlying_array)
+{
+    if (!py::hasattr(underlying_array, "_pa_array"))
+        return false;
+
+    py::object chunked = underlying_array.attr("_pa_array");
+    if (!py::hasattr(chunked, "chunks") || !py::hasattr(chunked, "type"))
+        return false;
+
+    auto type_str = py::str(chunked.attr("type")).cast<std::string>();
+    bool large_offsets;
+    if (type_str == "large_string")
+        large_offsets = true;
+    else if (type_str == "string")
+        large_offsets = false;
+    else
+        return false; /// e.g. string_view has a different buffer layout
+
+    std::vector<DB::ArrowStringChunkView> views;
+    size_t row_start = 0;
+    for (const auto & chunk_handle : chunked.attr("chunks"))
+    {
+        auto chunk = py::reinterpret_borrow<py::object>(chunk_handle);
+        DB::ArrowStringChunkView view;
+        view.length = py::len(chunk);
+        view.offset = chunk.attr("offset").cast<size_t>();
+        view.row_start = row_start;
+
+        py::list buffers = chunk.attr("buffers")();
+        if (py::len(buffers) != 3)
+            return false;
+
+        auto buffer_address = [](const py::handle & buffer) -> const void *
+        {
+            if (buffer.is_none())
+                return nullptr;
+            return reinterpret_cast<const void *>(buffer.attr("address").cast<uintptr_t>());
+        };
+
+        view.validity = static_cast<const UInt8 *>(buffer_address(buffers[0]));
+        view.offsets = buffer_address(buffers[1]);
+        view.data = static_cast<const char *>(buffer_address(buffers[2]));
+
+        if (view.length > 0 && view.offsets == nullptr)
+            return false;
+
+        row_start += view.length;
+        views.emplace_back(view);
+    }
+
+    if (row_start != column.row_count)
+        return false;
+
+    column.arrow_string_chunks = std::move(views);
+    column.arrow_large_offsets = large_offsets;
+    column.is_arrow_string = true;
+    column.is_object_type = false;
+    column.data = chunked;
+    column.buf = chunked.ptr(); /// non-null sentinel, never dereferenced on this path
+    column.tmp = chunked;       /// keep the ChunkedArray (and its buffers) alive
+    column.tmp.inc_ref();
+    return true;
+}
+
 void PandasDataFrame::fillColumn(
     const py::handle & data_source,
     const std::string & col_name,
@@ -244,6 +313,11 @@ void PandasDataFrame::fillColumn(
     }
 
     py::object underlying_array = series.attr("array");
+
+    /// Fast path for Arrow-backed string columns (pandas 3.x default `str` dtype,
+    /// pandas 2.x string[pyarrow]): scan the Arrow buffers directly, zero-copy.
+    if (numpy_type.type == NumpyNullableType::STRING && tryFillArrowStringColumn(column, underlying_array))
+        return;
 
     if (py::hasattr(underlying_array, "_mask"))
     {

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -146,6 +146,13 @@ ColumnPtr PandasScan::scanColumn(
 
     WhichDataType which(real_type);
 
+    if (col_wrap.is_arrow_string)
+    {
+        chassert(which.idx == TypeIndex::String);
+        innerScanArrowString(cursor, count, col_wrap, column);
+        return column;
+    }
+
     if (col_wrap.is_object_type)
     {
         SerializationPtr serialization;
@@ -475,11 +482,11 @@ void PandasScan::innerScanFloat(
         const T * start = ptr + cursor;
         helper->appendRawData<sizeof(T)>(reinterpret_cast<const char *>(start), count);
 
+        const size_t old_size = null_map.size();
+        null_map.resize(old_size + count);
+        UInt8 * null_pos = null_map.data() + old_size;
         for (size_t i = 0; i < count; ++i)
-        {
-            bool is_nan = std::isnan(start[i]);
-            null_map.push_back(is_nan ? 1 : 0);
-        }
+            null_pos[i] = start[i] != start[i] ? 1 : 0; /// NaN check, auto-vectorizable
     }
     else
     {
@@ -583,11 +590,11 @@ void PandasScan::innerScanDateTime64(
         const Int64 * start = ptr + cursor;
         helper->appendRawData<sizeof(Int64)>(reinterpret_cast<const char *>(start), count);
 
+        const size_t old_size = null_map.size();
+        null_map.resize(old_size + count);
+        UInt8 * null_pos = null_map.data() + old_size;
         for (size_t i = 0; i < count; ++i)
-        {
-            bool is_nat = start[i] <= std::numeric_limits<Int64>::min();
-            null_map.push_back(is_nat ? 1 : 0);
-        }
+            null_pos[i] = start[i] == std::numeric_limits<Int64>::min() ? 1 : 0; /// NaT check, auto-vectorizable
     }
     else
     {
@@ -621,11 +628,11 @@ void PandasScan::innerScanInterval(
         const Int64 * start = ptr + cursor;
         helper->appendRawData<sizeof(Int64)>(reinterpret_cast<const char *>(start), count);
 
+        const size_t old_size = null_map.size();
+        null_map.resize(old_size + count);
+        UInt8 * null_pos = null_map.data() + old_size;
         for (size_t i = 0; i < count; ++i)
-        {
-            bool is_nat = start[i] <= std::numeric_limits<Int64>::min();
-            null_map.push_back(is_nat ? 1 : 0);
-        }
+            null_pos[i] = start[i] == std::numeric_limits<Int64>::min() ? 1 : 0; /// NaT check, auto-vectorizable
     }
     else
     {
@@ -639,6 +646,118 @@ void PandasScan::innerScanInterval(
             bool is_nat = value <= std::numeric_limits<Int64>::min();
             null_map.push_back(is_nat ? 1 : 0);
         }
+    }
+}
+
+template <typename OffsetT>
+static void scanArrowStringSegment(
+    const ArrowStringChunkView & chunk,
+    const size_t local_start,
+    const size_t n,
+    ColumnString & column_string,
+    NullMap & null_map)
+{
+    auto & chars = column_string.getChars();
+    auto & offsets = column_string.getOffsets();
+
+    const OffsetT * off = static_cast<const OffsetT *>(chunk.offsets) + chunk.offset + local_start;
+    const char * data = chunk.data;
+
+    /// ColumnString stores raw payload back to back (no terminators), so for a
+    /// fully-valid segment the Arrow data buffer slice can be copied wholesale.
+    const size_t total_bytes = static_cast<size_t>(off[n] - off[0]);
+    size_t chars_pos = chars.size();
+    chars.resize(chars_pos + total_bytes);
+
+    const size_t offsets_old = offsets.size();
+    offsets.resize(offsets_old + n);
+    auto * offsets_pos = offsets.data() + offsets_old;
+
+    const size_t null_old = null_map.size();
+    null_map.resize(null_old + n);
+    UInt8 * null_pos = null_map.data() + null_old;
+
+    char * dst = reinterpret_cast<char *>(chars.data());
+
+    if (chunk.validity == nullptr)
+    {
+        if (total_bytes)
+            memcpy(dst + chars_pos, data + off[0], total_bytes);
+        const OffsetT base = off[0];
+        for (size_t i = 0; i < n; ++i)
+            offsets_pos[i] = chars_pos + static_cast<size_t>(off[i + 1] - base);
+        memset(null_pos, 0, n);
+        chars_pos += total_bytes;
+    }
+    else
+    {
+        const UInt8 * validity = chunk.validity;
+        const size_t bit_base = chunk.offset + local_start;
+        for (size_t i = 0; i < n; ++i)
+        {
+            const size_t bit = bit_base + i;
+            const bool is_valid = validity[bit >> 3] & (1u << (bit & 7));
+            if (is_valid)
+            {
+                const size_t len = static_cast<size_t>(off[i + 1] - off[i]);
+                if (len)
+                    memcpy(dst + chars_pos, data + off[i], len);
+                chars_pos += len;
+                null_pos[i] = 0;
+            }
+            else
+            {
+                null_pos[i] = 1;
+            }
+            offsets_pos[i] = chars_pos;
+        }
+
+        if (chars.size() != chars_pos)
+            chars.resize(chars_pos); /// null rows reserve payload they do not use
+    }
+}
+
+void PandasScan::innerScanArrowString(
+    const size_t cursor,
+    const size_t count,
+    const ColumnWrapper & col_wrap,
+    MutableColumnPtr & column)
+{
+    auto & nullable_column = assert_cast<ColumnNullable &>(*column);
+    auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
+    auto & null_map = nullable_column.getNullMapData();
+    auto * column_string = assert_cast<ColumnString *>(data_column.get());
+
+    const auto & chunks = col_wrap.arrow_string_chunks;
+
+    /// Find the chunk containing `cursor` (chunks are sorted by row_start)
+    size_t lo = 0;
+    size_t hi = chunks.size();
+    while (lo < hi)
+    {
+        const size_t mid = (lo + hi) / 2;
+        if (chunks[mid].row_start + chunks[mid].length <= cursor)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+
+    size_t row = cursor;
+    size_t remaining = count;
+    for (size_t chunk_idx = lo; remaining > 0; ++chunk_idx)
+    {
+        chassert(chunk_idx < chunks.size());
+        const auto & chunk = chunks[chunk_idx];
+        const size_t local_start = row - chunk.row_start;
+        const size_t n = std::min(remaining, chunk.length - local_start);
+
+        if (col_wrap.arrow_large_offsets)
+            scanArrowStringSegment<Int64>(chunk, local_start, n, *column_string, null_map);
+        else
+            scanArrowStringSegment<Int32>(chunk, local_start, n, *column_string, null_map);
+
+        row += n;
+        remaining -= n;
     }
 }
 

--- a/programs/local/PandasScan.h
+++ b/programs/local/PandasScan.h
@@ -32,6 +32,12 @@ public:
 private:
     static void innerCheck(const DB::ColumnWrapper & col_wrap);
 
+    static void innerScanArrowString(
+        const size_t cursor,
+        const size_t count,
+        const DB::ColumnWrapper & col_wrap,
+        DB::MutableColumnPtr & column);
+
     static void innerScanObject(
         const size_t cursor,
         const size_t count,

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -76,20 +76,15 @@ void PythonTableCache::findQueryableObjFromQuery(const String & query_str)
     // Try to match and extract the groups
     while (RE2::FindAndConsume(&input, pattern, &quoted_match, &unquoted_match))
     {
-        // If quoted string was matched
-        if (!quoted_match.empty())
-        {
-            auto handle = findQueryableObj(quoted_match);
-            if (!handle.is_none())
-                py_table_cache.emplace(quoted_match, handle);
-        }
-        // If unquoted identifier was matched
-        else if (!unquoted_match.empty())
-        {
-            auto handle = findQueryableObj(unquoted_match);
-            if (!handle.is_none())
-                py_table_cache.emplace(unquoted_match, handle);
-        }
+        // Skip the (expensive) inspect frame walk when the name is already cached;
+        // emplace never overwrites an existing entry anyway.
+        const auto & matched = !quoted_match.empty() ? quoted_match : unquoted_match;
+        if (matched.empty() || py_table_cache.contains(matched))
+            continue;
+
+        auto handle = findQueryableObj(matched);
+        if (!handle.is_none())
+            py_table_cache.emplace(matched, handle);
     }
 }
 

--- a/programs/local/PythonUtils.cpp
+++ b/programs/local/PythonUtils.cpp
@@ -35,13 +35,9 @@ static size_t ConvertPyUnicodeToUtf8(const void * input, int kind, size_t codepo
 
     // Estimate the maximum buffer size required for the UTF-8 output
     // Buffers is reserved from the caller, so we can safely resize it and memory will not be wasted
-    size_t estimated_size = codepoint_cnt * 4 + 1; // Allocate buffer for UTF-8 output
+    size_t estimated_size = codepoint_cnt * 4; // Allocate buffer for UTF-8 output
     size_t chars_cursor = chars.size();
-    size_t target_size = chars_cursor + estimated_size;
-    chars.resize(target_size);
-
-    // Resize the character buffer to accommodate the UTF-8 string
-    chars.resize(chars_cursor + estimated_size + 1); // +1 for null terminator
+    chars.resize(chars_cursor + estimated_size);
 
     size_t offset = chars_cursor;
     switch (kind)
@@ -75,11 +71,13 @@ static size_t ConvertPyUnicodeToUtf8(const void * input, int kind, size_t codepo
         }
     }
 
-    chars[offset++] = '\0'; // Null terminate the output string
-    offsets.push_back(offset); // Include the null terminator in the offset
-    chars.resize(offset); // Resize to the actual used size, including null terminator
+    /// ColumnString stores raw payload without terminators: offsets point just
+    /// past the last byte of each value (same convention as ColumnString::insertData).
+    /// The old code appended a '\0' here, corrupting every non-ASCII string value.
+    offsets.push_back(offset);
+    chars.resize(offset); // Resize to the actual used size
 
-    return offset; // Return the number of bytes written, not including the null terminator
+    return offset; // Return the number of bytes written
 }
 
 void FillColumnString(PyObject * obj, ColumnString * column)

--- a/programs/local/PythonUtils.h
+++ b/programs/local/PythonUtils.h
@@ -21,6 +21,19 @@ struct RegisteredArray
     py::array numpy_array;
 };
 
+/// Zero-copy view over one chunk of an Arrow-backed string column
+/// (pandas 3.x StringDtype with pyarrow storage). Buffers are owned by the
+/// pyarrow ChunkedArray held alive via ColumnWrapper::tmp.
+struct ArrowStringChunkView
+{
+    const UInt8 * validity = nullptr; /// validity bitmap, nullptr means all valid
+    const void * offsets = nullptr;   /// Int32 (string) or Int64 (large_string) value offsets
+    const char * data = nullptr;      /// utf8 payload, may be nullptr when empty
+    size_t offset = 0;                /// arrow array offset (slice support), in elements/bits
+    size_t length = 0;                /// number of rows in this chunk
+    size_t row_start = 0;             /// global row index of the first row of this chunk
+};
+
 struct ColumnWrapper
 {
     void * buf; // we may modify the data when cast it to PyObject **, so we need a non-const pointer
@@ -39,6 +52,11 @@ struct ColumnWrapper
     bool is_category = false;
     ColumnUniquePtr category_unique;
     std::string category_codes_type;
+
+    /// Arrow-backed string column fast path (no per-row PyObject access)
+    bool is_arrow_string = false;
+    bool arrow_large_offsets = false;
+    std::vector<ArrowStringChunkView> arrow_string_chunks;
 
     ~ColumnWrapper()
     {

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -2,6 +2,7 @@
 #include "NumpyType.h"
 #include "PandasDataFrame.h"
 #include "PybindWrapper.h"
+#include "PythonImporter.h"
 #include "PythonSource.h"
 #include "PyArrowTable.h"
 #include "PyArrowStreamFactory.h"
@@ -157,6 +158,17 @@ void StoragePython::prepareColumnCache(
 #endif
 
     auto & data_source = data_source_wrapper->getDataSource();
+
+    if (is_pandas_df)
+    {
+        /// Pre-resolve lazily-imported pandas attributes that GIL-free scan threads
+        /// compare against (isNone checks pandas.NaT / pandas.NA). The first access
+        /// imports them via Python C-API, which must happen while the GIL is held;
+        /// afterwards scan threads only do pointer comparisons.
+        auto & import_cache = CHDB::PythonImporter::ImportCache();
+        import_cache.pandas.NaT();
+        import_cache.pandas.NA();
+    }
 
     bool need_rebuild = (column_cache == nullptr) || (column_cache->size() != names.size());
     if (!need_rebuild)

--- a/tests/test_python_table_string_correctness.py
+++ b/tests/test_python_table_string_correctness.py
@@ -178,5 +178,150 @@ class TestStringColumnWithMissingValues(unittest.TestCase):
         )
 
 
+def arrow_str_series(values):
+    """Arrow-backed string Series on both pandas 2.x and 3.x.
+
+    string[pyarrow] is ArrowStringArray on 2.x and 3.x alike; pandas always
+    stores large_string (int32-offset `string` arrays are cast on
+    construction, so that branch is unreachable from pandas).
+    """
+    return pd.Series(pd.array(values, dtype="string[pyarrow]"))
+
+
+class TestArrowStringChunksAndSlices(unittest.TestCase):
+    """Multi-chunk arrays, sliced arrays (non-zero offset) and degenerate
+    shapes through the Arrow buffer scan path, on pandas 2.x and 3.x."""
+
+    def test_multi_chunk_with_nulls_and_empty(self):
+        a = [CJK, "", None, CAFE] * 25
+        b = [CYR, None, ROCKET, ""] * 25
+        s = pd.concat([arrow_str_series(a), arrow_str_series(b)], ignore_index=True)
+        df = pd.DataFrame({"s": s})
+        if hasattr(s.array, "_pa_array"):
+            self.assertGreaterEqual(s.array._pa_array.num_chunks, 2)
+        values = a + b
+        valid = [v for v in values if v is not None]
+        self.assertEqual(
+            q("SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s) FROM Python(df)"),
+            f"{len(values)},{len(valid)},{len(set(valid))}",
+        )
+        self.assertEqual(
+            q("SELECT sum(length(s)) FROM Python(df)"),
+            str(sum(len(v.encode()) for v in valid)),
+        )
+        self.assertEqual(
+            q(f"SELECT COUNT(*) FROM Python(df) WHERE s = '{CJK}'"), "25"
+        )
+        self.assertEqual(q("SELECT COUNT(*) FROM Python(df) WHERE s = ''"), "50")
+
+    def test_sliced_with_nulls_validity_bit_offset(self):
+        """iloc slice keeps the Arrow buffers and bumps the chunk offset, so
+        the validity bitmap must be read with a bit-level offset."""
+        base = [CJK, None, CAFE, "", None, CYR, ROCKET] * 40
+        full = pd.DataFrame({"s": arrow_str_series(base)})
+        for start, stop in [(7, 207), (1, 280), (13, 14)]:
+            df = full.iloc[start:stop].reset_index(drop=True)
+            window = base[start:stop]
+            valid = [v for v in window if v is not None]
+            self.assertEqual(
+                q("SELECT COUNT(*), COUNT(s), sum(length(s)) FROM Python(df)"),
+                f"{len(window)},{len(valid)},{sum(len(v.encode()) for v in valid)}",
+                f"slice [{start}:{stop}]",
+            )
+
+    def test_slice_spanning_chunks(self):
+        s = pd.concat(
+            [arrow_str_series([CJK] * 50), arrow_str_series([CYR] * 50)],
+            ignore_index=True,
+        )
+        df = pd.DataFrame({"s": s}).iloc[30:70].reset_index(drop=True)
+        self.assertEqual(
+            q("SELECT countIf(s = '{}') , countIf(s = '{}') FROM Python(df)".format(CJK, CYR)),
+            "20,20",
+        )
+
+    def test_all_null_column(self):
+        df = pd.DataFrame({"s": arrow_str_series([None, None, None])})
+        self.assertEqual(q("SELECT COUNT(*), COUNT(s) FROM Python(df)"), "3,0")
+
+    def test_all_empty_strings(self):
+        """Empty data buffer edge case."""
+        df = pd.DataFrame({"s": arrow_str_series(["", "", ""])})
+        self.assertEqual(
+            q("SELECT COUNT(*), COUNT(s), sum(length(s)) FROM Python(df)"), "3,3,0"
+        )
+
+
+class TestArrowStringLargerVolume(unittest.TestCase):
+    """~300k rows: spans multiple max_block_size (65409) blocks, multiple
+    parallel scan streams, and a chunk boundary inside a stream range."""
+
+    @classmethod
+    def setUpClass(cls):
+        pattern = [CJK, CYR + "suffix", "", None, CAFE * 3, ROCKET, "plain ascii"]
+        cls.values = (pattern * 21500)[:150000] + ([None, CJK * 2, "tail"] * 50000)
+        half = len(cls.values) // 2
+        cls.df = pd.DataFrame(
+            {
+                "s": pd.concat(
+                    [
+                        arrow_str_series(cls.values[:half]),
+                        arrow_str_series(cls.values[half:]),
+                    ],
+                    ignore_index=True,
+                ),
+                "i": range(len(cls.values)),
+            }
+        )
+        cls.valid = [v for v in cls.values if v is not None]
+
+    def test_counts_and_byte_lengths(self):
+        df = self.df  # noqa: F841
+        self.assertEqual(
+            q("SELECT COUNT(*), COUNT(s), COUNT(DISTINCT s) FROM Python(df)"),
+            f"{len(self.values)},{len(self.valid)},{len(set(self.valid))}",
+        )
+        self.assertEqual(
+            q("SELECT sum(length(s)) FROM Python(df)"),
+            str(sum(len(v.encode()) for v in self.valid)),
+        )
+
+    def test_min_max_and_filters(self):
+        df = self.df  # noqa: F841
+        lo, hi = min(self.valid), max(self.valid)
+        self.assertEqual(
+            q("SELECT hex(MIN(s)), hex(MAX(s)) FROM Python(df)"),
+            f'"{lo.encode().hex().upper()}","{hi.encode().hex().upper()}"',
+        )
+        self.assertEqual(
+            q(f"SELECT COUNT(*) FROM Python(df) WHERE s = '{CJK}'"),
+            str(self.values.count(CJK)),
+        )
+        self.assertEqual(
+            q("SELECT COUNT(*) FROM Python(df) WHERE s IS NULL"),
+            str(self.values.count(None)),
+        )
+
+    def test_group_by_matches_pandas(self):
+        df = self.df  # noqa: F841
+        got = q(
+            "SELECT s, COUNT(*) c FROM Python(df) WHERE s IS NOT NULL "
+            "GROUP BY s ORDER BY c DESC, s LIMIT 5"
+        )
+        vc = pd.Series(self.valid).value_counts()
+        expected_pairs = sorted(vc.items(), key=lambda kv: (-kv[1], kv[0]))[:5]
+        expected = "\n".join(f'"{k}",{v}' for k, v in expected_pairs)
+        self.assertEqual(got, expected)
+
+    def test_row_alignment_with_numeric_column(self):
+        """String rows must stay aligned with the parallel-scanned int column."""
+        df = self.df  # noqa: F841
+        idx = [i for i, v in enumerate(self.values) if v == "tail"]
+        self.assertEqual(
+            q("SELECT min(i), max(i), COUNT(*) FROM Python(df) WHERE s = 'tail'"),
+            f"{idx[0]},{idx[-1]},{len(idx)}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_python_table_string_correctness.py
+++ b/tests/test_python_table_string_correctness.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Regression tests for the Python(df) string input path.
+
+Covers two bugs fixed in programs/local/:
+
+1. Hang/segfault on string columns containing missing values:
+   PandasScan's GIL-free scan thread called isNone(), whose import cache
+   lazily resolved pandas.NaT via Python C-API without a thread state
+   (crash in _PyObject_Malloc on CPython 3.12+, then a deadlock in the
+   fatal signal handler). Fixed by pre-resolving pandas.NaT/NA under the
+   GIL in StoragePython::prepareColumnCache. On the buggy build these
+   tests hang forever when run first in the process.
+
+2. Trailing NUL byte on every non-ASCII string value:
+   ConvertPyUnicodeToUtf8 still appended the old ColumnString zero
+   terminator and counted it in offsets, so any non-ASCII value entering
+   chdb through the PyUnicode path was stored as value + '\\0' (equality
+   with literals never matched, length()/hex()/hashes were off by one).
+
+Both must pass on pandas 2.x (object-dtype strings) and pandas 3.x
+(Arrow-backed `str` dtype), which exercise different scan paths:
+object dtype -> per-row PyUnicode conversion; str dtype -> Arrow buffers.
+"""
+
+import unittest
+
+import pandas as pd
+
+import chdb
+
+
+PANDAS_MAJOR = int(pd.__version__.split(".")[0])
+
+# 1-byte (Latin-1), 2-byte (BMP) and 4-byte (non-BMP) PyUnicode kinds,
+# to cover every branch of the PyUnicode -> UTF-8 conversion.
+CAFE = "café"  # é: kind-1, utf8 C3A9
+CJK = "中文"  # 中文: kind-2, utf8 E4B8ADE69687
+CYR = "привет"  # привет: kind-2
+ROCKET = "\U0001f680"  # 🚀: kind-4, utf8 F09F9A80
+
+
+def fresh(s):
+    """Return a newly constructed string object equal to `s`.
+
+    Literal/interned strings can already carry a cached UTF-8 representation,
+    in which case the scan takes the direct-insert fast path and would mask
+    bugs in the manual PyUnicode -> UTF-8 conversion. A string built at
+    runtime has no cached UTF-8, so it deterministically exercises
+    ConvertPyUnicodeToUtf8.
+    """
+    return "".join([s[i] for i in range(len(s))])
+
+
+def q(sql):
+    return str(chdb.query(sql, "CSV")).strip()
+
+
+class TestNonAsciiStringValues(unittest.TestCase):
+    """Bug 2: values must be stored byte-exact, without a trailing NUL."""
+
+    def _check_byte_exact(self, df):  # noqa: F841 -- df referenced by Python(df)
+        rows = q(
+            "SELECT hex(s), length(s) FROM Python(df) ORDER BY s"
+        ).splitlines()
+        expected = sorted([CAFE, CJK, CYR, ROCKET, "ascii"])
+        self.assertEqual(len(rows), len(expected))
+        for row, value in zip(rows, expected):
+            utf8 = value.encode("utf-8")
+            self.assertEqual(row, f'"{utf8.hex().upper()}",{len(utf8)}')
+
+        # equality with a literal must match (failed when a NUL was appended)
+        for value in (CAFE, CJK, CYR, ROCKET):
+            self.assertEqual(
+                q(f"SELECT COUNT(*) FROM Python(df) WHERE s = '{value}'"),
+                "1",
+                f"equality failed for {value!r}",
+            )
+
+        # group keys must round-trip intact
+        self.assertEqual(
+            q(
+                "SELECT s, COUNT(*) FROM Python(df) "
+                f"WHERE s = '{CJK}' GROUP BY s"
+            ),
+            f'"{CJK}",1',
+        )
+
+    def test_object_dtype_pyunicode_path(self):
+        """object dtype: per-row PyUnicode conversion (both pandas 2.x/3.x)."""
+        values = [fresh(v) for v in (CAFE, CJK, CYR, ROCKET, "ascii")]
+        df = pd.DataFrame({"s": pd.Series(values, dtype=object)})
+        self.assertEqual(str(df["s"].dtype), "object")
+        self._check_byte_exact(df)
+
+    def test_default_string_dtype_path(self):
+        """astype(str): object dtype on pandas 2.x, Arrow `str` dtype on 3.x."""
+        df = pd.DataFrame({"s": [fresh(v) for v in (CAFE, CJK, CYR, ROCKET, "ascii")]})
+        df["s"] = df["s"].astype(str)
+        self._check_byte_exact(df)
+
+    @unittest.skipIf(PANDAS_MAJOR >= 3, "string[pyarrow] folded into str on 3.x")
+    def test_pyarrow_backed_string_dtype_pandas2(self):
+        """pandas 2.x string[pyarrow]: exercises the Arrow buffer scan path."""
+        df = pd.DataFrame(
+            {
+                "s": pd.array(
+                    [fresh(v) for v in (CAFE, CJK, CYR, ROCKET, "ascii")],
+                    dtype="string[pyarrow]",
+                )
+            }
+        )
+        self._check_byte_exact(df)
+
+
+class TestStringColumnWithMissingValues(unittest.TestCase):
+    """Bug 1: missing values in string columns must not hang the scan.
+
+    On the unfixed build, the first query in the process whose scan hits a
+    nan/NaT row crashes a GIL-free thread inside the lazy pandas.NaT import
+    and never returns (observed on CPython 3.12+).
+    """
+
+    def _check_nulls(self, df, n_total, n_valid):  # noqa: F841
+        self.assertEqual(
+            q("SELECT COUNT(*), COUNT(s) FROM Python(df)"),
+            f"{n_total},{n_valid}",
+        )
+        self.assertEqual(
+            q("SELECT COUNT(*) FROM Python(df) WHERE s IS NULL"),
+            str(n_total - n_valid),
+        )
+        self.assertEqual(q("SELECT MAX(s) FROM Python(df)"), f'"{CJK}"')
+
+    def test_object_dtype_with_nan(self):
+        """float('nan') in an object column: the exact lazy-NaT trigger."""
+        df = pd.DataFrame(
+            {"s": pd.Series(["x", float("nan"), CJK], dtype=object)}
+        )
+        self._check_nulls(df, 3, 2)
+
+    def test_object_dtype_with_pd_nat(self):
+        """pd.NaT in an object column: hits the cached-NaT pointer compare."""
+        df = pd.DataFrame({"s": pd.Series(["x", pd.NaT, CJK], dtype=object)})
+        self._check_nulls(df, 3, 2)
+
+    def test_object_dtype_with_none(self):
+        df = pd.DataFrame({"s": pd.Series(["x", None, CJK], dtype=object)})
+        self._check_nulls(df, 3, 2)
+
+    def test_default_string_dtype_with_none(self):
+        """None through astype-free default dtype (str on 3.x, object on 2.x)."""
+        df = pd.DataFrame({"s": ["x", None, CJK]})
+        self._check_nulls(df, 3, 2)
+
+    @unittest.skipIf(PANDAS_MAJOR >= 3, "string[pyarrow] folded into str on 3.x")
+    def test_pyarrow_backed_string_dtype_with_none_pandas2(self):
+        df = pd.DataFrame(
+            {"s": pd.array(["x", None, CJK], dtype="string[pyarrow]")}
+        )
+        self._check_nulls(df, 3, 2)
+
+    @unittest.skipIf(PANDAS_MAJOR < 3, "default str dtype needs pandas >= 3")
+    def test_str_dtype_nulls_and_values_pandas3(self):
+        """pandas 3.x `str` dtype with nulls: Arrow validity bitmap path."""
+        df = pd.DataFrame(
+            {"s": pd.array(["x", None, CJK, None, CYR], dtype="str")}
+        )
+        self.assertEqual(str(df["s"].dtype), "str")
+        self.assertEqual(
+            q("SELECT COUNT(*), COUNT(s) FROM Python(df)"), "5,3"
+        )
+        self.assertEqual(
+            q("SELECT hex(s) FROM Python(df) WHERE s IS NOT NULL ORDER BY s"),
+            "\n".join(
+                f'"{v.encode("utf-8").hex().upper()}"'
+                for v in sorted(["x", CJK, CYR])
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Optimizes the `Python(df)` read path for pandas 3.x DataFrames and fixes two correctness bugs found along the way. All changes are confined to `programs/local/`; no SQL operator kernels are touched.

**ClickBench `chdb-dataframe` (50M-row hits, pandas 3.0.3 / Python 3.14, hot run): total 219.2s → 20.1s (10.9x). Per-query geomean 4.5x, string-heavy queries 29-64x.**

| Query | baseline | optimized | speedup |
|---|---:|---:|---:|
| Q23 `SELECT *` + LIKE + ORDER BY | 61.86s | 1.65s | 37x |
| Q22 Title/URL LIKE + aggregates | 24.63s | 0.47s | 53x |
| Q37 Title GROUP BY | 15.60s | 0.24s | 64x |
| Q20 URL LIKE COUNT | 7.44s | 0.20s | 37x |
| numeric-only queries | — | — | ~1.0x (unchanged) |

## Problems addressed

1. **Perf: pandas 3.x `str` dtype hit a full-materialization slow path.** The default string dtype since pandas 3.0 is Arrow-backed (`ArrowStringArray`); `fillColumn` had no fast path for it and fell through to `to_numpy()`, materializing one PyObject per row (GIL-held, single-threaded) on every query for every referenced string column, then converting per-row via PyUnicode. `SELECT *` on a 100M-row frame needs 200GB+ just for the materialization.

2. **Hang/segfault: string columns containing nulls.** `isNone()` on a GIL-free scan thread lazily imports `pandas.NaT` on first use — Python C-API with no thread state, segfaults in `_PyObject_Malloc/get_state()` on CPython 3.12+, then wedges in the fatal signal handler. Fixed by pre-resolving `NaT`/`NA` under the GIL in `prepareColumnCache`.

3. **Data corruption: trailing NUL on every non-ASCII string value.** `ConvertPyUnicodeToUtf8` still wrote the old ColumnString zero-terminator convention (upstream removed it), so every non-ASCII value carried a trailing `\0`: equality with literals never matched, `length()`/hashes/ordering off by one byte. Verified quantitatively against pyarrow ground truth on hits — per-column `SUM(length())` deviations exactly equaled the count of non-ASCII rows; fixed path now matches byte-for-byte.

## Changes

- **`PandasDataFrame.cpp` / `PythonUtils.h`**: detect `ArrowStringArray` (`_pa_array`), capture per-chunk validity/offsets/data buffer views (string + large_string, multi-chunk, sliced arrays), keep the ChunkedArray alive via handle.
- **`PandasScan.{h,cpp}`**: `innerScanArrowString` — bulk-copy Arrow buffers into `ColumnString` (single memcpy per fully-valid segment + batch offset fill), validity bitmap → null map. GIL-free, parallel across streams.
- **`StoragePython.cpp`**: pre-resolve `pandas.NaT`/`pandas.NA` under the GIL (fixes the hang).
- **`PythonUtils.cpp`**: drop the zero terminator in `ConvertPyUnicodeToUtf8` (fixes NUL corruption; also affects object-dtype/PyReader/dict paths).
- **`PandasScan.cpp`**: vectorized NaN/NaT null-map construction (resize + tight loop instead of per-row push_back).
- **`PythonTableCache.cpp`**: skip the `inspect` frame walk when the table name is already cached.

## Verification

- 14 functional checks: nulls (previously hung), UTF-8 multi-lingual, multi-chunk, sliced arrays, datetime NaT, object-dtype fallback, hex-level byte-exactness for non-ASCII.
- hits-scale determinism: row counts, `COUNT(DISTINCT)`, per-column `SUM(length())`, `cityHash64` content hashes (per-column and row-wise multi-column), MIN/MAX, tie-broken top-N — all byte-identical to pyarrow-computed ground truth.
- perf (optimized build): scan layer is now memcpy-bound (Q23: 56% memcpy + 22% scan); remaining hotspots are aggregation/regex kernels, out of scope here.

## Notes for review

- The benchmark used a 50M-row half of hits (the full 100M-row DataFrame load peaks >118GB and OOMs the 123GB test box); baseline and optimized runs used identical data and methodology.
- Suggested follow-up (not in this PR): CI currently tests Python 3.11 with ASCII-only string inputs through `Python(df)`, which is why both correctness bugs went unnoticed — adding a 3.12+ matrix entry plus byte-exact non-ASCII/null-string round-trip cases would cover this class of regressions.
