### PR TITLE
Run scalar subqueries synchronously on the single-threaded WASM build

### DIFF
--- a/packages/chdb-wasm/test/matrix.test.mjs
+++ b/packages/chdb-wasm/test/matrix.test.mjs
@@ -44,6 +44,7 @@ check('join_small', async () => assert.strictEqual(await q('SELECT a.number FROM
 check('join_big', async () => assert.strictEqual(await q('SELECT count() FROM numbers(100000) a JOIN numbers(100000) b ON a.number = b.number'), '100000'));
 check('subquery', async () => assert.strictEqual(await q('SELECT sum(x) FROM (SELECT number * 2 AS x FROM numbers(1000))'), '999000'));
 check('cte', async () => assert.strictEqual(await q('WITH t AS (SELECT number n FROM numbers(100)) SELECT sum(n) FROM t'), '4950'));
+check('scalar_subquery', async () => assert.strictEqual(await q('SELECT (SELECT count() FROM numbers(10))'), '10'));
 check('arrayjoin', async () => assert.strictEqual(await q('SELECT arrayJoin([1, 2, 3]) AS x ORDER BY x', 'CSV'), '1\n2\n3'));
 check('window', async () => assert.strictEqual(await q('SELECT sum(number) OVER (ORDER BY number) FROM numbers(4)', 'CSV'), '0\n1\n3\n6'));
 

--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -10,6 +10,7 @@
 #include <Planner/Utils.h>
 
 #include <Processors/Executors/PullingAsyncPipelineExecutor.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/QueryPlan/LimitStep.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
@@ -238,7 +239,11 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                 io.pipeline.setQuota(subquery_context->getQuota());
             }
 
+#ifdef CHDB_WASM_SINGLE_THREADED
+            std::optional<PullingPipelineExecutor> executor;
+#else
             std::optional<PullingAsyncPipelineExecutor> executor;
+#endif
             Chunk chunk;
 
             if (!skip_execution_for_exists)
@@ -248,8 +253,10 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                 io.pipeline.setConcurrencyControl(context->getSettingsRef()[Setting::use_concurrency_control]);
 
                 executor.emplace(io.pipeline);
+#ifndef CHDB_WASM_SINGLE_THREADED
                 if (auto cancel_cb = context->hasQueryContext() ? context->getQueryContext()->getInteractiveCancelCallback() : nullptr)
                     executor->setCancelCallback(std::move(cancel_cb), std::max(UInt64(100), context->getSettingsRef()[Setting::interactive_delay] / 1000));
+#endif
                 while (chunk.getNumRows() == 0 && executor->pull(chunk))
                 {
                 }

--- a/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
+++ b/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
@@ -18,6 +18,7 @@
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ASTWithElement.h>
 #include <Processors/Executors/PullingAsyncPipelineExecutor.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Common/FieldVisitorToString.h>
 #include <Common/ProfileEvents.h>
 
@@ -211,11 +212,17 @@ void ExecuteScalarSubqueriesMatcher::visit(const ASTSubquery & subquery, ASTPtr 
         {
             auto io = interpreter->execute();
 
+#ifdef CHDB_WASM_SINGLE_THREADED
+            PullingPipelineExecutor executor(io.pipeline);
+#else
             PullingAsyncPipelineExecutor executor(io.pipeline);
+#endif
             io.pipeline.setProgressCallback(data.getContext()->getProgressCallback());
             io.pipeline.setConcurrencyControl(data.getContext()->getSettingsRef()[Setting::use_concurrency_control]);
+#ifndef CHDB_WASM_SINGLE_THREADED
             if (auto cancel_cb = data.getContext()->hasQueryContext() ? data.getContext()->getQueryContext()->getInteractiveCancelCallback() : nullptr)
                 executor.setCancelCallback(std::move(cancel_cb), std::max(UInt64(100), data.getContext()->getSettingsRef()[Setting::interactive_delay] / 1000));
+#endif
 
             while (block.rows() == 0 && executor.pull(block))
             {


### PR DESCRIPTION
The single-threaded (st) WASM build has no thread pool, so evaluating a scalar subquery via `PullingAsyncPipelineExecutor` — which offloads the sub-pipeline to a pool thread — throws `CANNOT_SCHEDULE_TASK`. 

Under `CHDB_WASM_SINGLE_THREADED`, run scalar subqueries on the synchronous `PullingPipelineExecutor` instead, and skip the async-only `setCancelCallback`. Guarded by the macro so the multi-threaded build is byte-for-byte unchanged.

Covers the new-analyzer path `Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp` and the legacy `Interpreters/ExecuteScalarSubqueriesVisitor.cpp`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes an error where an exception is thrown in an attempt to evaluate a scalar subquery on the single-threaded WASM build


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run scalar subqueries synchronously on the single-threaded WASM build
> The WASM single-threaded build cannot use async pipeline executors, causing scalar subqueries to fail. In both [`evaluateScalarSubqueryIfNeeded.cpp`](https://github.com/chdb-io/chdb-core/pull/101/files#diff-ab15640a059466fecd4f15f98dc79d85dc88de87a6a8f38ab5835d92739ee526) and [`ExecuteScalarSubqueriesVisitor.cpp`](https://github.com/chdb-io/chdb-core/pull/101/files#diff-5cd2fc2a468b867ad5aa126751a0f2ab7ed87dc320ca6a02e43098c4445b0bb8), executor construction is now conditional: `PullingPipelineExecutor` is used when `CHDB_WASM_SINGLE_THREADED` is defined, otherwise `PullingAsyncPipelineExecutor` is used. The interactive cancel callback is also skipped in single-threaded builds. A WASM matrix test asserting `SELECT (SELECT count() FROM numbers(10))` returns `10` is added to cover this path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19144f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->