### PR TITLE
C API: Expose INSERT write progress (written_rows / written_bytes) on chdb_result

### DIFF
--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -161,7 +161,7 @@ jobs:
           path: ft_dist/*.whl
           overwrite: true
       - name: Upload FT wheels to pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -647,7 +647,7 @@ jobs:
             ./linux-aarch64-debuginfo.tar.gz
           overwrite: true
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
@@ -657,7 +657,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -287,6 +287,7 @@ jobs:
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
           bash -x ./examples/runArrowQueryTest.sh
+          bash -x ./examples/runInsertProgressTest.sh
       - name: Check ccache statistics
         run: |
           ccache -s

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -273,6 +273,7 @@ jobs:
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
           bash -x ./examples/runArrowQueryTest.sh
+          bash -x ./examples/runInsertProgressTest.sh
       - name: Check ccache statistics
         run: |
           ccache -s

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -636,7 +636,7 @@ jobs:
             ./linux-x86_64-debuginfo.tar.gz
           overwrite: true
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
@@ -646,7 +646,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -307,6 +307,7 @@ jobs:
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
           bash -x ./examples/runArrowQueryTest.sh
+          bash -x ./examples/runInsertProgressTest.sh
       - name: Build wheels
         run: |
           rm -rf chdb/build/

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -608,7 +608,7 @@ jobs:
             ./macos-arm64-debuginfo.tar.gz
           overwrite: true
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
@@ -618,7 +618,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -608,7 +608,7 @@ jobs:
             ./macos-x86_64-debuginfo.tar.gz
           overwrite: true
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
@@ -618,7 +618,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -308,6 +308,7 @@ jobs:
           bash -x ./examples/runArrowTest.sh
           bash -x ./examples/runArrowStreamParse.sh
           bash -x ./examples/runArrowQueryTest.sh
+          bash -x ./examples/runInsertProgressTest.sh
       - name: Build wheels
         run: |
           rm -rf chdb/build/

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -38,6 +38,8 @@
         chdb_result_bytes_read;
         chdb_result_storage_rows_read;
         chdb_result_storage_bytes_read;
+        chdb_result_rows_written;
+        chdb_result_bytes_written;
         chdb_result_error;
 
         /* Arrow Integration */

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -34,6 +34,8 @@ _chdb_result_rows_read
 _chdb_result_bytes_read
 _chdb_result_storage_rows_read
 _chdb_result_storage_bytes_read
+_chdb_result_rows_written
+_chdb_result_bytes_written
 _chdb_result_error
 
 _chdb_arrow_scan

