### PR TITLE
Temporarily disable PyPI publishing of chdb-core-lite

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -699,14 +699,15 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
-        run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          eval "$(pyenv init -)"
-          pyenv shell 3.9
-          python -m twine upload dist/chdb_core_lite-*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.
+      # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.
+      # - name: Upload chdb-core-lite to pypi
+      #   if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+      #   run: |
+      #     export PATH="$HOME/.pyenv/bin:$PATH"
+      #     eval "$(pyenv init -)"
+      #     pyenv shell 3.9
+      #     python -m twine upload dist/chdb_core_lite-*.whl
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -681,14 +681,15 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
-        run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          eval "$(pyenv init -)"
-          pyenv shell 3.9
-          python -m twine upload dist/chdb_core_lite-*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.
+      # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.
+      # - name: Upload chdb-core-lite to pypi
+      #   if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+      #   run: |
+      #     export PATH="$HOME/.pyenv/bin:$PATH"
+      #     eval "$(pyenv init -)"
+      #     pyenv shell 3.9
+      #     python -m twine upload dist/chdb_core_lite-*.whl
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -677,14 +677,15 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
-        run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          eval "$(pyenv init -)"
-          pyenv shell 3.9
-          python -m twine upload dist/chdb_core_lite-*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.
+      # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.
+      # - name: Upload chdb-core-lite to pypi
+      #   if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+      #   run: |
+      #     export PATH="$HOME/.pyenv/bin:$PATH"
+      #     eval "$(pyenv init -)"
+      #     pyenv shell 3.9
+      #     python -m twine upload dist/chdb_core_lite-*.whl
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -677,14 +677,15 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      - name: Upload chdb-core-lite to pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
-        run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          eval "$(pyenv init -)"
-          pyenv shell 3.9
-          python -m twine upload dist/chdb_core_lite-*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.
+      # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.
+      # - name: Upload chdb-core-lite to pypi
+      #   if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+      #   run: |
+      #     export PATH="$HOME/.pyenv/bin:$PATH"
+      #     eval "$(pyenv init -)"
+      #     pyenv shell 3.9
+      #     python -m twine upload dist/chdb_core_lite-*.whl
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # # Free-threading wheels live in .github/workflows/build_ft_wheels.yml.


### PR DESCRIPTION
Comments out the PyPI upload steps for **chdb-core-lite** in all four platform wheel workflows, so a release publishes only the main `chdb_core` package to PyPI.

Everything else is unchanged:
- lite wheels are still built and tested on every PR / release,
- CI artifacts still include the lite wheels,
- GitHub Release asset uploads are untouched.

The steps are kept in place as comments (with a NOTE line) so re-enabling is a one-line uncomment per workflow.

The free-threading wheels part originally in this PR has been split into #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable PyPI publishing of `chdb-core-lite` across all build workflows
> Comments out the 'Upload chdb-core-lite to pypi' step in all four wheel-building workflows (Linux ARM64, Linux x86, macOS ARM64, macOS x86). Tag builds that are not release candidates will no longer publish `chdb_core_lite-*.whl` to PyPI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88a377a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->