### PR TITLE
Disable chdb-wasm distribution on tags (npm + GitHub Release asset)

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,7 +1,8 @@
-# Build chdb for WebAssembly (Emscripten), run the Node + headless-Chrome tests,
-# and — only on a v* tag — publish the `chdb-wasm` npm package. The publish steps
-# live in the same job, after the tests, so a tag that fails any test never
-# publishes; the tag name (vX.Y.Z) becomes the npm version.
+# Build chdb for WebAssembly (Emscripten) and run the Node + headless-Chrome
+# tests. The tag-time distribution steps (npm publish + GitHub Release asset)
+# are currently DISABLED (`if: false` below) — chdb-wasm is not distributed on
+# tags for now; the per-run CI artifact remains available. To re-enable, restore
+# the original condition noted on each step.
 #
 # Runs on every push to main, pull request, manual dispatch, and v* tags. One
 # Linux x86_64 (self-hosted) runner is enough: the .wasm is host-independent.
@@ -161,7 +162,9 @@ jobs:
       # and headless-Chrome tests) ran first, so a tag that fails tests never ships.
       # dist/ is already built by the npm step above; the version is taken from the tag. ----
       - name: Set npm version from tag
-        if: startsWith(github.ref, 'refs/tags/v')
+        # was: startsWith(github.ref, 'refs/tags/v') — disabled: chdb-wasm is not
+        # distributed on tags (neither npm nor GitHub Release asset) for now.
+        if: false
         working-directory: packages/chdb-wasm
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
@@ -169,7 +172,9 @@ jobs:
           npm pkg set version="$VERSION"
 
       - name: Publish to npm
-        if: startsWith(github.ref, 'refs/tags/v')
+        # was: startsWith(github.ref, 'refs/tags/v') — disabled: chdb-wasm is not
+        # distributed on tags (neither npm nor GitHub Release asset) for now.
+        if: false
         working-directory: packages/chdb-wasm
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
@@ -192,7 +197,9 @@ jobs:
       # both wasm bundles) to the GitHub release, creating the release if the tag has none
       # yet. continue-on-error — the npm publish above is the real deliverable.
       - name: Attach the npm tarball to the GitHub release
-        if: startsWith(github.ref, 'refs/tags/v')
+        # was: startsWith(github.ref, 'refs/tags/v') — disabled: chdb-wasm is not
+        # distributed on tags (neither npm nor GitHub Release asset) for now.
+        if: false
         continue-on-error: true
         run: |
           gh release upload "${GITHUB_REF_NAME}" "${CHDB_TGZ}" --clobber \


### PR DESCRIPTION
chdb-wasm is no longer distributed on `v*` tags at all — stable and `rc` alike. The three tag-time steps (version-from-tag, `npm publish`, attach-tarball-to-GitHub-Release) are gated with `if: false`; the original `startsWith(github.ref, 'refs/tags/v')` condition is noted on each step and the step bodies are untouched, so re-enabling is a one-line change per step.

What still happens:
- full wasm build + Node/headless-Chrome tests on every PR / push / tag (unchanged),
- the per-run `chdb-wasm` CI artifact (7-day retention) is unchanged.

Note: gating with `if: false` (rather than deleting the `if:` line) is deliberate — a step without an `if` runs unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable npm publish and GitHub Release asset upload for chdb-wasm on tags
> Sets `if: false` on the 'Set npm version from tag', 'Publish to npm', and 'Attach the npm tarball to the GitHub release' steps in [wasm.yml](.github/workflows/wasm.yml), replacing the previous `startsWith(github.ref, 'refs/tags/v')` condition. Build artifacts are still produced as CI outputs but are no longer distributed on tag pushes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 055bc67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->