--- a/examples/chdbInsertProgressTest.c
+++ b/examples/chdbInsertProgressTest.c
@@ -1,0 +1,156 @@
+/**
+ * chdbInsertProgressTest.c
+ *
+ * Smoke test for INSERT write-progress accessors on chdb_result
+ * (chdb_result_rows_written / chdb_result_bytes_written), issue #88.
+ *
+ * Verifies:
+ *   1. SELECT reports zero write progress.
+ *   2. Plain INSERT reports the number of rows written.
+ *   3. INSERT ... SELECT reports the number of rows written.
+ *   4. INSERT into a table with an attached materialized view includes the
+ *      cascaded MV writes (same semantics as the HTTP interface's
+ *      X-ClickHouse-Summary.written_rows).
+ *
+ * Build (against an already-built libchdb.so):
+ *   clang examples/chdbInsertProgressTest.c -I./programs/local \
+ *         -L. -lchdb -o examples/chdbInsertProgressTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbInsertProgressTest
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "chdb.h"
+
+static int g_failed_assertions = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "  ASSERT FAIL: %s (%s:%d)\n",                 \
+                    (msg), __FILE__, __LINE__);                            \
+            g_failed_assertions += 1;                                      \
+        }                                                                  \
+    } while (0)
+
+/* Runs a query, asserts it succeeded, and returns the result handle. */
+static chdb_result * run(chdb_connection conn, const char * query)
+{
+    chdb_result * result = chdb_query(conn, query, "CSV");
+    CHECK(result != NULL, query);
+    if (result) {
+        const char * error = chdb_result_error(result);
+        if (error) {
+            fprintf(stderr, "  query error: %s\n  query: %s\n", error, query);
+            g_failed_assertions += 1;
+        }
+    }
+    return result;
+}
+
+static void test_select_reports_zero_written(chdb_connection conn)
+{
+    printf("== test_select_reports_zero_written ==\n");
+    chdb_result * result = run(conn, "SELECT number FROM numbers(10)");
+    if (!result)
+        return;
+
+    CHECK(chdb_result_rows_read(result) == 10, "rows_read == 10");
+    CHECK(chdb_result_rows_written(result) == 0, "rows_written == 0 for SELECT");
+    CHECK(chdb_result_bytes_written(result) == 0, "bytes_written == 0 for SELECT");
+    chdb_destroy_query_result(result);
+}
+
+static void test_plain_insert_reports_written(chdb_connection conn)
+{
+    printf("== test_plain_insert_reports_written ==\n");
+    chdb_result * setup = run(conn,
+        "CREATE TABLE insert_progress_plain (k UInt32, v String) ENGINE = MergeTree ORDER BY k");
+    if (setup)
+        chdb_destroy_query_result(setup);
+
+    chdb_result * result = run(conn,
+        "INSERT INTO insert_progress_plain FORMAT JSONEachRow\n"
+        "{\"k\":1,\"v\":\"a\"}\n{\"k\":2,\"v\":\"b\"}\n{\"k\":3,\"v\":\"c\"}\n");
+    if (!result)
+        return;
+
+    uint64_t rows_written = chdb_result_rows_written(result);
+    uint64_t bytes_written = chdb_result_bytes_written(result);
+    printf("  rows_written=%" PRIu64 " bytes_written=%" PRIu64 "\n", rows_written, bytes_written);
+    CHECK(rows_written == 3, "rows_written == 3 for 3-row INSERT");
+    CHECK(bytes_written > 0, "bytes_written > 0 for 3-row INSERT");
+    chdb_destroy_query_result(result);
+}
+
+static void test_insert_select_reports_written(chdb_connection conn)
+{
+    printf("== test_insert_select_reports_written ==\n");
+    chdb_result * setup = run(conn,
+        "CREATE TABLE insert_progress_sel (n UInt64) ENGINE = MergeTree ORDER BY n");
+    if (setup)
+        chdb_destroy_query_result(setup);
+
+    chdb_result * result = run(conn,
+        "INSERT INTO insert_progress_sel SELECT number FROM numbers(1000)");
+    if (!result)
+        return;
+
+    uint64_t rows_written = chdb_result_rows_written(result);
+    printf("  rows_written=%" PRIu64 "\n", rows_written);
+    CHECK(rows_written == 1000, "rows_written == 1000 for INSERT SELECT");
+    CHECK(chdb_result_bytes_written(result) > 0, "bytes_written > 0 for INSERT SELECT");
+    chdb_destroy_query_result(result);
+}
+
+static void test_insert_with_mv_includes_cascade(chdb_connection conn)
+{
+    printf("== test_insert_with_mv_includes_cascade ==\n");
+    chdb_result * setup;
+    setup = run(conn,
+        "CREATE TABLE insert_progress_src (k UInt32) ENGINE = MergeTree ORDER BY k");
+    if (setup)
+        chdb_destroy_query_result(setup);
+    setup = run(conn,
+        "CREATE MATERIALIZED VIEW insert_progress_mv "
+        "ENGINE = MergeTree ORDER BY k AS SELECT k FROM insert_progress_src");
+    if (setup)
+        chdb_destroy_query_result(setup);
+
+    chdb_result * result = run(conn,
+        "INSERT INTO insert_progress_src VALUES (1), (2)");
+    if (!result)
+        return;
+
+    uint64_t rows_written = chdb_result_rows_written(result);
+    printf("  rows_written=%" PRIu64 " (2 source + 2 cascaded MV)\n", rows_written);
+    CHECK(rows_written == 4, "rows_written == 4: includes cascaded MV writes");
+    chdb_destroy_query_result(result);
+}
+
+int main(int argc, char ** argv)
+{
+    (void)argc; (void)argv;
+
+    char arg0[] = "clickhouse";
+    char arg1[] = "--multiquery";
+    char * args[] = {arg0, arg1};
+    chdb_connection * conn = chdb_connect(2, args);
+    if (!conn) {
+        fprintf(stderr, "chdb_connect failed\n");
+        return 1;
+    }
+
+    test_select_reports_zero_written(*conn);
+    test_plain_insert_reports_written(*conn);
+    test_insert_select_reports_written(*conn);
+    test_insert_with_mv_includes_cascade(*conn);
+
+    chdb_close_conn(conn);
+
+    printf("\n== summary: %d failed assertions ==\n", g_failed_assertions);
+    return g_failed_assertions == 0 ? 0 : 1;
+}

