### PR TITLE
[CI BASELINE — DO NOT MERGE] blacklist control for #93

### DIFF
--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -230,6 +230,10 @@ jobs:
             pyenv shell $version
             python -m pip install --upgrade pip
             python -m pip install setuptools wheel tox pandas pyarrow twine psutil deltalake wheel>=0.40.0 jupyter nbconvert
+            # numba (via llvmlite) bundles its own libc++; tests/test_numba_compatibility.py uses it to
+            # guard against the macOS weak-symbol coalescing crash. Tolerate Python versions that have no
+            # numba wheel yet -- the test auto-skips when numba is unavailable.
+            python -m pip install numba || echo "numba unavailable for Python $version (numba compatibility test will skip)"
             pyenv shell --unset
           done
       - name: Remove /usr/local/bin/python3
@@ -395,6 +399,26 @@ jobs:
             done
             pyenv shell --unset
           done
+        continue-on-error: false
+      - name: "numba import-order regression (conda numba, arm64)"
+        run: |
+          # Regression guard for the macOS import-order crash. conda's libc++
+          # exports std::__1 as STRONG symbols; without the stub/shim
+          # std::__1-hiding fix they override chdb's WEAK std::__1 (~86
+          # basic_string methods used by pybind11 EnsureSharedLibraryIsLoaded),
+          # corrupting the library-name string and aborting. pip numba wheels
+          # delocate libc++ and cannot reproduce this; conda numba can.
+          curl -Ls -o /tmp/mc.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+          bash /tmp/mc.sh -b -p "$HOME/mc"
+          source "$HOME/mc/bin/activate"
+          conda create -y -n nb -c conda-forge "python=3.11" numba pip
+          conda activate nb
+          python -m pip install dist/chdb_core-*.whl --force-reinstall --no-cache-dir
+          echo "=== control: import chdb then numba ==="
+          python -c "import chdb; import numba; print(chdb.query('SELECT 2', 'CSV'))"
+          echo "=== regressing: import numba then chdb (must NOT abort with the fix) ==="
+          python -c "import numba; import chdb; print(chdb.query('SELECT 1', 'CSV'))"
+          conda deactivate
         continue-on-error: false
       - name: Test torch compatibility on Python 3.11
         run: |

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -230,6 +230,10 @@ jobs:
             pyenv shell $version
             python -m pip install --upgrade pip
             python -m pip install setuptools tox pandas pyarrow twine psutil deltalake wheel>=0.40.0 jupyter nbconvert
+            # numba (via llvmlite) bundles its own libc++; tests/test_numba_compatibility.py uses it to
+            # guard against the macOS weak-symbol coalescing crash. Tolerate Python versions that have no
+            # numba wheel yet -- the test auto-skips when numba is unavailable.
+            python -m pip install numba || echo "numba unavailable for Python $version (numba compatibility test will skip)"
             pyenv shell --unset
           done
       - name: Remove /usr/local/bin/python3
@@ -395,6 +399,26 @@ jobs:
             done
             pyenv shell --unset
           done
+        continue-on-error: false
+      - name: "numba import-order regression (conda numba, x86_64)"
+        run: |
+          # Regression guard for the macOS import-order crash. conda's libc++
+          # exports std::__1 as STRONG symbols; without the stub/shim
+          # std::__1-hiding fix they override chdb's WEAK std::__1 (~86
+          # basic_string methods used by pybind11 EnsureSharedLibraryIsLoaded),
+          # corrupting the library-name string and aborting. pip numba wheels
+          # delocate libc++ and cannot reproduce this; conda numba can.
+          curl -Ls -o /tmp/mc.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+          bash /tmp/mc.sh -b -p "$HOME/mc"
+          source "$HOME/mc/bin/activate"
+          conda create -y -n nb -c conda-forge "python=3.11" numba pip
+          conda activate nb
+          python -m pip install dist/chdb_core-*.whl --force-reinstall --no-cache-dir
+          echo "=== control: import chdb then numba ==="
+          python -c "import chdb; import numba; print(chdb.query('SELECT 2', 'CSV'))"
+          echo "=== regressing: import numba then chdb (must NOT abort with the fix) ==="
+          python -c "import numba; import chdb; print(chdb.query('SELECT 1', 'CSV'))"
+          conda deactivate
         continue-on-error: false
       - name: Test torch compatibility on Python 3.11
         run: |

--- a/contrib/pybind11-cmake/CMakeLists.txt
+++ b/contrib/pybind11-cmake/CMakeLists.txt
@@ -47,6 +47,38 @@ message(STATUS "Using stable-ABI pybind11 from ${LIBRARY_DIR}")
 
 set(PYBIND11_LIB_SUFFIX "chdb")
 
