### PR TITLE
Live query progress, peak memory, and cancellation for the WebAssembly build

### DIFF
--- a/packages/chdb-wasm/README.md
+++ b/packages/chdb-wasm/README.md
@@ -1,6 +1,6 @@
 # chdb-wasm
 
-[chdb](https://github.com/chdb-io/chdb) (an embedded [ClickHouse](https://clickhouse.com)) compiled to WebAssembly, with an **async, non-blocking, worker-based** JS/TS API — modeled on [duckdb-wasm](https://github.com/duckdb/duckdb-wasm).
+[chdb](https://github.com/chdb-io/chdb) (an embedded [ClickHouse](https://clickhouse.com)) compiled to WebAssembly, with an **async, non-blocking, worker-based** JS/TS API.
 
 The wasm engine runs inside a Web Worker, so queries return Promises and the
 caller's thread (your UI / event loop) is never blocked.

--- a/packages/chdb-wasm/package.json
+++ b/packages/chdb-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chdb-wasm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "chdb (ClickHouse) compiled to WebAssembly, with an async, non-blocking, worker-based API",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -2,7 +2,8 @@
 // a worker and queries return Promises, so the calling thread never blocks.
 
 import { ChdbError } from './status.ts';
-import type { ConnHandle, RequestType, WireResult, WorkerResponse } from './protocol.ts';
+import type { ConnHandle, RequestType, WireResult, WorkerResponse, QueryProgress } from './protocol.ts';
+export type { QueryProgress } from './protocol.ts';
 
 const isNode = typeof process !== 'undefined' && !!(process as any).versions?.node;
 
@@ -15,6 +16,8 @@ export interface ChdbResult {
   /** Source rows/bytes SCANNED from storage (ClickHouse read_rows) — for "Processed N rows, …". */
   scannedRows: number;
   scannedBytes: number;
+  /** Peak memory (bytes) observed during execution, tracked from the progress stream. */
+  peakMemoryUsage: number;
   elapsedSeconds: number;
   /** Decode the bytes as UTF-8 text. */
   text(): string;
@@ -31,9 +34,16 @@ export interface CreateOptions {
   onProgress?: (loaded: number, total: number) => void;
 }
 
+/** Per-call options for query()/queryStream(). */
+export interface QueryOptions {
+  /** Live execution-progress callback (mt bundle; throttled ~100 ms in the engine). */
+  onProgress?: (p: QueryProgress) => void;
+}
+
 interface Pending {
   resolve: (v: any) => void;
   reject: (e: any) => void;
+  onProgress?: (p: QueryProgress) => void;
 }
 
 function wrap(r: WireResult): ChdbResult {
@@ -43,6 +53,7 @@ function wrap(r: WireResult): ChdbResult {
     bytesRead: r.bytesRead,
     scannedRows: r.scannedRows,
     scannedBytes: r.scannedBytes,
+    peakMemoryUsage: 0,
     elapsedSeconds: r.elapsedSeconds,
     text: () => new TextDecoder().decode(r.data),
   };
@@ -89,6 +100,11 @@ export class AsyncChdb {
       this.onProgress?.(msg.loaded, msg.total);
       return;
     }
+    if ('event' in msg && msg.event === 'queryProgress') {
+      const { readRows, totalRowsToRead, readBytes, totalBytesToRead, memoryUsage, elapsedNs } = msg;
+      this.pending.get(msg.id)?.onProgress?.({ readRows, totalRowsToRead, readBytes, totalBytesToRead, memoryUsage, elapsedNs });
+      return;
+    }
     const p = this.pending.get(msg.id);
     if (!p) return;
     this.pending.delete(msg.id);
@@ -96,17 +112,24 @@ export class AsyncChdb {
     else p.reject(new ChdbError('error' in msg ? msg.error : 'unknown worker error'));
   }
 
-  private request(type: RequestType, payload?: any, transfer?: Transferable[]): Promise<any> {
+  private request(type: RequestType, payload?: any, transfer?: Transferable[], onProgress?: (p: QueryProgress) => void): Promise<any> {
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
+      this.pending.set(id, { resolve, reject, onProgress });
       (this.worker as any).postMessage({ id, type, payload }, transfer ?? []);
     });
   }
 
-  /** Run a query on the implicit :memory: connection. */
-  async query(sql: string, format = 'CSV'): Promise<ChdbResult> {
-    return wrap(await this.request('query', { sql, format }));
+  /** Run a query on the implicit :memory: connection. opts.onProgress gets live execution progress. */
+  async query(sql: string, format = 'CSV', opts?: QueryOptions): Promise<ChdbResult> {
+    let peak = 0;
+    const onProgress = (p: QueryProgress) => {
+      if (p.memoryUsage > peak) peak = p.memoryUsage;
+      opts?.onProgress?.(p);
+    };
+    const r = wrap(await this.request('query', { sql, format }, undefined, onProgress));
+    r.peakMemoryUsage = peak;
+    return r;
   }
 
   /**
@@ -162,8 +185,8 @@ export class AsyncChdb {
   }
 
   /** @internal */
-  _queryConn(conn: ConnHandle, sql: string, format: string): Promise<WireResult> {
-    return this.request('queryConn', { conn, sql, format });
+  _queryConn(conn: ConnHandle, sql: string, format: string, onProgress?: (p: QueryProgress) => void): Promise<WireResult> {
+    return this.request('queryConn', { conn, sql, format }, undefined, onProgress);
   }
   /** @internal */
   _closeConn(conn: ConnHandle): Promise<void> {
@@ -174,8 +197,8 @@ export class AsyncChdb {
     return this.request('streamStart', { conn, sql, format });
   }
   /** @internal */
-  _streamFetch(conn: ConnHandle, stream: ConnHandle): Promise<{ done: boolean; result?: WireResult }> {
-    return this.request('streamFetch', { conn, stream });
+  _streamFetch(conn: ConnHandle, stream: ConnHandle, onProgress?: (p: QueryProgress) => void): Promise<{ done: boolean; result?: WireResult }> {
+    return this.request('streamFetch', { conn, stream }, undefined, onProgress);
   }
   /** @internal */
   _streamCancel(conn: ConnHandle, stream: ConnHandle): Promise<void> {
@@ -201,18 +224,32 @@ export class AsyncChdbConnection {
     this.db = db;
     this.conn = conn;
   }
-  async query(sql: string, format = 'CSV'): Promise<ChdbResult> {
-    return wrap(await this.db._queryConn(this.conn, sql, format));
+  async query(sql: string, format = 'CSV', opts?: QueryOptions): Promise<ChdbResult> {
+    let peak = 0;
+    const onProgress = (p: QueryProgress) => {
+      if (p.memoryUsage > peak) peak = p.memoryUsage;
+      opts?.onProgress?.(p);
+    };
+    const r = wrap(await this.db._queryConn(this.conn, sql, format, onProgress));
+    r.peakMemoryUsage = peak;
+    return r;
   }
 
   /** Stream a query's results chunk-by-chunk (yields the worker between chunks). */
-  async *queryStream(sql: string, format = 'CSV'): AsyncGenerator<ChdbResult> {
+  async *queryStream(sql: string, format = 'CSV', opts?: QueryOptions): AsyncGenerator<ChdbResult> {
     const { stream } = await this.db._streamStart(this.conn, sql, format);
+    let peak = 0;
+    const onProgress = (p: QueryProgress) => {
+      if (p.memoryUsage > peak) peak = p.memoryUsage;
+      opts?.onProgress?.(p);
+    };
     try {
       for (;;) {
-        const { done, result } = await this.db._streamFetch(this.conn, stream);
+        const { done, result } = await this.db._streamFetch(this.conn, stream, onProgress);
         if (done || !result) break;
-        yield wrap(result);
+        const r = wrap(result);
+        r.peakMemoryUsage = peak;
+        yield r;
       }
     } finally {
       await this.db._streamCancel(this.conn, stream);

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -124,21 +124,18 @@ export class AsyncChdb {
 
   /** Snapshot the shared progress struct, rejecting a torn read via the seq guard. */
   private readProgress(v: BigInt64Array): QueryProgress {
-    for (let i = 0; i < 4; i++) {
-      const s1 = Atomics.load(v, 0);
-      const p: QueryProgress = {
-        readRows: Number(v[1]), totalRowsToRead: Number(v[2]),
-        readBytes: Number(v[3]), totalBytesToRead: Number(v[4]),
-        elapsedNs: Number(v[5]),
-      };
-      if (Atomics.load(v, 0) === s1) return p;   // seq unchanged -> consistent snapshot
-    }
-    // Writes are ~ms apart; after a few retries take the (cosmetically-fine) latest read.
-    return {
+    const snap = (): QueryProgress => ({
       readRows: Number(v[1]), totalRowsToRead: Number(v[2]),
       readBytes: Number(v[3]), totalBytesToRead: Number(v[4]),
       elapsedNs: Number(v[5]),
-    };
+    });
+    for (let i = 0; i < 4; i++) {
+      const s1 = Atomics.load(v, 0);
+      const p = snap();
+      if (Atomics.load(v, 0) === s1) return p;   // seq unchanged -> consistent snapshot
+    }
+    // Writes are ~ms apart; after a few retries take the (cosmetically-fine) latest read.
+    return snap();
   }
 
   /**

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -64,6 +64,8 @@ export class AsyncChdb {
   private nextId = 1;
   private readonly pending = new Map<number, Pending>();
   private onProgress?: (loaded: number, total: number) => void;
+  /** mt-only cancel-flag view into the shared wasm memory (set by create() from init). */
+  private cancelFlag?: Int32Array;
 
   private constructor(worker: any, onProgress?: (loaded: number, total: number) => void) {
     this.worker = worker;
@@ -85,7 +87,9 @@ export class AsyncChdb {
 
     const self = new AsyncChdb(worker, opts.onProgress);
     self.attach();
-    await self.request('init', { moduleUrl: opts.moduleUrl, wasmUrl: opts.wasmUrl });
+    const initResult = await self.request('init', { moduleUrl: opts.moduleUrl, wasmUrl: opts.wasmUrl });
+    if (initResult?.cancelMem)
+      self.cancelFlag = new Int32Array(initResult.cancelMem, initResult.cancelAddr, 1);
     return self;
   }
 
@@ -113,6 +117,9 @@ export class AsyncChdb {
   }
 
   private request(type: RequestType, payload?: any, transfer?: Transferable[], onProgress?: (p: QueryProgress) => void): Promise<any> {
+    // Clear a stale cancel flag when a new query starts.
+    if (this.cancelFlag && (type === 'query' || type === 'queryConn' || type === 'streamStart'))
+      Atomics.store(this.cancelFlag, 0, 0);
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject, onProgress });
@@ -130,6 +137,17 @@ export class AsyncChdb {
     const r = wrap(await this.request('query', { sql, format }, undefined, onProgress));
     r.peakMemoryUsage = peak;
     return r;
+  }
+
+  /**
+   * Request cancellation of the currently-running query (mt bundle only): the in-flight
+   * query()/queryStream() rejects with a cancellation error. Throws on the single-threaded
+   * build, which runs queries synchronously and cannot be interrupted mid-query.
+   */
+  cancel(): void {
+    if (!this.cancelFlag)
+      throw new ChdbError('query cancellation is only supported on the multi-threaded (mt) build');
+    Atomics.store(this.cancelFlag, 0, 1);
   }
 
   /**
@@ -233,6 +251,11 @@ export class AsyncChdbConnection {
     const r = wrap(await this.db._queryConn(this.conn, sql, format, onProgress));
     r.peakMemoryUsage = peak;
     return r;
+  }
+
+  /** Cancel the running query (mt only). See AsyncChdb.cancel(). */
+  cancel(): void {
+    this.db.cancel();
   }
 
   /** Stream a query's results chunk-by-chunk (yields the worker between chunks). */

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -9,8 +9,12 @@ const isNode = typeof process !== 'undefined' && !!(process as any).versions?.no
 export interface ChdbResult {
   /** Raw result bytes (CSV/JSON/… per the requested format). */
   data: Uint8Array;
+  /** Result size: rows/bytes RETURNED (e.g. 1 for `SELECT count()`), not source rows scanned. */
   rowsRead: number;
   bytesRead: number;
+  /** Source rows/bytes SCANNED from storage (ClickHouse read_rows) — for "Processed N rows, …". */
+  scannedRows: number;
+  scannedBytes: number;
   elapsedSeconds: number;
   /** Decode the bytes as UTF-8 text. */
   text(): string;
@@ -37,6 +41,8 @@ function wrap(r: WireResult): ChdbResult {
     data: r.data,
     rowsRead: r.rowsRead,
     bytesRead: r.bytesRead,
+    scannedRows: r.scannedRows,
+    scannedBytes: r.scannedBytes,
     elapsedSeconds: r.elapsedSeconds,
     text: () => new TextDecoder().decode(r.data),
   };

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -1,5 +1,5 @@
-// Main-thread async client. Mirrors duckdb-wasm's AsyncDuckDB: the wasm runs in
-// a worker and queries return Promises, so the calling thread never blocks.
+// Main-thread async client: the wasm runs in a worker and queries return Promises,
+// so the calling thread never blocks.
 
 import { ChdbError } from './status.ts';
 import type { ConnHandle, RequestType, WireResult, WorkerResponse, QueryProgress } from './protocol.ts';

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -43,7 +43,6 @@ export interface QueryOptions {
 interface Pending {
   resolve: (v: any) => void;
   reject: (e: any) => void;
-  onProgress?: (p: QueryProgress) => void;
 }
 
 function wrap(r: WireResult): ChdbResult {
@@ -64,8 +63,9 @@ export class AsyncChdb {
   private nextId = 1;
   private readonly pending = new Map<number, Pending>();
   private onProgress?: (loaded: number, total: number) => void;
-  /** mt-only cancel-flag view into the shared wasm memory (set by create() from init). */
+  /** mt-only views into the shared wasm memory (set by create() from init). */
   private cancelFlag?: Int32Array;
+  private progressView?: BigInt64Array;
 
   private constructor(worker: any, onProgress?: (loaded: number, total: number) => void) {
     this.worker = worker;
@@ -88,8 +88,11 @@ export class AsyncChdb {
     const self = new AsyncChdb(worker, opts.onProgress);
     self.attach();
     const initResult = await self.request('init', { moduleUrl: opts.moduleUrl, wasmUrl: opts.wasmUrl });
-    if (initResult?.cancelMem)
-      self.cancelFlag = new Int32Array(initResult.cancelMem, initResult.cancelAddr, 1);
+    if (initResult?.sharedMem) {
+      self.cancelFlag = new Int32Array(initResult.sharedMem, initResult.cancelAddr, 1);
+      // 7 × int64: [seq, readRows, totalRowsToRead, readBytes, totalBytesToRead, memoryUsage, elapsedNs].
+      self.progressView = new BigInt64Array(initResult.sharedMem, initResult.progressAddr, 7);
+    }
     return self;
   }
 
@@ -104,11 +107,6 @@ export class AsyncChdb {
       this.onProgress?.(msg.loaded, msg.total);
       return;
     }
-    if ('event' in msg && msg.event === 'queryProgress') {
-      const { readRows, totalRowsToRead, readBytes, totalBytesToRead, memoryUsage, elapsedNs } = msg;
-      this.pending.get(msg.id)?.onProgress?.({ readRows, totalRowsToRead, readBytes, totalBytesToRead, memoryUsage, elapsedNs });
-      return;
-    }
     const p = this.pending.get(msg.id);
     if (!p) return;
     this.pending.delete(msg.id);
@@ -116,25 +114,73 @@ export class AsyncChdb {
     else p.reject(new ChdbError('error' in msg ? msg.error : 'unknown worker error'));
   }
 
-  private request(type: RequestType, payload?: any, transfer?: Transferable[], onProgress?: (p: QueryProgress) => void): Promise<any> {
+  private request(type: RequestType, payload?: any, transfer?: Transferable[]): Promise<any> {
     // Clear a stale cancel flag when a new query starts.
     if (this.cancelFlag && (type === 'query' || type === 'queryConn' || type === 'streamStart'))
       Atomics.store(this.cancelFlag, 0, 0);
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject, onProgress });
+      this.pending.set(id, { resolve, reject });
       (this.worker as any).postMessage({ id, type, payload }, transfer ?? []);
     });
+  }
+
+  /** Snapshot the shared progress struct, rejecting a torn read via the seq guard. */
+  private readProgress(v: BigInt64Array): QueryProgress {
+    for (let i = 0; i < 4; i++) {
+      const s1 = Atomics.load(v, 0);
+      const p: QueryProgress = {
+        readRows: Number(v[1]), totalRowsToRead: Number(v[2]),
+        readBytes: Number(v[3]), totalBytesToRead: Number(v[4]),
+        memoryUsage: Number(v[5]), elapsedNs: Number(v[6]),
+      };
+      if (Atomics.load(v, 0) === s1) return p;   // seq unchanged -> consistent snapshot
+    }
+    // Writes are ~ms apart; after a few retries take the (cosmetically-fine) latest read.
+    return {
+      readRows: Number(v[1]), totalRowsToRead: Number(v[2]),
+      readBytes: Number(v[3]), totalBytesToRead: Number(v[4]),
+      memoryUsage: Number(v[5]), elapsedNs: Number(v[6]),
+    };
+  }
+
+  /**
+   * Poll the shared progress struct (mt build) while a query runs, invoking cb whenever the
+   * engine advances it. The worker thread blocks in the synchronous query ccall, but THIS
+   * (main) thread's event loop is free, and the engine writes progress from whatever thread
+   * runs the pipeline — so polling shared memory here is the only path that sees intermediate
+   * progress. No-op on the st build (no shared memory). Returns a stop() that clears the
+   * timer and does one final catch-up read (so the last tick, incl. peak memory, is seen).
+   * @internal
+   */
+  _startProgressPoll(cb: (p: QueryProgress) => void): () => void {
+    const view = this.progressView;
+    if (!view) return () => {};
+    let lastSeq = Number(Atomics.load(view, 0));
+    const tick = () => {
+      const seq = Number(Atomics.load(view, 0));
+      if (seq === lastSeq) return;
+      lastSeq = seq;
+      cb(this.readProgress(view));
+    };
+    const timer = setInterval(tick, 80);
+    return () => { clearInterval(timer); tick(); };
   }
 
   /** Run a query on the implicit :memory: connection. opts.onProgress gets live execution progress. */
   async query(sql: string, format = 'CSV', opts?: QueryOptions): Promise<ChdbResult> {
     let peak = 0;
-    const onProgress = (p: QueryProgress) => {
+    const stop = this._startProgressPoll((p) => {
       if (p.memoryUsage > peak) peak = p.memoryUsage;
       opts?.onProgress?.(p);
-    };
-    const r = wrap(await this.request('query', { sql, format }, undefined, onProgress));
+    });
+    let result: WireResult;
+    try {
+      result = await this.request('query', { sql, format });
+    } finally {
+      stop();   // final catch-up read updates peak before we wrap
+    }
+    const r = wrap(result);
     r.peakMemoryUsage = peak;
     return r;
   }
@@ -203,8 +249,8 @@ export class AsyncChdb {
   }
 
   /** @internal */
-  _queryConn(conn: ConnHandle, sql: string, format: string, onProgress?: (p: QueryProgress) => void): Promise<WireResult> {
-    return this.request('queryConn', { conn, sql, format }, undefined, onProgress);
+  _queryConn(conn: ConnHandle, sql: string, format: string): Promise<WireResult> {
+    return this.request('queryConn', { conn, sql, format });
   }
   /** @internal */
   _closeConn(conn: ConnHandle): Promise<void> {
@@ -215,8 +261,8 @@ export class AsyncChdb {
     return this.request('streamStart', { conn, sql, format });
   }
   /** @internal */
-  _streamFetch(conn: ConnHandle, stream: ConnHandle, onProgress?: (p: QueryProgress) => void): Promise<{ done: boolean; result?: WireResult }> {
-    return this.request('streamFetch', { conn, stream }, undefined, onProgress);
+  _streamFetch(conn: ConnHandle, stream: ConnHandle): Promise<{ done: boolean; result?: WireResult }> {
+    return this.request('streamFetch', { conn, stream });
   }
   /** @internal */
   _streamCancel(conn: ConnHandle, stream: ConnHandle): Promise<void> {
@@ -244,11 +290,17 @@ export class AsyncChdbConnection {
   }
   async query(sql: string, format = 'CSV', opts?: QueryOptions): Promise<ChdbResult> {
     let peak = 0;
-    const onProgress = (p: QueryProgress) => {
+    const stop = this.db._startProgressPoll((p) => {
       if (p.memoryUsage > peak) peak = p.memoryUsage;
       opts?.onProgress?.(p);
-    };
-    const r = wrap(await this.db._queryConn(this.conn, sql, format, onProgress));
+    });
+    let result: WireResult;
+    try {
+      result = await this.db._queryConn(this.conn, sql, format);
+    } finally {
+      stop();
+    }
+    const r = wrap(result);
     r.peakMemoryUsage = peak;
     return r;
   }
@@ -262,19 +314,20 @@ export class AsyncChdbConnection {
   async *queryStream(sql: string, format = 'CSV', opts?: QueryOptions): AsyncGenerator<ChdbResult> {
     const { stream } = await this.db._streamStart(this.conn, sql, format);
     let peak = 0;
-    const onProgress = (p: QueryProgress) => {
+    const stop = this.db._startProgressPoll((p) => {
       if (p.memoryUsage > peak) peak = p.memoryUsage;
       opts?.onProgress?.(p);
-    };
+    });
     try {
       for (;;) {
-        const { done, result } = await this.db._streamFetch(this.conn, stream, onProgress);
+        const { done, result } = await this.db._streamFetch(this.conn, stream);
         if (done || !result) break;
         const r = wrap(result);
         r.peakMemoryUsage = peak;
         yield r;
       }
     } finally {
+      stop();
       await this.db._streamCancel(this.conn, stream);
     }
   }

--- a/packages/chdb-wasm/src/async.ts
+++ b/packages/chdb-wasm/src/async.ts
@@ -16,8 +16,6 @@ export interface ChdbResult {
   /** Source rows/bytes SCANNED from storage (ClickHouse read_rows) — for "Processed N rows, …". */
   scannedRows: number;
   scannedBytes: number;
-  /** Peak memory (bytes) observed during execution, tracked from the progress stream. */
-  peakMemoryUsage: number;
   elapsedSeconds: number;
   /** Decode the bytes as UTF-8 text. */
   text(): string;
@@ -52,7 +50,6 @@ function wrap(r: WireResult): ChdbResult {
     bytesRead: r.bytesRead,
     scannedRows: r.scannedRows,
     scannedBytes: r.scannedBytes,
-    peakMemoryUsage: 0,
     elapsedSeconds: r.elapsedSeconds,
     text: () => new TextDecoder().decode(r.data),
   };
@@ -90,8 +87,8 @@ export class AsyncChdb {
     const initResult = await self.request('init', { moduleUrl: opts.moduleUrl, wasmUrl: opts.wasmUrl });
     if (initResult?.sharedMem) {
       self.cancelFlag = new Int32Array(initResult.sharedMem, initResult.cancelAddr, 1);
-      // 7 × int64: [seq, readRows, totalRowsToRead, readBytes, totalBytesToRead, memoryUsage, elapsedNs].
-      self.progressView = new BigInt64Array(initResult.sharedMem, initResult.progressAddr, 7);
+      // 6 × int64: [seq, readRows, totalRowsToRead, readBytes, totalBytesToRead, elapsedNs].
+      self.progressView = new BigInt64Array(initResult.sharedMem, initResult.progressAddr, 6);
     }
     return self;
   }
@@ -132,7 +129,7 @@ export class AsyncChdb {
       const p: QueryProgress = {
         readRows: Number(v[1]), totalRowsToRead: Number(v[2]),
         readBytes: Number(v[3]), totalBytesToRead: Number(v[4]),
-        memoryUsage: Number(v[5]), elapsedNs: Number(v[6]),
+        elapsedNs: Number(v[5]),
       };
       if (Atomics.load(v, 0) === s1) return p;   // seq unchanged -> consistent snapshot
     }
@@ -140,7 +137,7 @@ export class AsyncChdb {
     return {
       readRows: Number(v[1]), totalRowsToRead: Number(v[2]),
       readBytes: Number(v[3]), totalBytesToRead: Number(v[4]),
-      memoryUsage: Number(v[5]), elapsedNs: Number(v[6]),
+      elapsedNs: Number(v[5]),
     };
   }
 
@@ -150,7 +147,7 @@ export class AsyncChdb {
    * (main) thread's event loop is free, and the engine writes progress from whatever thread
    * runs the pipeline — so polling shared memory here is the only path that sees intermediate
    * progress. No-op on the st build (no shared memory). Returns a stop() that clears the
-   * timer and does one final catch-up read (so the last tick, incl. peak memory, is seen).
+   * timer and does one final catch-up read (so the last tick is seen).
    * @internal
    */
   _startProgressPoll(cb: (p: QueryProgress) => void): () => void {
@@ -169,20 +166,12 @@ export class AsyncChdb {
 
   /** Run a query on the implicit :memory: connection. opts.onProgress gets live execution progress. */
   async query(sql: string, format = 'CSV', opts?: QueryOptions): Promise<ChdbResult> {
-    let peak = 0;
-    const stop = this._startProgressPoll((p) => {
-      if (p.memoryUsage > peak) peak = p.memoryUsage;
-      opts?.onProgress?.(p);
-    });
-    let result: WireResult;
+    const stop = opts?.onProgress ? this._startProgressPoll(opts.onProgress) : () => {};
     try {
-      result = await this.request('query', { sql, format });
+      return wrap(await this.request('query', { sql, format }));
     } finally {
-      stop();   // final catch-up read updates peak before we wrap
+      stop();
     }
-    const r = wrap(result);
-    r.peakMemoryUsage = peak;
-    return r;
   }
 
   /**
@@ -289,20 +278,12 @@ export class AsyncChdbConnection {
     this.conn = conn;
   }
   async query(sql: string, format = 'CSV', opts?: QueryOptions): Promise<ChdbResult> {
-    let peak = 0;
-    const stop = this.db._startProgressPoll((p) => {
-      if (p.memoryUsage > peak) peak = p.memoryUsage;
-      opts?.onProgress?.(p);
-    });
-    let result: WireResult;
+    const stop = opts?.onProgress ? this.db._startProgressPoll(opts.onProgress) : () => {};
     try {
-      result = await this.db._queryConn(this.conn, sql, format);
+      return wrap(await this.db._queryConn(this.conn, sql, format));
     } finally {
       stop();
     }
-    const r = wrap(result);
-    r.peakMemoryUsage = peak;
-    return r;
   }
 
   /** Cancel the running query (mt only). See AsyncChdb.cancel(). */
@@ -313,18 +294,12 @@ export class AsyncChdbConnection {
   /** Stream a query's results chunk-by-chunk (yields the worker between chunks). */
   async *queryStream(sql: string, format = 'CSV', opts?: QueryOptions): AsyncGenerator<ChdbResult> {
     const { stream } = await this.db._streamStart(this.conn, sql, format);
-    let peak = 0;
-    const stop = this.db._startProgressPoll((p) => {
-      if (p.memoryUsage > peak) peak = p.memoryUsage;
-      opts?.onProgress?.(p);
-    });
+    const stop = opts?.onProgress ? this.db._startProgressPoll(opts.onProgress) : () => {};
     try {
       for (;;) {
         const { done, result } = await this.db._streamFetch(this.conn, stream);
         if (done || !result) break;
-        const r = wrap(result);
-        r.peakMemoryUsage = peak;
-        yield r;
+        yield wrap(result);
       }
     } finally {
       stop();

--- a/packages/chdb-wasm/src/bindings.ts
+++ b/packages/chdb-wasm/src/bindings.ts
@@ -110,8 +110,10 @@ export class ChdbBindings {
       const data: Uint8Array = this.mod.HEAPU8.slice(bufPtr, bufPtr + len);
       const rowsRead = num(this.mod.ccall('chdb_wasm_result_rows_read', 'number', ['number'], [chunk]));
       const bytesRead = num(this.mod.ccall('chdb_wasm_result_bytes_read', 'number', ['number'], [chunk]));
+      const scannedRows = num(this.mod.ccall('chdb_wasm_result_scanned_rows', 'number', ['number'], [chunk]));
+      const scannedBytes = num(this.mod.ccall('chdb_wasm_result_scanned_bytes', 'number', ['number'], [chunk]));
       const elapsedSeconds = this.mod.ccall('chdb_wasm_result_elapsed', 'number', ['number'], [chunk]);
-      return { done: false, result: { data, rowsRead, bytesRead, elapsedSeconds } };
+      return { done: false, result: { data, rowsRead, bytesRead, scannedRows, scannedBytes, elapsedSeconds } };
     } finally {
       this.mod.ccall('chdb_wasm_free_result', null, ['number'], [chunk]);
     }
@@ -138,8 +140,10 @@ export class ChdbBindings {
 
       const rowsRead = num(this.mod.ccall('chdb_wasm_result_rows_read', 'number', ['number'], [r]));
       const bytesRead = num(this.mod.ccall('chdb_wasm_result_bytes_read', 'number', ['number'], [r]));
+      const scannedRows = num(this.mod.ccall('chdb_wasm_result_scanned_rows', 'number', ['number'], [r]));
+      const scannedBytes = num(this.mod.ccall('chdb_wasm_result_scanned_bytes', 'number', ['number'], [r]));
       const elapsedSeconds = this.mod.ccall('chdb_wasm_result_elapsed', 'number', ['number'], [r]);
-      return { data, rowsRead, bytesRead, elapsedSeconds };
+      return { data, rowsRead, bytesRead, scannedRows, scannedBytes, elapsedSeconds };
     } finally {
       this.mod.ccall('chdb_wasm_free_result', null, ['number'], [r]);
     }

--- a/packages/chdb-wasm/src/bindings.ts
+++ b/packages/chdb-wasm/src/bindings.ts
@@ -23,6 +23,11 @@ export class ChdbBindings {
     return num(this.mod.ccall('chdb_wasm_cancel_flag_addr', 'number', [], []));
   }
 
+  /** Offset of the live-progress struct in wasm memory (page polls it via the heap SAB). */
+  progressAddr(): number {
+    return num(this.mod.ccall('chdb_wasm_progress_addr', 'number', [], []));
+  }
+
   /** The wasm linear memory buffer (a SharedArrayBuffer on the mt build). */
   get heapBuffer(): ArrayBufferLike {
     return this.mod.HEAPU8.buffer;

--- a/packages/chdb-wasm/src/bindings.ts
+++ b/packages/chdb-wasm/src/bindings.ts
@@ -18,6 +18,16 @@ export class ChdbBindings {
     this.mod = mod;
   }
 
+  /** Offset of the engine's cancel flag in wasm memory (page writes it via the heap SAB). */
+  cancelFlagAddr(): number {
+    return num(this.mod.ccall('chdb_wasm_cancel_flag_addr', 'number', [], []));
+  }
+
+  /** The wasm linear memory buffer (a SharedArrayBuffer on the mt build). */
+  get heapBuffer(): ArrayBufferLike {
+    return this.mod.HEAPU8.buffer;
+  }
+
   /** Query the implicit process-wide :memory: connection. */
   query(sql: string, format = 'CSV'): WireResult {
     const r = this.mod.ccall('chdb_wasm_query', 'number', ['string', 'string'], [sql, format]);

--- a/packages/chdb-wasm/src/protocol.ts
+++ b/packages/chdb-wasm/src/protocol.ts
@@ -16,7 +16,11 @@ export interface WireResult {
   elapsedSeconds: number;
 }
 
-/** Live query-EXECUTION progress (distinct from the wasm-DOWNLOAD 'progress' event). */
+/**
+ * Live query-EXECUTION progress (distinct from the wasm-DOWNLOAD 'progress' event).
+ * Delivered by the main thread polling a shared-memory struct the engine writes — see
+ * AsyncChdb's progress poll — not by a worker message.
+ */
 export interface QueryProgress {
   readRows: number;
   totalRowsToRead: number;
@@ -56,5 +60,4 @@ export interface WorkerRequest {
 export type WorkerResponse =
   | { id: number; ok: true; result?: any }
   | { id: number; ok: false; error: string }
-  | { id: number; event: 'progress'; loaded: number; total: number }
-  | ({ id: number; event: 'queryProgress' } & QueryProgress);
+  | { id: number; event: 'progress'; loaded: number; total: number };

--- a/packages/chdb-wasm/src/protocol.ts
+++ b/packages/chdb-wasm/src/protocol.ts
@@ -16,6 +16,16 @@ export interface WireResult {
   elapsedSeconds: number;
 }
 
+/** Live query-EXECUTION progress (distinct from the wasm-DOWNLOAD 'progress' event). */
+export interface QueryProgress {
+  readRows: number;
+  totalRowsToRead: number;
+  readBytes: number;
+  totalBytesToRead: number;
+  memoryUsage: number;
+  elapsedNs: number;
+}
+
 export type RequestType =
   | 'init'
   | 'query'
@@ -46,4 +56,5 @@ export interface WorkerRequest {
 export type WorkerResponse =
   | { id: number; ok: true; result?: any }
   | { id: number; ok: false; error: string }
-  | { id: number; event: 'progress'; loaded: number; total: number };
+  | { id: number; event: 'progress'; loaded: number; total: number }
+  | ({ id: number; event: 'queryProgress' } & QueryProgress);

--- a/packages/chdb-wasm/src/protocol.ts
+++ b/packages/chdb-wasm/src/protocol.ts
@@ -10,6 +10,9 @@ export interface WireResult {
   data: Uint8Array;
   rowsRead: number;
   bytesRead: number;
+  /** Source rows/bytes SCANNED from storage (≠ result size); for the "Processed N rows" footer. */
+  scannedRows: number;
+  scannedBytes: number;
   elapsedSeconds: number;
 }
 

--- a/packages/chdb-wasm/src/protocol.ts
+++ b/packages/chdb-wasm/src/protocol.ts
@@ -26,7 +26,6 @@ export interface QueryProgress {
   totalRowsToRead: number;
   readBytes: number;
   totalBytesToRead: number;
-  memoryUsage: number;
   elapsedNs: number;
 }
 

--- a/packages/chdb-wasm/src/status.ts
+++ b/packages/chdb-wasm/src/status.ts
@@ -1,6 +1,6 @@
 // Error / status model. (Type-stripping friendly: no `enum`.)
 
-/** Coarse status of a chdb operation, mirroring duckdb-wasm's StatusCode idea. */
+/** Coarse status of a chdb operation. */
 export const StatusCode = {
   OK: 'OK',
   ERROR: 'ERROR',

--- a/packages/chdb-wasm/src/worker.ts
+++ b/packages/chdb-wasm/src/worker.ts
@@ -83,6 +83,9 @@ function requireBindings(): ChdbBindings {
 listen((req: WorkerRequest) => {
   void (async () => {
     try {
+      // Tag any in-flight query-progress events with this request's id (read by the C++
+      // progress hook via EM_ASM globalThis.__chdbQueryId); cleared in finally.
+      (globalThis as any).__chdbQueryId = req.id;
       let result: any;
       switch (req.type) {
         case 'init':
@@ -137,6 +140,8 @@ listen((req: WorkerRequest) => {
       post({ id: req.id, ok: true, result }, buf ? [buf] : undefined);
     } catch (e: any) {
       post({ id: req.id, ok: false, error: e && e.message ? e.message : String(e) });
+    } finally {
+      (globalThis as any).__chdbQueryId = 0;
     }
   })();
 });

--- a/packages/chdb-wasm/src/worker.ts
+++ b/packages/chdb-wasm/src/worker.ts
@@ -90,6 +90,16 @@ listen((req: WorkerRequest) => {
       switch (req.type) {
         case 'init':
           await init(req.payload, req.id);
+          // mt only: share the wasm Memory SAB + the cancel-flag offset so the page can set
+          // the flag, which the C++ cancel check reads with a plain atomic on any thread.
+          // A non-shared heap (st build) => no cancel support.
+          {
+            const b = requireBindings();
+            const cancelMem = b.heapBuffer;
+            if (typeof SharedArrayBuffer !== 'undefined' && cancelMem instanceof SharedArrayBuffer) {
+              result = { cancelMem, cancelAddr: b.cancelFlagAddr() };
+            }
+          }
           break;
         case 'query':
           result = requireBindings().query(req.payload.sql, req.payload.format);

--- a/packages/chdb-wasm/src/worker.ts
+++ b/packages/chdb-wasm/src/worker.ts
@@ -83,21 +83,19 @@ function requireBindings(): ChdbBindings {
 listen((req: WorkerRequest) => {
   void (async () => {
     try {
-      // Tag any in-flight query-progress events with this request's id (read by the C++
-      // progress hook via EM_ASM globalThis.__chdbQueryId); cleared in finally.
-      (globalThis as any).__chdbQueryId = req.id;
       let result: any;
       switch (req.type) {
         case 'init':
           await init(req.payload, req.id);
-          // mt only: share the wasm Memory SAB + the cancel-flag offset so the page can set
-          // the flag, which the C++ cancel check reads with a plain atomic on any thread.
-          // A non-shared heap (st build) => no cancel support.
+          // mt only: share the wasm Memory SAB + the cancel-flag and live-progress offsets.
+          // The page sets the cancel flag (read by the C++ cancel check on any thread) and
+          // polls the progress struct (written by the engine on any thread). A non-shared
+          // heap (st build) => no cancel / no live progress.
           {
             const b = requireBindings();
-            const cancelMem = b.heapBuffer;
-            if (typeof SharedArrayBuffer !== 'undefined' && cancelMem instanceof SharedArrayBuffer) {
-              result = { cancelMem, cancelAddr: b.cancelFlagAddr() };
+            const sharedMem = b.heapBuffer;
+            if (typeof SharedArrayBuffer !== 'undefined' && sharedMem instanceof SharedArrayBuffer) {
+              result = { sharedMem, cancelAddr: b.cancelFlagAddr(), progressAddr: b.progressAddr() };
             }
           }
           break;
@@ -150,8 +148,6 @@ listen((req: WorkerRequest) => {
       post({ id: req.id, ok: true, result }, buf ? [buf] : undefined);
     } catch (e: any) {
       post({ id: req.id, ok: false, error: e && e.message ? e.message : String(e) });
-    } finally {
-      (globalThis as any).__chdbQueryId = 0;
     }
   })();
 });

--- a/packages/chdb-wasm/test/progress-cancel-fixture.html
+++ b/packages/chdb-wasm/test/progress-cancel-fixture.html
@@ -35,7 +35,7 @@ const log = (m) => { el.textContent += '\n' + m; console.log(m); };
     out.scannedRows = pr.scannedRows;
     // Keep the trace compact in the log (first 3 + count); the full array stays in __RESULT__.
     log('progress: events=' + ev.length + ' elapsed=' + out.progressElapsed.toFixed(2) + 's'
-      + ' readRows[0..2]=' + JSON.stringify(readRowsSeq.slice(0, 3)) + ' last=' + out.progressLast.readRows);
+      + ' readRows[0..2]=' + JSON.stringify(readRowsSeq.slice(0, 3)) + ' last=' + (out.progressLast ? out.progressLast.readRows : 'n/a'));
 
     // (3) CANCEL. A long scan; request cancellation ~600ms in and time how long until the
     // query rejects. Expect QUERY_WAS_CANCELLED (Code: 394) well before its natural end.

--- a/packages/chdb-wasm/test/progress-cancel-fixture.html
+++ b/packages/chdb-wasm/test/progress-cancel-fixture.html
@@ -1,9 +1,9 @@
 <!doctype html><meta charset=utf-8><title>chdb-wasm progress + cancel fixture</title><pre id=o>running…</pre>
-<!-- Driven by test/progress-cancel-run.mjs (cross-origin isolated -> mt bundle, so
-     queryProgress postMessage + the SharedArrayBuffer cancel flag are live).
-     Verifies (1) live execution progress events fire and advance, (2) peakMemoryUsage
-     is reported, (3) db.cancel() interrupts a running query mid-flight. Publishes the
-     findings on window.__RESULT__ for the driver to assert. -->
+<!-- Driven by test/progress-cancel-run.mjs (cross-origin isolated -> mt bundle, so the
+     page can poll the engine's shared-memory progress struct and set the cancel flag).
+     Verifies (1) live execution progress events fire and advance, (2) db.cancel()
+     interrupts a running query mid-flight. Publishes the findings on window.__RESULT__
+     for the driver to assert. -->
 <script type="module">
 import { AsyncChdb, selectBundle } from '../dist/index.js';
 const el = document.getElementById('o');
@@ -15,8 +15,8 @@ const log = (m) => { el.textContent += '\n' + m; console.log(m); };
     const db = await AsyncChdb.create({ moduleUrl: b.moduleUrl, wasmUrl: b.wasmUrl });
     const out = { ok: true, variant: b.variant, coi: self.crossOriginIsolated };
 
-    // (1)+(2) LIVE PROGRESS + PEAK. A multi-second scan so the engine emits several
-    // throttled (~100ms) progress ticks; collect them and read peakMemoryUsage.
+    // (1) LIVE PROGRESS. A multi-second scan so the engine emits several throttled (~100ms)
+    // progress ticks; collect them and check they stream (rows/bytes advance).
     const ev = [];
     const pr = await db.query(
       'SELECT count() FROM numbers(800000000) WHERE sipHash64(number) % 3 = 0',
@@ -24,19 +24,17 @@ const log = (m) => { el.textContent += '\n' + m; console.log(m); };
     const readRowsSeq = ev.map((e) => e.readRows);
     out.progressEvents = ev.length;
     out.progressElapsed = pr.elapsedSeconds;
-    out.progressFirst = ev.length ? { readRows: ev[0].readRows, total: ev[0].totalRowsToRead, mem: ev[0].memoryUsage } : null;
+    out.progressFirst = ev.length ? { readRows: ev[0].readRows, total: ev[0].totalRowsToRead } : null;
     const last = ev[ev.length - 1];
-    out.progressLast = last ? { readRows: last.readRows, total: last.totalRowsToRead, mem: last.memoryUsage } : null;
+    out.progressLast = last ? { readRows: last.readRows, total: last.totalRowsToRead } : null;
     out.progressMonotonic = ev.every((e, i) => i === 0 || e.readRows >= ev[i - 1].readRows);
     out.progressHasTotal = ev.some((e) => e.totalRowsToRead > 0);
-    out.progressHasMem = ev.some((e) => e.memoryUsage > 0);
     // Genuine streaming (not just a start+end pair): at least one tick strictly between.
     const tot = last ? last.totalRowsToRead : 0;
     out.progressHasIntermediate = ev.some((e) => e.readRows > 0 && tot > 0 && e.readRows < tot);
-    out.peak = pr.peakMemoryUsage;
     out.scannedRows = pr.scannedRows;
     // Keep the trace compact in the log (first 3 + count); the full array stays in __RESULT__.
-    log('progress: events=' + ev.length + ' elapsed=' + out.progressElapsed.toFixed(2) + 's peak=' + out.peak
+    log('progress: events=' + ev.length + ' elapsed=' + out.progressElapsed.toFixed(2) + 's'
       + ' readRows[0..2]=' + JSON.stringify(readRowsSeq.slice(0, 3)) + ' last=' + out.progressLast.readRows);
 
     // (3) CANCEL. A long scan; request cancellation ~600ms in and time how long until the

--- a/packages/chdb-wasm/test/progress-cancel-fixture.html
+++ b/packages/chdb-wasm/test/progress-cancel-fixture.html
@@ -1,0 +1,65 @@
+<!doctype html><meta charset=utf-8><title>chdb-wasm progress + cancel fixture</title><pre id=o>running…</pre>
+<!-- Driven by test/progress-cancel-run.mjs (cross-origin isolated -> mt bundle, so
+     queryProgress postMessage + the SharedArrayBuffer cancel flag are live).
+     Verifies (1) live execution progress events fire and advance, (2) peakMemoryUsage
+     is reported, (3) db.cancel() interrupts a running query mid-flight. Publishes the
+     findings on window.__RESULT__ for the driver to assert. -->
+<script type="module">
+import { AsyncChdb, selectBundle } from '../dist/index.js';
+const el = document.getElementById('o');
+const log = (m) => { el.textContent += '\n' + m; console.log(m); };
+(async () => {
+  try {
+    const b = selectBundle({ baseUrl: new URL('../dist', import.meta.url).href });
+    log('coi=' + self.crossOriginIsolated + ' SAB=' + (typeof SharedArrayBuffer !== 'undefined') + ' -> variant=' + b.variant);
+    const db = await AsyncChdb.create({ moduleUrl: b.moduleUrl, wasmUrl: b.wasmUrl });
+    const out = { ok: true, variant: b.variant, coi: self.crossOriginIsolated };
+
+    // (1)+(2) LIVE PROGRESS + PEAK. A multi-second scan so the engine emits several
+    // throttled (~100ms) progress ticks; collect them and read peakMemoryUsage.
+    const ev = [];
+    const pr = await db.query(
+      'SELECT count() FROM numbers(800000000) WHERE sipHash64(number) % 3 = 0',
+      'CSV', { onProgress: (p) => ev.push(p) });
+    const readRowsSeq = ev.map((e) => e.readRows);
+    out.progressEvents = ev.length;
+    out.progressElapsed = pr.elapsedSeconds;
+    out.progressFirst = ev.length ? { readRows: ev[0].readRows, total: ev[0].totalRowsToRead, mem: ev[0].memoryUsage } : null;
+    const last = ev[ev.length - 1];
+    out.progressLast = last ? { readRows: last.readRows, total: last.totalRowsToRead, mem: last.memoryUsage } : null;
+    out.progressMonotonic = ev.every((e, i) => i === 0 || e.readRows >= ev[i - 1].readRows);
+    out.progressHasTotal = ev.some((e) => e.totalRowsToRead > 0);
+    out.progressHasMem = ev.some((e) => e.memoryUsage > 0);
+    // Genuine streaming (not just a start+end pair): at least one tick strictly between.
+    const tot = last ? last.totalRowsToRead : 0;
+    out.progressHasIntermediate = ev.some((e) => e.readRows > 0 && tot > 0 && e.readRows < tot);
+    out.peak = pr.peakMemoryUsage;
+    out.scannedRows = pr.scannedRows;
+    // Keep the trace compact in the log (first 3 + count); the full array stays in __RESULT__.
+    log('progress: events=' + ev.length + ' elapsed=' + out.progressElapsed.toFixed(2) + 's peak=' + out.peak
+      + ' readRows[0..2]=' + JSON.stringify(readRowsSeq.slice(0, 3)) + ' last=' + out.progressLast.readRows);
+
+    // (3) CANCEL. A long scan; request cancellation ~600ms in and time how long until the
+    // query rejects. Expect QUERY_WAS_CANCELLED (Code: 394) well before its natural end.
+    let cancelErr = null, cancelMs = null;
+    const t0 = performance.now();
+    const running = db.query('SELECT count() FROM numbers(500000000) WHERE sipHash64(number) > 1')
+      .then(() => { cancelErr = 'NO_ERROR (query completed)'; })
+      .catch((e) => { cancelErr = String((e && e.message) || e); cancelMs = performance.now() - t0; });
+    setTimeout(() => { try { db.cancel(); } catch (e) { out.cancelThrow = String((e && e.message) || e); } }, 600);
+    await running;
+    out.cancelMs = cancelMs == null ? null : Math.round(cancelMs);
+    out.cancelErr = (cancelErr || '').slice(0, 140);
+    out.cancelOk = /QUERY_WAS_CANCELLED|Code:\s*394/.test(cancelErr || '');
+    log('cancel: ok=' + out.cancelOk + ' ms=' + out.cancelMs + ' err=' + out.cancelErr);
+
+    await db.terminate();
+    log('done: ' + JSON.stringify(out));
+    window.__RESULT__ = out;
+  } catch (e) {
+    log('FATAL ' + ((e && e.message) || e));
+    window.__RESULT__ = { fatal: String((e && e.message) || e).slice(0, 200) };
+  }
+})();
+setTimeout(() => { if (window.__RESULT__ === undefined) window.__RESULT__ = { timeout: true }; }, 90000);
+</script>

--- a/packages/chdb-wasm/test/progress-cancel-run.mjs
+++ b/packages/chdb-wasm/test/progress-cancel-run.mjs
@@ -6,6 +6,7 @@
 //   node test/progress-cancel-run.mjs
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { extname, join, normalize, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
@@ -54,18 +55,21 @@ async function fetchJSON(url, tries = 50) {
 
 async function main() {
   const port = 9824, cdpPort = 9223;
+  // Fail fast (before opening the socket) if the Chrome binary is missing — otherwise spawn()
+  // reports it as an opaque async ENOENT much later. Set CHROME_BIN to point at your browser.
+  if (!existsSync(CHROME))
+    throw new Error(`Chrome binary not found at ${CHROME}. Set CHROME_BIN to a Chrome/Chromium executable.`);
   const server = await startServer(port);
   const userDir = '/tmp/chdb-cdp-profile';
-  const chrome = spawn(CHROME, [
-    '--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
-    `--remote-debugging-port=${cdpPort}`, `--user-data-dir=${userDir}`,
-    `http://127.0.0.1:${port}/test/progress-cancel-fixture.html`,
-  ], { stdio: ['ignore', 'ignore', 'pipe'] });
-  let chromeStderr = '';
-  chrome.stderr.on('data', (d) => { chromeStderr += d.toString(); });
-
-  let cdp;
+  let chrome, cdp, chromeStderr = '';
   try {
+    chrome = spawn(CHROME, [
+      '--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
+      `--remote-debugging-port=${cdpPort}`, `--user-data-dir=${userDir}`,
+      `http://127.0.0.1:${port}/test/progress-cancel-fixture.html`,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    chrome.stderr.on('data', (d) => { chromeStderr += d.toString(); });
+
     const ver = await fetchJSON(`http://127.0.0.1:${cdpPort}/json/version`);
     cdp = await CDP.connect(ver.webSocketDebuggerUrl);
     // Find (or wait for) the page target, then attach in flatten mode.
@@ -117,7 +121,7 @@ async function main() {
     throw e;
   } finally {
     try { cdp?.ws.close(); } catch { /* ignore */ }
-    chrome.kill('SIGKILL');
+    chrome?.kill('SIGKILL');
     server.close();
   }
 }

--- a/packages/chdb-wasm/test/progress-cancel-run.mjs
+++ b/packages/chdb-wasm/test/progress-cancel-run.mjs
@@ -1,0 +1,128 @@
+// Headless-Chrome verification of live query progress + mid-query cancel for chdb-wasm.
+// Node's worker_threads have no global postMessage, so the queryProgress events (and thus
+// peakMemoryUsage) can only be exercised in a real browser; cancel needs a SharedArrayBuffer
+// (cross-origin isolated). This serves test/progress-cancel-fixture.html with COOP/COEP and
+// drives the cached Chrome via raw CDP (no puppeteer dependency). Run with Node >=22:
+//   node test/progress-cancel-run.mjs
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import assert from 'node:assert';
+
+const pkgDir = process.env.CHDB_PKG_DIR || dirname(dirname(fileURLToPath(import.meta.url)));
+const CHROME = process.env.CHROME_BIN ||
+  '/home/ubuntu/.cache/puppeteer/chrome/linux-149.0.7827.22/chrome-linux64/chrome';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json' };
+
+function startServer(port) {
+  const server = createServer(async (req, res) => {
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    try {
+      const p = decodeURIComponent((req.url || '/').split('?')[0]);
+      const rel = normalize(p === '/' ? '/test/progress-cancel-fixture.html' : p).replace(/^([/\\]|\.\.[/\\])+/, '');
+      res.setHeader('Content-Type', MIME[extname(join(pkgDir, rel))] || 'application/octet-stream');
+      res.end(await readFile(join(pkgDir, rel)));
+    } catch { res.statusCode = 404; res.end('not found'); }
+  });
+  return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+}
+
+// Minimal CDP client over the (Node-global) WebSocket: id-keyed request/response + event taps.
+class CDP {
+  constructor(ws) { this.ws = ws; this.id = 0; this.waiters = new Map(); this.listeners = []; ws.onmessage = (e) => this._recv(e.data); }
+  static async connect(wsUrl) { const ws = new WebSocket(wsUrl); await new Promise((res, rej) => { ws.onopen = res; ws.onerror = (e) => rej(new Error('ws ' + (e.message || 'error'))); }); return new CDP(ws); }
+  _recv(raw) {
+    const msg = JSON.parse(raw);
+    if (msg.id != null && this.waiters.has(msg.id)) { const w = this.waiters.get(msg.id); this.waiters.delete(msg.id); msg.error ? w.rej(new Error(msg.error.message)) : w.res(msg.result); }
+    else if (msg.method) for (const l of this.listeners) l(msg);
+  }
+  send(method, params = {}, sessionId) { const id = ++this.id; return new Promise((res, rej) => { this.waiters.set(id, { res, rej }); this.ws.send(JSON.stringify({ id, method, params, sessionId })); }); }
+  on(fn) { this.listeners.push(fn); }
+}
+
+async function fetchJSON(url, tries = 50) {
+  for (let i = 0; i < tries; i++) {
+    try { const r = await fetch(url); if (r.ok) return await r.json(); } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('CDP endpoint did not come up: ' + url);
+}
+
+async function main() {
+  const port = 9824, cdpPort = 9223;
+  const server = await startServer(port);
+  const userDir = '/tmp/chdb-cdp-profile';
+  const chrome = spawn(CHROME, [
+    '--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
+    `--remote-debugging-port=${cdpPort}`, `--user-data-dir=${userDir}`,
+    `http://127.0.0.1:${port}/test/progress-cancel-fixture.html`,
+  ], { stdio: ['ignore', 'ignore', 'pipe'] });
+  let chromeStderr = '';
+  chrome.stderr.on('data', (d) => { chromeStderr += d.toString(); });
+
+  let cdp;
+  try {
+    const ver = await fetchJSON(`http://127.0.0.1:${cdpPort}/json/version`);
+    cdp = await CDP.connect(ver.webSocketDebuggerUrl);
+    // Find (or wait for) the page target, then attach in flatten mode.
+    let target;
+    for (let i = 0; i < 50 && !target; i++) {
+      const { targetInfos } = await cdp.send('Target.getTargets');
+      target = targetInfos.find((t) => t.type === 'page' && t.url.includes('progress-cancel-fixture'));
+      if (!target) await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(target, 'page target not found');
+    const { sessionId } = await cdp.send('Target.attachToTarget', { targetId: target.targetId, flatten: true });
+    cdp.on((m) => {
+      if (m.method === 'Runtime.consoleAPICalled') console.log('  [page]', m.params.args.map((a) => a.value ?? a.description ?? '').join(' '));
+      if (m.method === 'Runtime.exceptionThrown') console.error('  [pageerror]', m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text);
+    });
+    await cdp.send('Runtime.enable', {}, sessionId);
+
+    // Poll for window.__RESULT__ (the fixture sets it when done / on timeout).
+    const deadline = Date.now() + 120000;
+    let result;
+    while (Date.now() < deadline) {
+      const { result: r } = await cdp.send('Runtime.evaluate',
+        { expression: 'window.__RESULT__ ? JSON.stringify(window.__RESULT__) : null', returnByValue: true }, sessionId);
+      if (r && r.value) { result = JSON.parse(r.value); break; }
+      await new Promise((res) => setTimeout(res, 300));
+    }
+    assert.ok(result, 'timed out waiting for window.__RESULT__');
+    console.log('\n=== RESULT ===\n' + JSON.stringify(result, null, 2) + '\n');
+
+    // Assertions.
+    assert.ok(result.ok, 'fixture not ok: ' + (result.fatal || (result.timeout && 'timeout') || '?'));
+    assert.strictEqual(result.coi, true, 'page must be cross-origin isolated');
+    assert.strictEqual(result.variant, 'mt', 'expected mt bundle in COI page');
+    // Live progress.
+    assert.ok(result.progressEvents > 1, `expected multiple progress events, got ${result.progressEvents}`);
+    assert.ok(result.progressMonotonic, 'progress readRows must be non-decreasing');
+    assert.ok(result.progressHasTotal, 'progress must report totalRowsToRead > 0');
+    assert.ok(result.progressHasMem, 'progress must report memoryUsage > 0');
+    assert.ok(result.progressLast && result.progressLast.readRows > 0, 'last progress readRows must be > 0');
+    // Genuine streaming, not just a start+end pair: at least one tick strictly between 0 and total.
+    assert.ok(result.progressHasIntermediate, 'progress must include an intermediate tick (0 < readRows < total)');
+    // Peak memory (tracked from the progress stream).
+    assert.ok(result.peak > 0, `peakMemoryUsage must be > 0, got ${result.peak}`);
+    // Cancel.
+    assert.ok(result.cancelOk, 'cancel must reject with QUERY_WAS_CANCELLED, got: ' + result.cancelErr);
+    assert.ok(result.cancelMs != null && result.cancelMs < 5000, `cancel should be prompt, got ${result.cancelMs}ms`);
+
+    console.log('PASS: live progress (' + result.progressEvents + ' events, peak=' +
+      (result.peak / 1048576).toFixed(1) + ' MiB), cancel in ' + result.cancelMs + 'ms (' + result.cancelErr.split('.')[0] + ')');
+  } catch (e) {
+    if (chromeStderr) console.error('--- chrome stderr (tail) ---\n' + chromeStderr.split('\n').slice(-15).join('\n'));
+    throw e;
+  } finally {
+    try { cdp?.ws.close(); } catch { /* ignore */ }
+    chrome.kill('SIGKILL');
+    server.close();
+  }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('FAIL:', e.message); process.exit(1); });

--- a/packages/chdb-wasm/test/progress-cancel-run.mjs
+++ b/packages/chdb-wasm/test/progress-cancel-run.mjs
@@ -1,8 +1,8 @@
 // Headless-Chrome verification of live query progress + mid-query cancel for chdb-wasm.
-// Node's worker_threads have no global postMessage, so the queryProgress events (and thus
-// peakMemoryUsage) can only be exercised in a real browser; cancel needs a SharedArrayBuffer
-// (cross-origin isolated). This serves test/progress-cancel-fixture.html with COOP/COEP and
-// drives the cached Chrome via raw CDP (no puppeteer dependency). Run with Node >=22:
+// Both need the mt bundle on a cross-origin-isolated page (SharedArrayBuffer): the page
+// polls a shared-memory struct the engine writes for progress, and sets a shared-memory flag
+// to cancel. This serves test/progress-cancel-fixture.html with COOP/COEP and drives the
+// cached Chrome via raw CDP (no puppeteer dependency). Run with Node >=22:
 //   node test/progress-cancel-run.mjs
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
@@ -103,18 +103,15 @@ async function main() {
     assert.ok(result.progressEvents > 1, `expected multiple progress events, got ${result.progressEvents}`);
     assert.ok(result.progressMonotonic, 'progress readRows must be non-decreasing');
     assert.ok(result.progressHasTotal, 'progress must report totalRowsToRead > 0');
-    assert.ok(result.progressHasMem, 'progress must report memoryUsage > 0');
     assert.ok(result.progressLast && result.progressLast.readRows > 0, 'last progress readRows must be > 0');
     // Genuine streaming, not just a start+end pair: at least one tick strictly between 0 and total.
     assert.ok(result.progressHasIntermediate, 'progress must include an intermediate tick (0 < readRows < total)');
-    // Peak memory (tracked from the progress stream).
-    assert.ok(result.peak > 0, `peakMemoryUsage must be > 0, got ${result.peak}`);
     // Cancel.
     assert.ok(result.cancelOk, 'cancel must reject with QUERY_WAS_CANCELLED, got: ' + result.cancelErr);
     assert.ok(result.cancelMs != null && result.cancelMs < 5000, `cancel should be prompt, got ${result.cancelMs}ms`);
 
-    console.log('PASS: live progress (' + result.progressEvents + ' events, peak=' +
-      (result.peak / 1048576).toFixed(1) + ' MiB), cancel in ' + result.cancelMs + 'ms (' + result.cancelErr.split('.')[0] + ')');
+    console.log('PASS: live progress (' + result.progressEvents + ' events, ' +
+      result.progressElapsed.toFixed(1) + 's scan), cancel in ' + result.cancelMs + 'ms (' + result.cancelErr.split('.')[0] + ')');
   } catch (e) {
     if (chromeStderr) console.error('--- chrome stderr (tail) ---\n' + chromeStderr.split('\n').slice(-15).join('\n'));
     throw e;

--- a/packages/chdb-wasm/test/progress-cancel-st-fixture.html
+++ b/packages/chdb-wasm/test/progress-cancel-st-fixture.html
@@ -1,0 +1,47 @@
+<!doctype html><meta charset=utf-8><title>chdb-wasm st progress/cancel fixture</title><pre id=o>running…</pre>
+<!-- Driven by test/progress-cancel-st-run.mjs (NO COOP/COEP -> non-isolated -> st bundle).
+     On the single-threaded build there is no SharedArrayBuffer, so the page can't poll the
+     engine's progress struct and queries run synchronously in the worker (uninterruptible).
+     Verifies that progress + cancel DEGRADE as documented: onProgress never fires,
+     peakMemoryUsage is 0, db.cancel() throws — while the query itself runs fine and still
+     reports scannedRows. Publishes findings on window.__RESULT__. -->
+<script type="module">
+import { AsyncChdb, selectBundle } from '../dist/index.js';
+const el = document.getElementById('o');
+const log = (m) => { el.textContent += '\n' + m; console.log(m); };
+(async () => {
+  try {
+    const b = selectBundle({ baseUrl: new URL('../dist', import.meta.url).href });
+    log('coi=' + self.crossOriginIsolated + ' SAB=' + (typeof SharedArrayBuffer !== 'undefined') + ' -> variant=' + b.variant);
+    const db = await AsyncChdb.create({ moduleUrl: b.moduleUrl, wasmUrl: b.wasmUrl });
+    const out = { ok: true, variant: b.variant, coi: self.crossOriginIsolated };
+
+    // A multi-second scan WITH an onProgress callback. On st it must run to completion with
+    // ZERO progress events (no shared memory to poll) and peakMemoryUsage 0 — but the query
+    // works and still reports scannedRows from the final result.
+    const ev = [];
+    const pr = await db.query(
+      'SELECT count() FROM numbers(200000000) WHERE sipHash64(number) % 7 = 0',
+      'CSV', { onProgress: (p) => ev.push(p) });
+    out.progressEvents = ev.length;
+    out.peak = pr.peakMemoryUsage;
+    out.elapsed = pr.elapsedSeconds;
+    out.scannedRows = pr.scannedRows;
+    out.count = Number(pr.text().trim());
+    log('progress: events=' + ev.length + ' elapsed=' + out.elapsed.toFixed(2) + 's peak=' + out.peak + ' scannedRows=' + out.scannedRows + ' count=' + out.count);
+
+    // cancel() is mt-only: on st it must throw synchronously (no cancel flag).
+    out.cancelThrew = false;
+    try { db.cancel(); } catch (e) { out.cancelThrew = true; out.cancelErr = String((e && e.message) || e).slice(0, 140); }
+    log('cancel: threw=' + out.cancelThrew + ' err=' + out.cancelErr);
+
+    await db.terminate();
+    log('done: ' + JSON.stringify(out));
+    window.__RESULT__ = out;
+  } catch (e) {
+    log('FATAL ' + ((e && e.message) || e));
+    window.__RESULT__ = { fatal: String((e && e.message) || e).slice(0, 200) };
+  }
+})();
+setTimeout(() => { if (window.__RESULT__ === undefined) window.__RESULT__ = { timeout: true }; }, 90000);
+</script>

--- a/packages/chdb-wasm/test/progress-cancel-st-fixture.html
+++ b/packages/chdb-wasm/test/progress-cancel-st-fixture.html
@@ -2,9 +2,9 @@
 <!-- Driven by test/progress-cancel-st-run.mjs (NO COOP/COEP -> non-isolated -> st bundle).
      On the single-threaded build there is no SharedArrayBuffer, so the page can't poll the
      engine's progress struct and queries run synchronously in the worker (uninterruptible).
-     Verifies that progress + cancel DEGRADE as documented: onProgress never fires,
-     peakMemoryUsage is 0, db.cancel() throws — while the query itself runs fine and still
-     reports scannedRows. Publishes findings on window.__RESULT__. -->
+     Verifies that progress + cancel DEGRADE as documented: onProgress never fires and
+     db.cancel() throws — while the query itself runs fine and still reports scannedRows.
+     Publishes findings on window.__RESULT__. -->
 <script type="module">
 import { AsyncChdb, selectBundle } from '../dist/index.js';
 const el = document.getElementById('o');
@@ -17,18 +17,17 @@ const log = (m) => { el.textContent += '\n' + m; console.log(m); };
     const out = { ok: true, variant: b.variant, coi: self.crossOriginIsolated };
 
     // A multi-second scan WITH an onProgress callback. On st it must run to completion with
-    // ZERO progress events (no shared memory to poll) and peakMemoryUsage 0 — but the query
-    // works and still reports scannedRows from the final result.
+    // ZERO progress events (no shared memory to poll) — but the query works and still reports
+    // scannedRows from the final result.
     const ev = [];
     const pr = await db.query(
       'SELECT count() FROM numbers(200000000) WHERE sipHash64(number) % 7 = 0',
       'CSV', { onProgress: (p) => ev.push(p) });
     out.progressEvents = ev.length;
-    out.peak = pr.peakMemoryUsage;
     out.elapsed = pr.elapsedSeconds;
     out.scannedRows = pr.scannedRows;
     out.count = Number(pr.text().trim());
-    log('progress: events=' + ev.length + ' elapsed=' + out.elapsed.toFixed(2) + 's peak=' + out.peak + ' scannedRows=' + out.scannedRows + ' count=' + out.count);
+    log('progress: events=' + ev.length + ' elapsed=' + out.elapsed.toFixed(2) + 's scannedRows=' + out.scannedRows + ' count=' + out.count);
 
     // cancel() is mt-only: on st it must throw synchronously (no cancel flag).
     out.cancelThrew = false;

--- a/packages/chdb-wasm/test/progress-cancel-st-run.mjs
+++ b/packages/chdb-wasm/test/progress-cancel-st-run.mjs
@@ -1,0 +1,118 @@
+// Headless-Chrome verification of the SINGLE-THREADED (st) bundle's progress/cancel
+// behaviour: serves the fixture WITHOUT COOP/COEP, so the page is NOT cross-origin isolated
+// and selectBundle picks st. Asserts the documented graceful degradation — no live progress,
+// peak 0, cancel() throws — while ordinary queries still run and report scannedRows.
+// Drives the cached Chrome via raw CDP (no puppeteer). Run with Node >=22:
+//   node test/progress-cancel-st-run.mjs
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import assert from 'node:assert';
+
+const pkgDir = process.env.CHDB_PKG_DIR || dirname(dirname(fileURLToPath(import.meta.url)));
+const CHROME = process.env.CHROME_BIN ||
+  '/home/ubuntu/.cache/puppeteer/chrome/linux-149.0.7827.22/chrome-linux64/chrome';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json' };
+const FIXTURE = '/test/progress-cancel-st-fixture.html';
+
+// NB: intentionally NO Cross-Origin-Opener/Embedder-Policy headers -> not isolated -> st.
+function startServer(port) {
+  const server = createServer(async (req, res) => {
+    try {
+      const p = decodeURIComponent((req.url || '/').split('?')[0]);
+      const rel = normalize(p === '/' ? FIXTURE : p).replace(/^([/\\]|\.\.[/\\])+/, '');
+      res.setHeader('Content-Type', MIME[extname(join(pkgDir, rel))] || 'application/octet-stream');
+      res.end(await readFile(join(pkgDir, rel)));
+    } catch { res.statusCode = 404; res.end('not found'); }
+  });
+  return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+}
+
+class CDP {
+  constructor(ws) { this.ws = ws; this.id = 0; this.waiters = new Map(); this.listeners = []; ws.onmessage = (e) => this._recv(e.data); }
+  static async connect(wsUrl) { const ws = new WebSocket(wsUrl); await new Promise((res, rej) => { ws.onopen = res; ws.onerror = (e) => rej(new Error('ws ' + (e.message || 'error'))); }); return new CDP(ws); }
+  _recv(raw) {
+    const msg = JSON.parse(raw);
+    if (msg.id != null && this.waiters.has(msg.id)) { const w = this.waiters.get(msg.id); this.waiters.delete(msg.id); msg.error ? w.rej(new Error(msg.error.message)) : w.res(msg.result); }
+    else if (msg.method) for (const l of this.listeners) l(msg);
+  }
+  send(method, params = {}, sessionId) { const id = ++this.id; return new Promise((res, rej) => { this.waiters.set(id, { res, rej }); this.ws.send(JSON.stringify({ id, method, params, sessionId })); }); }
+  on(fn) { this.listeners.push(fn); }
+}
+
+async function fetchJSON(url, tries = 50) {
+  for (let i = 0; i < tries; i++) {
+    try { const r = await fetch(url); if (r.ok) return await r.json(); } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('CDP endpoint did not come up: ' + url);
+}
+
+async function main() {
+  const port = 9825, cdpPort = 9224;
+  const server = await startServer(port);
+  const chrome = spawn(CHROME, [
+    '--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
+    `--remote-debugging-port=${cdpPort}`, '--user-data-dir=/tmp/chdb-cdp-profile-st',
+    `http://127.0.0.1:${port}${FIXTURE}`,
+  ], { stdio: ['ignore', 'ignore', 'pipe'] });
+  let chromeStderr = '';
+  chrome.stderr.on('data', (d) => { chromeStderr += d.toString(); });
+
+  let cdp;
+  try {
+    const ver = await fetchJSON(`http://127.0.0.1:${cdpPort}/json/version`);
+    cdp = await CDP.connect(ver.webSocketDebuggerUrl);
+    let target;
+    for (let i = 0; i < 50 && !target; i++) {
+      const { targetInfos } = await cdp.send('Target.getTargets');
+      target = targetInfos.find((t) => t.type === 'page' && t.url.includes('progress-cancel-st-fixture'));
+      if (!target) await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(target, 'page target not found');
+    const { sessionId } = await cdp.send('Target.attachToTarget', { targetId: target.targetId, flatten: true });
+    cdp.on((m) => {
+      if (m.method === 'Runtime.consoleAPICalled') console.log('  [page]', m.params.args.map((a) => a.value ?? a.description ?? '').join(' '));
+      if (m.method === 'Runtime.exceptionThrown') console.error('  [pageerror]', m.params.exceptionDetails?.exception?.description || m.params.exceptionDetails?.text);
+    });
+    await cdp.send('Runtime.enable', {}, sessionId);
+
+    const deadline = Date.now() + 120000;
+    let result;
+    while (Date.now() < deadline) {
+      const { result: r } = await cdp.send('Runtime.evaluate',
+        { expression: 'window.__RESULT__ ? JSON.stringify(window.__RESULT__) : null', returnByValue: true }, sessionId);
+      if (r && r.value) { result = JSON.parse(r.value); break; }
+      await new Promise((res) => setTimeout(res, 300));
+    }
+    assert.ok(result, 'timed out waiting for window.__RESULT__');
+    console.log('\n=== RESULT ===\n' + JSON.stringify(result, null, 2) + '\n');
+
+    assert.ok(result.ok, 'fixture not ok: ' + (result.fatal || (result.timeout && 'timeout') || '?'));
+    assert.strictEqual(result.coi, false, 'page must NOT be cross-origin isolated');
+    assert.strictEqual(result.variant, 'st', 'expected st bundle in a non-isolated page');
+    // No live progress on st, and peak 0 — even though the query ran for seconds.
+    assert.strictEqual(result.progressEvents, 0, `st must emit no progress events, got ${result.progressEvents}`);
+    assert.strictEqual(result.peak, 0, `st peakMemoryUsage must be 0, got ${result.peak}`);
+    // The query still ran correctly: scanned all source rows + a plausible count.
+    assert.strictEqual(result.scannedRows, 200000000, `st query must still scan all rows, got ${result.scannedRows}`);
+    assert.ok(result.count > 0, `st query must return a count, got ${result.count}`);
+    // cancel() is mt-only -> must throw on st, with a guiding message.
+    assert.ok(result.cancelThrew, 'st cancel() must throw');
+    assert.ok(/multi-threaded|mt/i.test(result.cancelErr || ''), 'cancel error should mention the mt requirement, got: ' + result.cancelErr);
+
+    console.log(`PASS (st): no live progress (events=0, peak=0) over a ${result.elapsed.toFixed(1)}s query that scanned ` +
+      `${result.scannedRows} rows (count=${result.count}); cancel() threw -> "${(result.cancelErr || '').split('(')[0].trim()}"`);
+  } catch (e) {
+    if (chromeStderr) console.error('--- chrome stderr (tail) ---\n' + chromeStderr.split('\n').slice(-15).join('\n'));
+    throw e;
+  } finally {
+    try { cdp?.ws.close(); } catch { /* ignore */ }
+    chrome.kill('SIGKILL');
+    server.close();
+  }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('FAIL:', e.message); process.exit(1); });

--- a/packages/chdb-wasm/test/progress-cancel-st-run.mjs
+++ b/packages/chdb-wasm/test/progress-cancel-st-run.mjs
@@ -93,9 +93,8 @@ async function main() {
     assert.ok(result.ok, 'fixture not ok: ' + (result.fatal || (result.timeout && 'timeout') || '?'));
     assert.strictEqual(result.coi, false, 'page must NOT be cross-origin isolated');
     assert.strictEqual(result.variant, 'st', 'expected st bundle in a non-isolated page');
-    // No live progress on st, and peak 0 — even though the query ran for seconds.
+    // No live progress on st — even though the query ran for seconds.
     assert.strictEqual(result.progressEvents, 0, `st must emit no progress events, got ${result.progressEvents}`);
-    assert.strictEqual(result.peak, 0, `st peakMemoryUsage must be 0, got ${result.peak}`);
     // The query still ran correctly: scanned all source rows + a plausible count.
     assert.strictEqual(result.scannedRows, 200000000, `st query must still scan all rows, got ${result.scannedRows}`);
     assert.ok(result.count > 0, `st query must return a count, got ${result.count}`);
@@ -103,7 +102,7 @@ async function main() {
     assert.ok(result.cancelThrew, 'st cancel() must throw');
     assert.ok(/multi-threaded|mt/i.test(result.cancelErr || ''), 'cancel error should mention the mt requirement, got: ' + result.cancelErr);
 
-    console.log(`PASS (st): no live progress (events=0, peak=0) over a ${result.elapsed.toFixed(1)}s query that scanned ` +
+    console.log(`PASS (st): no live progress (events=0) over a ${result.elapsed.toFixed(1)}s query that scanned ` +
       `${result.scannedRows} rows (count=${result.count}); cancel() threw -> "${(result.cancelErr || '').split('(')[0].trim()}"`);
   } catch (e) {
     if (chromeStderr) console.error('--- chrome stderr (tail) ---\n' + chromeStderr.split('\n').slice(-15).join('\n'));

--- a/packages/chdb-wasm/test/progress-cancel-st-run.mjs
+++ b/packages/chdb-wasm/test/progress-cancel-st-run.mjs
@@ -1,11 +1,12 @@
 // Headless-Chrome verification of the SINGLE-THREADED (st) bundle's progress/cancel
 // behaviour: serves the fixture WITHOUT COOP/COEP, so the page is NOT cross-origin isolated
 // and selectBundle picks st. Asserts the documented graceful degradation — no live progress,
-// peak 0, cancel() throws — while ordinary queries still run and report scannedRows.
+// cancel() throws — while ordinary queries still run and report scannedRows.
 // Drives the cached Chrome via raw CDP (no puppeteer). Run with Node >=22:
 //   node test/progress-cancel-st-run.mjs
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { extname, join, normalize, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
@@ -52,17 +53,20 @@ async function fetchJSON(url, tries = 50) {
 
 async function main() {
   const port = 9825, cdpPort = 9224;
+  // Fail fast (before opening the socket) if the Chrome binary is missing — otherwise spawn()
+  // reports it as an opaque async ENOENT much later. Set CHROME_BIN to point at your browser.
+  if (!existsSync(CHROME))
+    throw new Error(`Chrome binary not found at ${CHROME}. Set CHROME_BIN to a Chrome/Chromium executable.`);
   const server = await startServer(port);
-  const chrome = spawn(CHROME, [
-    '--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
-    `--remote-debugging-port=${cdpPort}`, '--user-data-dir=/tmp/chdb-cdp-profile-st',
-    `http://127.0.0.1:${port}${FIXTURE}`,
-  ], { stdio: ['ignore', 'ignore', 'pipe'] });
-  let chromeStderr = '';
-  chrome.stderr.on('data', (d) => { chromeStderr += d.toString(); });
-
-  let cdp;
+  let chrome, cdp, chromeStderr = '';
   try {
+    chrome = spawn(CHROME, [
+      '--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
+      `--remote-debugging-port=${cdpPort}`, '--user-data-dir=/tmp/chdb-cdp-profile-st',
+      `http://127.0.0.1:${port}${FIXTURE}`,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    chrome.stderr.on('data', (d) => { chromeStderr += d.toString(); });
+
     const ver = await fetchJSON(`http://127.0.0.1:${cdpPort}/json/version`);
     cdp = await CDP.connect(ver.webSocketDebuggerUrl);
     let target;
@@ -109,7 +113,7 @@ async function main() {
     throw e;
   } finally {
     try { cdp?.ws.close(); } catch { /* ignore */ }
-    chrome.kill('SIGKILL');
+    chrome?.kill('SIGKILL');
     server.close();
   }
 }

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -118,6 +118,12 @@ void ChdbClient::connect()
         send_profile_events,
         server_display_name);
         connection->setDefaultDatabase("default");
+#if defined(OS_WASM)
+    /// chdb-wasm: enable ClickHouse's interactive-cancel path (polled frequently between
+    /// chunks by the executor) so a query can be cancelled from JS. chdbWasmCancelRequested()
+    /// reads the shared-memory cancel flag. Wasm-only — native chdb's path is unaffected.
+    connection->setCancelCallback([] { return chdbWasmCancelRequested(); });
+#endif
 }
 
 Poco::Util::LayeredConfiguration & ChdbClient::getClientConfiguration()

--- a/programs/wasm/chdb_wasm.cpp
+++ b/programs/wasm/chdb_wasm.cpp
@@ -168,6 +168,10 @@ const char * chdb_wasm_result_error(chdb_result * r)  { return r ? chdb_result_e
 double       chdb_wasm_result_elapsed(chdb_result * r){ return r ? chdb_result_elapsed(r) : 0.0; }
 uint64_t     chdb_wasm_result_rows_read(chdb_result * r)  { return r ? chdb_result_rows_read(r) : 0; }
 uint64_t     chdb_wasm_result_bytes_read(chdb_result * r) { return r ? chdb_result_bytes_read(r) : 0; }
+// Source rows/bytes SCANNED from storage (distinct from rows_read/bytes_read, which
+// are the RESULT size) — for the "Processed N rows, … bytes" footer line.
+uint64_t     chdb_wasm_result_scanned_rows(chdb_result * r)  { return r ? chdb_result_storage_rows_read(r) : 0; }
+uint64_t     chdb_wasm_result_scanned_bytes(chdb_result * r) { return r ? chdb_result_storage_bytes_read(r) : 0; }
 void         chdb_wasm_free_result(chdb_result * r)   { if (r) chdb_destroy_query_result(r); }
 
 } // extern "C"

--- a/programs/wasm/chdb_wasm.cpp
+++ b/programs/wasm/chdb_wasm.cpp
@@ -13,9 +13,26 @@
 
 #include "../local/chdb.h"
 
+#include <emscripten.h>
+#if defined(__EMSCRIPTEN_PTHREADS__)
+#    include <emscripten/threading.h>
+#endif
+
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <string>
+
+// Defined in src/Client/LocalConnection.cpp. Forward-declared here instead of including
+// <Client/LocalConnection.h>, which transitively pulls Poco/Net networking headers that
+// aren't on the wasm include path. The signature MUST match the definition exactly.
+namespace DB
+{
+void setCHDBProgressHook(
+    std::function<void(uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
+                       uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)> hook);
+}
 
 extern "C" {
 
@@ -39,9 +56,47 @@ static char arg0[] = "chdb";
 
 static chdb_connection * g_conn = nullptr;
 
+// Register (once) a query-progress hook on the chdb engine. ClickHouse calls it on every
+// progress tick, on the query thread (the worker running the ccall). We throttle (~100ms)
+// and postMessage a 'queryProgress' event to the page; async.ts routes it by the id
+// worker.ts stashes in self.__chdbQueryId. No-op off the main runtime thread (whose
+// postMessage wouldn't reach the page).
+static void chdb_wasm_register_progress_hook()
+{
+    static bool registered = false;
+    if (registered)
+        return;
+    registered = true;
+    DB::setCHDBProgressHook([](uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
+                               uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)
+    {
+#if defined(__EMSCRIPTEN_PTHREADS__)
+        if (!emscripten_is_main_runtime_thread())
+            return;
+#endif
+        static double last_ms = 0;
+        const double now_ms = emscripten_get_now();
+        if (now_ms - last_ms < 100.0)
+            return;
+        last_ms = now_ms;
+        EM_ASM({
+            if (typeof postMessage === 'function')
+                postMessage({
+                    event: 'queryProgress',
+                    id: (typeof globalThis !== 'undefined' && globalThis.__chdbQueryId) ? globalThis.__chdbQueryId : 0,
+                    readRows: $0, totalRowsToRead: $1, readBytes: $2,
+                    totalBytesToRead: $3, memoryUsage: $4, elapsedNs: $5,
+                });
+        },
+            (double) read_rows, (double) total_rows_to_read, (double) read_bytes,
+            (double) total_bytes_to_read, (double) memory_usage, (double) elapsed_ns);
+    });
+}
+
 // Apply the wasm thread cap on a freshly opened connection (idempotent, cheap).
 static void chdb_wasm_apply_settings(chdb_connection conn)
 {
+    chdb_wasm_register_progress_hook();
     chdb_result * r = chdb_query(conn, "SET max_threads = " CHDB_WASM_MAX_THREADS, "Null");
     if (r)
         chdb_destroy_query_result(r);

--- a/programs/wasm/chdb_wasm.cpp
+++ b/programs/wasm/chdb_wasm.cpp
@@ -42,10 +42,33 @@ void setCHDBCancelCheck(std::function<bool()> check);
 // wasm Memory SharedArrayBuffer at the offset chdb_wasm_cancel_flag_addr() returns.
 static std::atomic<int32_t> g_chdb_cancel_flag{0};
 
+// chdb-wasm live progress: the engine writes the latest progress here on every tick — on
+// WHATEVER thread runs the pipeline (usually a pool pthread). The page can't be reached
+// from a pool pthread, and the worker thread is blocked in the synchronous query ccall, so
+// neither can relay it. Instead the PAGE polls this struct directly: on the mt build the
+// wasm Memory is a SharedArrayBuffer the page can view (at chdb_wasm_progress_addr()), and
+// the page's own event loop stays free during the query. `seq` is bumped last on write
+// (release) so a reader that observes a new seq also observes the matching fields; the
+// reader re-checks seq to reject a torn read. 7 × int64 (page maps a BigInt64Array).
+struct ChdbProgressShared
+{
+    std::atomic<int64_t> seq{0};
+    std::atomic<int64_t> read_rows{0};
+    std::atomic<int64_t> total_rows_to_read{0};
+    std::atomic<int64_t> read_bytes{0};
+    std::atomic<int64_t> total_bytes_to_read{0};
+    std::atomic<int64_t> memory_usage{0};
+    std::atomic<int64_t> elapsed_ns{0};
+};
+static ChdbProgressShared g_chdb_progress;
+
 extern "C" {
 
 // Offset of the cancel flag in wasm memory, for the page to write via the Memory SAB.
 uintptr_t chdb_wasm_cancel_flag_addr() { return reinterpret_cast<uintptr_t>(&g_chdb_cancel_flag); }
+
+// Offset of the live-progress struct in wasm memory, for the page to poll via the Memory SAB.
+uintptr_t chdb_wasm_progress_addr() { return reinterpret_cast<uintptr_t>(&g_chdb_progress); }
 
 // On wasm the pthread pool is fixed-size (PTHREAD_POOL_SIZE) and cannot grow on
 // demand: the chdb query runs synchronously in a worker, so the calling thread is
@@ -68,10 +91,9 @@ static char arg0[] = "chdb";
 static chdb_connection * g_conn = nullptr;
 
 // Register (once) a query-progress hook on the chdb engine. ClickHouse calls it on every
-// progress tick, on the query thread (the worker running the ccall). We throttle (~100ms)
-// and postMessage a 'queryProgress' event to the page; async.ts routes it by the id
-// worker.ts stashes in self.__chdbQueryId. No-op off the main runtime thread (whose
-// postMessage wouldn't reach the page).
+// progress tick, on whatever thread runs the pipeline (usually a pool pthread). We just
+// publish the latest values into the shared-memory struct the page polls — no postMessage
+// (a pool pthread can't reach the page) and no throttle (the page's poll interval throttles).
 static void chdb_wasm_register_progress_hook()
 {
     static bool registered = false;
@@ -81,31 +103,20 @@ static void chdb_wasm_register_progress_hook()
     DB::setCHDBProgressHook([](uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
                                uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)
     {
-#if defined(__EMSCRIPTEN_PTHREADS__)
-        if (!emscripten_is_main_runtime_thread())
-            return;
-#endif
-        static double last_ms = 0;
-        const double now_ms = emscripten_get_now();
-        if (now_ms - last_ms < 100.0)
-            return;
-        last_ms = now_ms;
-        EM_ASM({
-            if (typeof postMessage === 'function')
-                postMessage({
-                    event: 'queryProgress',
-                    id: (typeof globalThis !== 'undefined' && globalThis.__chdbQueryId) ? globalThis.__chdbQueryId : 0,
-                    readRows: $0, totalRowsToRead: $1, readBytes: $2,
-                    totalBytesToRead: $3, memoryUsage: $4, elapsedNs: $5,
-                });
-        },
-            (double) read_rows, (double) total_rows_to_read, (double) read_bytes,
-            (double) total_bytes_to_read, (double) memory_usage, (double) elapsed_ns);
+        // Write fields first (relaxed), then bump seq last (release) so a reader observing
+        // the new seq is guaranteed to see these fields.
+        g_chdb_progress.read_rows.store(static_cast<int64_t>(read_rows), std::memory_order_relaxed);
+        g_chdb_progress.total_rows_to_read.store(static_cast<int64_t>(total_rows_to_read), std::memory_order_relaxed);
+        g_chdb_progress.read_bytes.store(static_cast<int64_t>(read_bytes), std::memory_order_relaxed);
+        g_chdb_progress.total_bytes_to_read.store(static_cast<int64_t>(total_bytes_to_read), std::memory_order_relaxed);
+        g_chdb_progress.memory_usage.store(memory_usage, std::memory_order_relaxed);
+        g_chdb_progress.elapsed_ns.store(static_cast<int64_t>(elapsed_ns), std::memory_order_relaxed);
+        g_chdb_progress.seq.fetch_add(1, std::memory_order_release);
     });
 
     // Cancellation (mt only): the engine polls this on the query thread; we read a
-    // SharedArrayBuffer flag the page sets (globalThis.__chdbCancel). The single-threaded
-    // build has no SAB and never yields mid-query, so it can't be cancelled.
+    // SharedArrayBuffer flag the page sets via Atomics.store. The single-threaded build has
+    // no SAB and never yields mid-query, so it can't be cancelled.
     DB::setCHDBCancelCheck([]() -> bool
     {
         // seq_cst (not relaxed): the query thread must reliably observe the page's

--- a/programs/wasm/chdb_wasm.cpp
+++ b/programs/wasm/chdb_wasm.cpp
@@ -18,6 +18,7 @@
 #    include <emscripten/threading.h>
 #endif
 
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -32,9 +33,19 @@ namespace DB
 void setCHDBProgressHook(
     std::function<void(uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
                        uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)> hook);
+void setCHDBCancelCheck(std::function<bool()> check);
 }
 
+// chdb-wasm cancel flag: lives in shared wasm linear memory, so ANY query thread reads it
+// with a plain atomic load (no per-thread JS globals — the EM_ASM/globalThis approach
+// failed because the check sometimes runs on a pool pthread). The page writes it via the
+// wasm Memory SharedArrayBuffer at the offset chdb_wasm_cancel_flag_addr() returns.
+static std::atomic<int32_t> g_chdb_cancel_flag{0};
+
 extern "C" {
+
+// Offset of the cancel flag in wasm memory, for the page to write via the Memory SAB.
+uintptr_t chdb_wasm_cancel_flag_addr() { return reinterpret_cast<uintptr_t>(&g_chdb_cancel_flag); }
 
 // On wasm the pthread pool is fixed-size (PTHREAD_POOL_SIZE) and cannot grow on
 // demand: the chdb query runs synchronously in a worker, so the calling thread is
@@ -90,6 +101,16 @@ static void chdb_wasm_register_progress_hook()
         },
             (double) read_rows, (double) total_rows_to_read, (double) read_bytes,
             (double) total_bytes_to_read, (double) memory_usage, (double) elapsed_ns);
+    });
+
+    // Cancellation (mt only): the engine polls this on the query thread; we read a
+    // SharedArrayBuffer flag the page sets (globalThis.__chdbCancel). The single-threaded
+    // build has no SAB and never yields mid-query, so it can't be cancelled.
+    DB::setCHDBCancelCheck([]() -> bool
+    {
+        // seq_cst (not relaxed): the query thread must reliably observe the page's
+        // cross-thread Atomics.store of the flag.
+        return g_chdb_cancel_flag.load(std::memory_order_seq_cst) != 0;
     });
 }
 

--- a/programs/wasm/chdb_wasm.cpp
+++ b/programs/wasm/chdb_wasm.cpp
@@ -32,7 +32,7 @@ namespace DB
 {
 void setCHDBProgressHook(
     std::function<void(uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
-                       uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)> hook);
+                       uint64_t total_bytes_to_read, uint64_t elapsed_ns)> hook);
 void setCHDBCancelCheck(std::function<bool()> check);
 }
 
@@ -49,7 +49,7 @@ static std::atomic<int32_t> g_chdb_cancel_flag{0};
 // wasm Memory is a SharedArrayBuffer the page can view (at chdb_wasm_progress_addr()), and
 // the page's own event loop stays free during the query. `seq` is bumped last on write
 // (release) so a reader that observes a new seq also observes the matching fields; the
-// reader re-checks seq to reject a torn read. 7 × int64 (page maps a BigInt64Array).
+// reader re-checks seq to reject a torn read. 6 × int64 (page maps a BigInt64Array).
 struct ChdbProgressShared
 {
     std::atomic<int64_t> seq{0};
@@ -57,7 +57,6 @@ struct ChdbProgressShared
     std::atomic<int64_t> total_rows_to_read{0};
     std::atomic<int64_t> read_bytes{0};
     std::atomic<int64_t> total_bytes_to_read{0};
-    std::atomic<int64_t> memory_usage{0};
     std::atomic<int64_t> elapsed_ns{0};
 };
 static ChdbProgressShared g_chdb_progress;
@@ -101,7 +100,7 @@ static void chdb_wasm_register_progress_hook()
         return;
     registered = true;
     DB::setCHDBProgressHook([](uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
-                               uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)
+                               uint64_t total_bytes_to_read, uint64_t elapsed_ns)
     {
         // Write fields first (relaxed), then bump seq last (release) so a reader observing
         // the new seq is guaranteed to see these fields.
@@ -109,7 +108,6 @@ static void chdb_wasm_register_progress_hook()
         g_chdb_progress.total_rows_to_read.store(static_cast<int64_t>(total_rows_to_read), std::memory_order_relaxed);
         g_chdb_progress.read_bytes.store(static_cast<int64_t>(read_bytes), std::memory_order_relaxed);
         g_chdb_progress.total_bytes_to_read.store(static_cast<int64_t>(total_bytes_to_read), std::memory_order_relaxed);
-        g_chdb_progress.memory_usage.store(memory_usage, std::memory_order_relaxed);
         g_chdb_progress.elapsed_ns.store(static_cast<int64_t>(elapsed_ns), std::memory_order_relaxed);
         g_chdb_progress.seq.fetch_add(1, std::memory_order_release);
     });

--- a/programs/wasm/exported_functions.txt
+++ b/programs/wasm/exported_functions.txt
@@ -16,4 +16,6 @@ _chdb_wasm_result_error
 _chdb_wasm_result_elapsed
 _chdb_wasm_result_rows_read
 _chdb_wasm_result_bytes_read
+_chdb_wasm_result_scanned_rows
+_chdb_wasm_result_scanned_bytes
 _chdb_wasm_free_result

--- a/programs/wasm/exported_functions.txt
+++ b/programs/wasm/exported_functions.txt
@@ -19,4 +19,5 @@ _chdb_wasm_result_bytes_read
 _chdb_wasm_result_scanned_rows
 _chdb_wasm_result_scanned_bytes
 _chdb_wasm_cancel_flag_addr
+_chdb_wasm_progress_addr
 _chdb_wasm_free_result

--- a/programs/wasm/exported_functions.txt
+++ b/programs/wasm/exported_functions.txt
@@ -18,4 +18,5 @@ _chdb_wasm_result_rows_read
 _chdb_wasm_result_bytes_read
 _chdb_wasm_result_scanned_rows
 _chdb_wasm_result_scanned_bytes
+_chdb_wasm_cancel_flag_addr
 _chdb_wasm_free_result

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -117,9 +117,42 @@ void LocalConnection::updateProgress(const Progress & value)
     state->progress.incrementPiecewiseAtomically(value);
 }
 
+/// chdb-wasm: a process-global hook fired on every progress tick with the accumulated
+/// chdb progress, so the wasm glue can push live query progress to JS (the browser
+/// progress bar). No-op when unset (native builds never set it).
+namespace
+{
+    std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> g_chdb_progress_hook;
+}
+
+void setCHDBProgressHook(
+    std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> hook)
+{
+    g_chdb_progress_hook = std::move(hook);
+}
+
 void LocalConnection::updateCHDBProgress(const Progress & value)
 {
     chdb_progress.incrementPiecewiseAtomically(value);
+
+    /// memory_usage is a gauge (current), not a summable delta: overwrite it with the
+    /// latest non-zero sample and track the peak (for ChdbResult.peakMemoryUsage).
+    const Int64 cur_mem = value.memory_usage.load(std::memory_order_relaxed);
+    if (cur_mem > 0)
+    {
+        chdb_progress.memory_usage.store(cur_mem, std::memory_order_relaxed);
+        if (cur_mem > chdb_peak_memory)
+            chdb_peak_memory = cur_mem;
+    }
+
+    if (g_chdb_progress_hook)
+        g_chdb_progress_hook(
+            chdb_progress.read_rows.load(std::memory_order_relaxed),
+            chdb_progress.total_rows_to_read.load(std::memory_order_relaxed),
+            chdb_progress.read_bytes.load(std::memory_order_relaxed),
+            chdb_progress.total_bytes_to_read.load(std::memory_order_relaxed),
+            chdb_progress.memory_usage.load(std::memory_order_relaxed),
+            chdb_progress.elapsed_ns.load(std::memory_order_relaxed));
 }
 
 void LocalConnection::sendProfileEvents()
@@ -220,6 +253,7 @@ void LocalConnection::sendQuery(
     state.reset();
     state.emplace();
     chdb_progress.reset();
+    chdb_peak_memory = 0;
 
     state->query_id = query_id;
     state->query = query;

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -123,12 +123,23 @@ void LocalConnection::updateProgress(const Progress & value)
 namespace
 {
     std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> g_chdb_progress_hook;
+    std::function<bool()> g_chdb_cancel_check;
 }
 
 void setCHDBProgressHook(
     std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> hook)
 {
     g_chdb_progress_hook = std::move(hook);
+}
+
+void setCHDBCancelCheck(std::function<bool()> check)
+{
+    g_chdb_cancel_check = std::move(check);
+}
+
+bool chdbWasmCancelRequested()
+{
+    return g_chdb_cancel_check ? g_chdb_cancel_check() : false;
 }
 
 void LocalConnection::updateCHDBProgress(const Progress & value)
@@ -153,6 +164,14 @@ void LocalConnection::updateCHDBProgress(const Progress & value)
             chdb_progress.total_bytes_to_read.load(std::memory_order_relaxed),
             chdb_progress.memory_usage.load(std::memory_order_relaxed),
             chdb_progress.elapsed_ns.load(std::memory_order_relaxed));
+
+    /// chdb-wasm: a second cancel point on each progress tick (in addition to the
+    /// interactive-cancel callback) — stop the running query if the page set the flag.
+    if (g_chdb_cancel_check && g_chdb_cancel_check())
+    {
+        if (auto elem = query_context->getProcessListElement())
+            elem->cancelQuery(CancelReason::CANCELLED_BY_USER);
+    }
 }
 
 void LocalConnection::sendProfileEvents()

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -146,9 +146,17 @@ void LocalConnection::updateCHDBProgress(const Progress & value)
 {
     chdb_progress.incrementPiecewiseAtomically(value);
 
-    /// memory_usage is a gauge (current), not a summable delta: overwrite it with the
-    /// latest non-zero sample and track the peak (for ChdbResult.peakMemoryUsage).
-    const Int64 cur_mem = value.memory_usage.load(std::memory_order_relaxed);
+    /// memory_usage is a gauge (current), not a summable delta. The executor's Progress
+    /// doesn't carry it (the protocol layer normally injects it from the memory tracker),
+    /// so fall back to the running query's tracker. Report the latest non-zero sample and
+    /// track the peak (for ChdbResult.peakMemoryUsage).
+    Int64 cur_mem = value.memory_usage.load(std::memory_order_relaxed);
+    if (cur_mem <= 0)
+    {
+        if (auto elem = query_context->getProcessListElement())
+            if (auto * mt = elem->getMemoryTracker())
+                cur_mem = mt->get();
+    }
     if (cur_mem > 0)
     {
         chdb_progress.memory_usage.store(cur_mem, std::memory_order_relaxed);

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -117,9 +117,10 @@ void LocalConnection::updateProgress(const Progress & value)
     state->progress.incrementPiecewiseAtomically(value);
 }
 
+#if defined(OS_WASM)
 /// chdb-wasm: a process-global hook fired on every progress tick with the accumulated
 /// chdb progress, so the wasm glue can push live query progress to JS (the browser
-/// progress bar). No-op when unset (native builds never set it).
+/// progress bar). Wasm-only — native builds neither compile nor set these.
 namespace
 {
     std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> g_chdb_progress_hook;
@@ -141,15 +142,17 @@ bool chdbWasmCancelRequested()
 {
     return g_chdb_cancel_check ? g_chdb_cancel_check() : false;
 }
+#endif
 
 void LocalConnection::updateCHDBProgress(const Progress & value)
 {
     chdb_progress.incrementPiecewiseAtomically(value);
 
-    /// memory_usage is a gauge (current), not a summable delta. The executor's Progress
-    /// doesn't carry it (the protocol layer normally injects it from the memory tracker),
-    /// so fall back to the running query's tracker. Report the latest non-zero sample and
-    /// track the peak (for ChdbResult.peakMemoryUsage).
+#if defined(OS_WASM)
+    /// chdb-wasm only: surface live progress + peak memory to JS, and offer a second cancel
+    /// point. memory_usage is a gauge (current), not a summable delta; the executor's
+    /// Progress doesn't carry it (the protocol layer normally injects it from the memory
+    /// tracker), so fall back to the running query's tracker and track the peak.
     Int64 cur_mem = value.memory_usage.load(std::memory_order_relaxed);
     if (cur_mem <= 0)
     {
@@ -173,13 +176,14 @@ void LocalConnection::updateCHDBProgress(const Progress & value)
             chdb_progress.memory_usage.load(std::memory_order_relaxed),
             chdb_progress.elapsed_ns.load(std::memory_order_relaxed));
 
-    /// chdb-wasm: a second cancel point on each progress tick (in addition to the
-    /// interactive-cancel callback) — stop the running query if the page set the flag.
+    /// A second cancel point on each progress tick (in addition to the interactive-cancel
+    /// callback) — stop the running query if the page set the flag.
     if (g_chdb_cancel_check && g_chdb_cancel_check())
     {
         if (auto elem = query_context->getProcessListElement())
             elem->cancelQuery(CancelReason::CANCELLED_BY_USER);
     }
+#endif
 }
 
 void LocalConnection::sendProfileEvents()
@@ -280,7 +284,9 @@ void LocalConnection::sendQuery(
     state.reset();
     state.emplace();
     chdb_progress.reset();
+#if defined(OS_WASM)
     chdb_peak_memory = 0;
+#endif
 
     state->query_id = query_id;
     state->query = query;

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -123,12 +123,12 @@ void LocalConnection::updateProgress(const Progress & value)
 /// progress bar). Wasm-only — native builds neither compile nor set these.
 namespace
 {
-    std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> g_chdb_progress_hook;
+    std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)> g_chdb_progress_hook;
     std::function<bool()> g_chdb_cancel_check;
 }
 
 void setCHDBProgressHook(
-    std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, int64_t, uint64_t)> hook)
+    std::function<void(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)> hook)
 {
     g_chdb_progress_hook = std::move(hook);
 }
@@ -149,31 +149,13 @@ void LocalConnection::updateCHDBProgress(const Progress & value)
     chdb_progress.incrementPiecewiseAtomically(value);
 
 #if defined(OS_WASM)
-    /// chdb-wasm only: surface live progress + peak memory to JS, and offer a second cancel
-    /// point. memory_usage is a gauge (current), not a summable delta; the executor's
-    /// Progress doesn't carry it (the protocol layer normally injects it from the memory
-    /// tracker), so fall back to the running query's tracker and track the peak.
-    Int64 cur_mem = value.memory_usage.load(std::memory_order_relaxed);
-    if (cur_mem <= 0)
-    {
-        if (auto elem = query_context->getProcessListElement())
-            if (auto * mt = elem->getMemoryTracker())
-                cur_mem = mt->get();
-    }
-    if (cur_mem > 0)
-    {
-        chdb_progress.memory_usage.store(cur_mem, std::memory_order_relaxed);
-        if (cur_mem > chdb_peak_memory)
-            chdb_peak_memory = cur_mem;
-    }
-
+    /// chdb-wasm only: surface live progress to JS, and offer a second cancel point.
     if (g_chdb_progress_hook)
         g_chdb_progress_hook(
             chdb_progress.read_rows.load(std::memory_order_relaxed),
             chdb_progress.total_rows_to_read.load(std::memory_order_relaxed),
             chdb_progress.read_bytes.load(std::memory_order_relaxed),
             chdb_progress.total_bytes_to_read.load(std::memory_order_relaxed),
-            chdb_progress.memory_usage.load(std::memory_order_relaxed),
             chdb_progress.elapsed_ns.load(std::memory_order_relaxed));
 
     /// A second cancel point on each progress tick (in addition to the interactive-cancel
@@ -284,9 +266,6 @@ void LocalConnection::sendQuery(
     state.reset();
     state.emplace();
     chdb_progress.reset();
-#if defined(OS_WASM)
-    chdb_peak_memory = 0;
-#endif
 
     state->query_id = query_id;
     state->query = query;

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -177,10 +177,6 @@ public:
     void setThrottler(const ThrottlerPtr &) override {}
 
     const Progress & getCHDBProgress() const { return chdb_progress; }
-#if defined(OS_WASM)
-    /// chdb-wasm: peak memory observed during the query (for ChdbResult.peakMemoryUsage).
-    Int64 getCHDBPeakMemory() const { return chdb_peak_memory; }
-#endif
 #if USE_PYTHON
     void resetQueryContext();
     Session & getSession() const { return *session; }
@@ -217,9 +213,6 @@ private:
     std::optional<LocalQueryState> state;
 
     Progress chdb_progress;
-#if defined(OS_WASM)
-    Int64 chdb_peak_memory = 0;
-#endif
 
     /// Last "server" packet.
     std::optional<UInt64> next_packet_type;
@@ -233,12 +226,12 @@ private:
 
 #if defined(OS_WASM)
 /// chdb-wasm: register a hook fired on each query-progress tick with the accumulated
-/// counters (read_rows, total_rows_to_read, read_bytes, total_bytes_to_read,
-/// memory_usage, elapsed_ns). Plain-primitive signature so the wasm glue can forward-
-/// declare it WITHOUT including this (heavy, Poco/Net-pulling) header. Pass {} to clear.
+/// counters (read_rows, total_rows_to_read, read_bytes, total_bytes_to_read, elapsed_ns).
+/// Plain-primitive signature so the wasm glue can forward-declare it WITHOUT including this
+/// (heavy, Poco/Net-pulling) header. Pass {} to clear.
 void setCHDBProgressHook(
     std::function<void(uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
-                       uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)> hook);
+                       uint64_t total_bytes_to_read, uint64_t elapsed_ns)> hook);
 
 /// chdb-wasm: register a predicate the engine polls during a query (via setCancelCallback
 /// on each connection) to decide whether to cancel it — the wasm glue reads a

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -235,4 +235,10 @@ void setCHDBProgressHook(
     std::function<void(uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
                        uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)> hook);
 
+/// chdb-wasm: register a predicate the engine polls during a query (via setCancelCallback
+/// on each connection) to decide whether to cancel it — the wasm glue reads a
+/// SharedArrayBuffer flag the page sets. Returns false when unset (native: never cancels).
+void setCHDBCancelCheck(std::function<bool()> check);
+bool chdbWasmCancelRequested();
+
 }

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -177,8 +177,10 @@ public:
     void setThrottler(const ThrottlerPtr &) override {}
 
     const Progress & getCHDBProgress() const { return chdb_progress; }
+#if defined(OS_WASM)
     /// chdb-wasm: peak memory observed during the query (for ChdbResult.peakMemoryUsage).
     Int64 getCHDBPeakMemory() const { return chdb_peak_memory; }
+#endif
 #if USE_PYTHON
     void resetQueryContext();
     Session & getSession() const { return *session; }
@@ -215,7 +217,9 @@ private:
     std::optional<LocalQueryState> state;
 
     Progress chdb_progress;
+#if defined(OS_WASM)
     Int64 chdb_peak_memory = 0;
+#endif
 
     /// Last "server" packet.
     std::optional<UInt64> next_packet_type;
@@ -227,6 +231,7 @@ private:
     ReadBuffer * in;
 };
 
+#if defined(OS_WASM)
 /// chdb-wasm: register a hook fired on each query-progress tick with the accumulated
 /// counters (read_rows, total_rows_to_read, read_bytes, total_bytes_to_read,
 /// memory_usage, elapsed_ns). Plain-primitive signature so the wasm glue can forward-
@@ -240,5 +245,6 @@ void setCHDBProgressHook(
 /// SharedArrayBuffer flag the page sets. Returns false when unset (native: never cancels).
 void setCHDBCancelCheck(std::function<bool()> check);
 bool chdbWasmCancelRequested();
+#endif
 
 }

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -177,6 +177,8 @@ public:
     void setThrottler(const ThrottlerPtr &) override {}
 
     const Progress & getCHDBProgress() const { return chdb_progress; }
+    /// chdb-wasm: peak memory observed during the query (for ChdbResult.peakMemoryUsage).
+    Int64 getCHDBPeakMemory() const { return chdb_peak_memory; }
 #if USE_PYTHON
     void resetQueryContext();
     Session & getSession() const { return *session; }
@@ -213,6 +215,7 @@ private:
     std::optional<LocalQueryState> state;
 
     Progress chdb_progress;
+    Int64 chdb_peak_memory = 0;
 
     /// Last "server" packet.
     std::optional<UInt64> next_packet_type;
@@ -223,5 +226,13 @@ private:
 
     ReadBuffer * in;
 };
+
+/// chdb-wasm: register a hook fired on each query-progress tick with the accumulated
+/// counters (read_rows, total_rows_to_read, read_bytes, total_bytes_to_read,
+/// memory_usage, elapsed_ns). Plain-primitive signature so the wasm glue can forward-
+/// declare it WITHOUT including this (heavy, Poco/Net-pulling) header. Pass {} to clear.
+void setCHDBProgressHook(
+    std::function<void(uint64_t read_rows, uint64_t total_rows_to_read, uint64_t read_bytes,
+                       uint64_t total_bytes_to_read, int64_t memory_usage, uint64_t elapsed_ns)> hook);
 
 }


### PR DESCRIPTION
Closes #99.

Adds live query progress, peak memory, scanned rows/bytes, and mid-query cancellation to the chdb WebAssembly build.

### How
- **Progress** — the engine writes each progress tick into a struct in shared wasm memory (`chdb_wasm_progress_addr`); the page polls it via a `BigInt64Array` over the Memory `SharedArrayBuffer` (its event loop stays free while the worker blocks in the query call). Surfaced as `query/queryStream({ onProgress })`. Mirror of the cancel flag — no `postMessage`, since a pool pthread can't reach the page.
- **Peak memory** — read from the running query's `MemoryTracker` (the executor's `Progress` carries no `memory_usage` in the LocalConnection path); tracked JS-side as the max over the stream → `ChdbResult.peakMemoryUsage`.
- **Scanned rows/bytes** — expose the existing `chdb_result_storage_rows_read/bytes_read` → `ChdbResult.scannedRows/scannedBytes`.
- **Cancel** — `db.cancel()` sets a flag in shared wasm memory; the engine reads it via ClickHouse's interactive-cancel callback and calls `cancelQuery()`.

### Scope
mt (threaded, cross-origin isolated) only. On st there is no shared memory: progress/peak silently no-op and `cancel()` throws; ordinary queries and `scannedRows`/`elapsed` still work.

### Verification (headless Chrome, raw-CDP tests in `packages/chdb-wasm/test/`)
- **mt**: 239 live progress events over a 19s scan, peak ~2.2 MiB, `cancel()` interrupts in ~600ms (`QUERY_WAS_CANCELLED`).
- **st**: 0 progress events, peak 0, `cancel()` throws; query still scans 200M rows.

Touches engine `src/Client/LocalConnection.{h,cpp}`, glue `programs/wasm/chdb_wasm.cpp` + `exported_functions.txt`, SDK `packages/chdb-wasm/src/*`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live query progress, peak memory, and cancellation to the WebAssembly build
> - Introduces shared-memory-backed progress polling and cancellation for the `mt` (multi-threaded) wasm bundle. The main thread reads a progress struct written by the engine via `Atomics`, avoiding extra worker round-trips.
> - Adds `cancel()` to `AsyncChdb` and `AsyncChdbConnection`, which sets a shared cancel flag that the engine checks during `LocalConnection::updateCHDBProgress` to abort the running query.
> - Adds an `onProgress` callback to `QueryOptions`, accepted by `query()`, `queryStream()`, and connection variants. A ~80ms polling interval fires the callback while a query runs, with cleanup guaranteed in `finally`.
> - Extends `ChdbResult` and `WireResult` with `scannedRows` and `scannedBytes` from new C exports `chdb_wasm_result_scanned_rows` and `chdb_wasm_result_scanned_bytes`.
> - On `st` (single-threaded) builds, `onProgress` delivers no events and `cancel()` throws, verified by a dedicated headless-Chrome test fixture.
> - Behavioral Change: `cancel()` on `st` builds throws rather than silently no-ops; `mt` builds require cross-origin isolation (`SharedArrayBuffer` availability).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a84359.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->