--- a/examples/runInsertProgressTest.sh
+++ b/examples/runInsertProgressTest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Compile and link"
+clang chdbInsertProgressTest.c -o chdbInsertProgressTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbInsertProgressTest
+
+echo "Run it:"
+./chdbInsertProgressTest

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -235,6 +235,8 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
         auto * local_connection = static_cast<LocalConnection *>(connection.get());
         size_t storage_rows_read = local_connection->getCHDBProgress().read_rows;
         size_t storage_bytes_read = local_connection->getCHDBProgress().read_bytes;
+        size_t rows_written = local_connection->getCHDBProgress().written_rows;
+        size_t bytes_written = local_connection->getCHDBProgress().written_bytes;
 
         if (format_str == CHUNK_COLLECT_FORMAT_NAME)
         {
@@ -245,7 +247,9 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
                 getProcessedRows(),
                 getProcessedBytes(),
                 storage_rows_read,
-                storage_bytes_read);
+                storage_bytes_read,
+                rows_written,
+                bytes_written);
 #if USE_PYTHON
             python_table_cache->clear();
 #endif
@@ -258,7 +262,9 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
             getProcessedRows(),
             getProcessedBytes(),
             storage_rows_read,
-            storage_bytes_read);
+            storage_bytes_read,
+            rows_written,
+            bytes_written);
 #if USE_PYTHON
         python_table_cache->clear();
 #endif
@@ -336,6 +342,8 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
         const auto old_processed_bytes = getProcessedBytes();
         size_t old_storage_rows_read = local_connection->getCHDBProgress().read_rows;
         size_t old_storage_bytes_read = local_connection->getCHDBProgress().read_bytes;
+        size_t old_rows_written = local_connection->getCHDBProgress().written_rows;
+        size_t old_bytes_written = local_connection->getCHDBProgress().written_bytes;
         const auto old_elapsed_time = getElapsedTime();
 
         CHDB::QueryResultPtr res;
@@ -349,6 +357,8 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
             const auto processed_bytes = getProcessedBytes();
             size_t storage_rows_read = local_connection->getCHDBProgress().read_rows;
             size_t storage_bytes_read = local_connection->getCHDBProgress().read_bytes;
+            size_t rows_written = local_connection->getCHDBProgress().written_rows;
+            size_t bytes_written = local_connection->getCHDBProgress().written_bytes;
             const auto elapsed_time = getElapsedTime();
 
             if (Poco::toLower(default_output_format) == CHUNK_COLLECT_FORMAT_NAME)
@@ -361,7 +371,9 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
                     rows_read,
                     processed_bytes - old_processed_bytes,
                     storage_rows_read - old_storage_rows_read,
-                    storage_bytes_read - old_storage_bytes_read);
+                    storage_bytes_read - old_storage_bytes_read,
+                    rows_written - old_rows_written,
+                    bytes_written - old_bytes_written);
 
 #if USE_PYTHON
                 py::gil_scoped_acquire acquire;