+# chdb_spec: On macOS the pybind11 stub/shim dylibs below statically link
+# ClickHouse's bundled libcxx (contrib/libcxx) and export its std::__1::*
+# methods (e.g. std::__1::basic_string) as *weak external* symbols.
+#
+# When numba is imported before chdb it pulls in conda's own libc++.dylib,
+# which exports the same std::__1::* methods as *strong* symbols. dyld resolves
+# a strong definition over a weak one, so conda's libc++ takes over ~86 of the
+# stub's weak basic_string methods -- including the ones pybind11
+# non-limited-api EnsureSharedLibraryIsLoaded() uses to build the shim library
+# name. The two libc++ ABIs differ, so chdb's std::string is misinterpreted:
+# the library-name string is corrupted, dlopen gets a garbled path, and the
+# interpreter aborts at import time.
+#
+# Note: this is a strong-over-weak override, NOT weak<->weak coalescing -- the
+# weak-vs-weak symbol intersection is empty. (pip numba wheels delocate their
+# bundled libc++ so they do not collide and cannot reproduce this; conda numba
+# does, which is what the macOS CI regression step exercises.)
+#
+# The main _chdb.abi3.so already hides these symbols; only these two standalone
+# targets leaked weak std::__1. Strip std::__1 from their export tables so each
+# binds to its own statically linked libcxx internally.
+if (APPLE)
+    set(CHDB_PYBIND11_DARWIN_UNEXPORTED "${CMAKE_CURRENT_BINARY_DIR}/darwin_unexported_libcxx_symbols.txt")
+    file(WRITE "${CHDB_PYBIND11_DARWIN_UNEXPORTED}"
+"__ZNSt3__1*
+__ZNKSt3__1*
+__ZTVNSt3__1*
+__ZTINSt3__1*
+__ZTSNSt3__1*
+")
+endif()
+
 # Build the main pybind11nonlimitedapi_stubs library
 set(STUBS_SOURCES
     "${LIBRARY_DIR}/source/non_limited_api/non_limited_api_stubs.cpp"
@@ -81,6 +113,9 @@ set_target_properties(pybind11_stubs PROPERTIES
 
 if (APPLE)
     target_link_options(pybind11_stubs PRIVATE -undefined dynamic_lookup)
+    if (CHDB_PYBIND11_DARWIN_UNEXPORTED)
+        target_link_options(pybind11_stubs PRIVATE "-Wl,-unexported_symbols_list,${CHDB_PYBIND11_DARWIN_UNEXPORTED}")
+    endif()
 else()
     target_link_options(pybind11_stubs PRIVATE -Wl,--unresolved-symbols=ignore-all)
     if (USE_MUSL)
@@ -123,6 +158,9 @@ if(Python_FOUND OR CHDB_CROSSCOMPILING)
 
     if (APPLE)
         target_link_options(${PYBIND11_NONLIMITEDAPI_LIBNAME} PRIVATE -undefined dynamic_lookup)
+        if (CHDB_PYBIND11_DARWIN_UNEXPORTED)
+            target_link_options(${PYBIND11_NONLIMITEDAPI_LIBNAME} PRIVATE "-Wl,-unexported_symbols_list,${CHDB_PYBIND11_DARWIN_UNEXPORTED}")
+        endif()
     else()
         target_link_options(${PYBIND11_NONLIMITEDAPI_LIBNAME} PRIVATE -Wl,--unresolved-symbols=ignore-all)
         if (USE_MUSL)

--- a/tests/test_numba_compatibility.py
+++ b/tests/test_numba_compatibility.py
@@ -1,0 +1,76 @@
+#!python3
+"""Regression test: chdb must import cleanly even after numba (macOS).
+
+On macOS, chdb's pybind11 stub/shim dylibs statically link ClickHouse's bundled
+libcxx and used to export libc++ ``std::__1`` methods (e.g. ``basic_string``) as
+*weak external* symbols. numba (through llvmlite) bundles its own libc++; when
+``import numba`` runs before ``import chdb``, dyld's weak-symbol coalescing made
+chdb bind to numba's ABI-incompatible libc++, corrupting memory inside
+pybind11's ``EnsureSharedLibraryIsLoaded`` and aborting the interpreter with a
+garbled ``dlopen`` path. Hiding ``std::__1`` from those dylibs' export tables
+fixes it.
+
+Because the failure aborts the whole process, each import order is exercised in
+a subprocess and asserted via its exit code, rather than importing in-process
+(which would take down the entire test runner).
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import unittest
+
+HAS_NUMBA = importlib.util.find_spec("numba") is not None
+IS_MACOS = sys.platform == "darwin"
+IS_LITE = os.environ.get("CHDB_LITE") == "1"
+
+
+@unittest.skipUnless(
+    HAS_NUMBA and IS_MACOS and not IS_LITE,
+    "regression test requires numba on macOS (non-lite build)",
+)
+class TestNumbaCompatibility(unittest.TestCase):
+    """chdb and numba must coexist regardless of import order on macOS."""
+
+    def _run_import(self, code):
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+    def test_import_numba_then_chdb(self):
+        # The order that used to abort: numba first, then chdb.
+        proc = self._run_import(
+            "import numba; import chdb; "
+            "print(chdb.query('SELECT 1 AS a', 'CSV'), end='')"
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "`import numba; import chdb` aborted "
+            f"(returncode={proc.returncode}).\n"
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
+        self.assertIn("1", proc.stdout)
+
+    def test_import_chdb_then_numba(self):
+        # Control: the order that always worked.
+        proc = self._run_import(
+            "import chdb; import numba; "
+            "print(chdb.query('SELECT 2 AS a', 'CSV'), end='')"
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "`import chdb; import numba` aborted "
+            f"(returncode={proc.returncode}).\n"
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
+        self.assertIn("2", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Diagnostic baseline for #93, **not for merge**.

This branch is exactly the original (blacklist) fix from #93 — i.e. #93 **minus** the whitelist commit `8fee8e9` (`-exported_symbols_list` allowlist conversion). Same tree as commit `9eecda6`.

Purpose: run the identical macOS CI on the pre-whitelist code to determine whether the macOS test failures seen on #93's head (`8fee8e9`) are caused by the whitelist conversion or are pre-existing/flaky.

- If this run shows the **same** macOS failures → pre-existing, unrelated to the allowlist.
- If this run is **clean** → the allowlist commit introduced them.

Will be closed once the comparison is done.