@@ -388,7 +400,9 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
                         processed_rows - old_processed_rows,
                         processed_bytes - old_processed_bytes,
                         storage_rows_read - old_storage_rows_read,
-                        storage_bytes_read - old_storage_bytes_read);
+                        storage_bytes_read - old_storage_bytes_read,
+                        rows_written - old_rows_written,
+                        bytes_written - old_bytes_written);
                 }
                 else
                 {

--- a/programs/local/QueryResult.h
+++ b/programs/local/QueryResult.h
@@ -75,14 +75,18 @@ public:
         uint64_t rows_read_,
         uint64_t bytes_read_,
         uint64_t storage_rows_read_,
-        uint64_t storage_bytes_read_)
+        uint64_t storage_bytes_read_,
+        uint64_t rows_written_ = 0,
+        uint64_t bytes_written_ = 0)
         : QueryResult(QueryResultType::RESULT_TYPE_MATERIALIZED),
         result_buffer(std::move(result_buffer_)),
         elapsed(elapsed_),
         rows_read(rows_read_),
         bytes_read(bytes_read_),
         storage_rows_read(storage_rows_read_),
-        storage_bytes_read(storage_bytes_read_)
+        storage_bytes_read(storage_bytes_read_),
+        rows_written(rows_written_),
+        bytes_written(bytes_written_)
     {}
 
     explicit MaterializedQueryResult(String error_message_)
@@ -109,6 +113,12 @@ public:
     uint64_t bytes_read;
     uint64_t storage_rows_read;
     uint64_t storage_bytes_read;
+    /// Write progress of INSERT queries, accumulated from the engine's
+    /// CountingTransform progress callbacks. Includes rows/bytes written by
+    /// cascaded materialized views — same semantics as the HTTP interface's
+    /// X-ClickHouse-Summary.written_rows.
+    uint64_t rows_written;
+    uint64_t bytes_written;
 };
 
 /// Raw Chunk-bag query result. Produced by ChunkCollectorOutputFormat-backed
@@ -124,7 +134,9 @@ public:
         uint64_t rows_read_,
         uint64_t bytes_read_,
         uint64_t storage_rows_read_,
-        uint64_t storage_bytes_read_)
+        uint64_t storage_bytes_read_,
+        uint64_t rows_written_ = 0,
+        uint64_t bytes_written_ = 0)
         : QueryResult(QueryResultType::RESULT_TYPE_CHUNK),
         chunks(std::move(chunks_)),
         header(header_),
@@ -132,7 +144,9 @@ public:
         rows_read(rows_read_),
         bytes_read(bytes_read_),
         storage_rows_read(storage_rows_read_),
-        storage_bytes_read(storage_bytes_read_)
+        storage_bytes_read(storage_bytes_read_),
+        rows_written(rows_written_),
+        bytes_written(bytes_written_)
     {}
 
     explicit ChunkQueryResult(String error_message_)
@@ -152,6 +166,8 @@ public:
     uint64_t bytes_read;
     uint64_t storage_rows_read;
     uint64_t storage_bytes_read;
+    uint64_t rows_written;
+    uint64_t bytes_written;
 };
 
 using QueryResultPtr = std::unique_ptr<QueryResult>;

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -1024,6 +1024,38 @@ uint64_t chdb_result_storage_bytes_read(chdb_result * result)
     return 0;
 }
 
+uint64_t chdb_result_rows_written(chdb_result * result)
+{
+    if (!result)
+        return 0;
+
+    auto * query_result = reinterpret_cast<QueryResult *>(result);
+
+    if (query_result->getType() == QueryResultType::RESULT_TYPE_MATERIALIZED)
+    {
+        auto * materialized_result = reinterpret_cast<MaterializedQueryResult *>(result);
+        return materialized_result->rows_written;
+    }
+
+    return 0;
+}
+
+uint64_t chdb_result_bytes_written(chdb_result * result)
+{
+    if (!result)
+        return 0;
+
+    auto * query_result = reinterpret_cast<QueryResult *>(result);
+
+    if (query_result->getType() == QueryResultType::RESULT_TYPE_MATERIALIZED)
+    {
+        auto * materialized_result = reinterpret_cast<MaterializedQueryResult *>(result);
+        return materialized_result->bytes_written;
+    }
+
+    return 0;
+}
+
 const char * chdb_result_error(chdb_result * result)
 {
     if (!result)

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -480,6 +480,25 @@ CHDB_EXPORT uint64_t chdb_result_storage_rows_read(chdb_result * result);
 CHDB_EXPORT uint64_t chdb_result_storage_bytes_read(chdb_result * result);
 
 /**
+ * Gets rows written by the query (INSERT write progress)
+ * Note: includes rows written by cascaded materialized views, same semantics
+ * as X-ClickHouse-Summary.written_rows on the HTTP interface — not just the
+ * input rows accepted by the target table.
+ * @param result The query result handle
+ * @return Number of rows written, 0 for read-only queries
+ */
+CHDB_EXPORT uint64_t chdb_result_rows_written(chdb_result * result);
+
+/**
+ * Gets bytes written by the query (INSERT write progress)
+ * Note: includes bytes written by cascaded materialized views, same semantics
+ * as X-ClickHouse-Summary.written_bytes on the HTTP interface.
+ * @param result The query result handle
+ * @return Number of bytes written, 0 for read-only queries
+ */
+CHDB_EXPORT uint64_t chdb_result_bytes_written(chdb_result * result);
+
+/**
  * Retrieves error message from query execution
  * @param result The query result handle
  * @return Null-terminated error description, NULL if no error


### PR DESCRIPTION
Closes #88

## What

Adds `chdb_result_rows_written()` / `chdb_result_bytes_written()` to the C API, exposing the INSERT write progress that the engine already tracks but never copied into the result object.

## How

Exactly the last-mile wiring described in #88:

- `programs/local/QueryResult.h`: `MaterializedQueryResult` and `ChunkQueryResult` gain `rows_written` / `bytes_written` fields (defaulted to 0, so error-path constructors are unaffected).
- `programs/local/ChdbClient.cpp`: `executeMaterializedQuery` copies `getCHDBProgress().written_rows` / `.written_bytes` into both result types; the streaming fetch path records per-fetch deltas, mirroring the existing `storage_rows_read` handling.
- `programs/local/chdb.h` + `chdb.cpp`: two new accessors following the `chdb_result_storage_rows_read` precedent (opaque-handle accessor, returns 0 for non-materialized results and NULL handles).
- `chdb/libchdb_export.map` + `chdb/libchdb_export_macos.txt`: new symbols added to both export allow-lists.
- Deprecated `local_result_v2` is untouched. ABI-safe: additive accessors on an opaque handle.

## Semantics

`written_rows` includes cascaded materialized-view writes — same semantics as `X-ClickHouse-Summary.written_rows` over HTTP. The doc comments in `chdb.h` call this out so bindings don't present it as "input rows accepted".

The empirical check requested in the issue is done and encoded as a test assertion: on the embedded path both counting layers feed `chdb_progress`, so a 2-row INSERT into a table with one attached MV reports `rows_written=4`.

## Test

New `examples/chdbInsertProgressTest.c` + `examples/runInsertProgressTest.sh`, wired into all four wheel CI workflows next to the existing example tests. It verifies:

1. SELECT reports `rows_written == 0` / `bytes_written == 0`
2. 3-row `INSERT ... FORMAT JSONEachRow` reports `rows_written == 3`, `bytes_written > 0`
3. `INSERT ... SELECT numbers(1000)` reports `rows_written == 1000`
4. INSERT with attached MV reports `rows_written == 4` (2 source + 2 cascaded)

Verified locally on macOS arm64: all 4 tests pass against a freshly built `libchdb.so`; Python module smoke test (query + session INSERT) shows no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)