### PR TITLE
Fix silently-missing linux-x86_64 debuginfo release asset (2 GiB limit)

### DIFF
--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -488,8 +488,11 @@ jobs:
       - name: Package debug symbols
         run: |
           ls *.debug
-          tar -czvf linux-x86_64-debuginfo.tar.gz *.debug
-          ls -lh linux-x86_64-debuginfo.tar.gz
+          # xz instead of gzip: the x86_64 debuginfo exceeds GitHub's 2 GiB
+          # release-asset limit as .tar.gz, so the upload step 422'd silently
+          # (masked by continue-on-error) and every release shipped without it.
+          XZ_OPT='-T0 -4' tar -cJvf linux-x86_64-debuginfo.tar.xz *.debug
+          ls -lh linux-x86_64-debuginfo.tar.xz
       # -----------------------------------------------------------------------
       # chdb-core-lite: build & test the slim variant of the wheel (~50 MB)
       # The slim variant goes through the same chdb/build.sh + make wheel path,
@@ -658,7 +661,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         continue-on-error: true
         run: |
-          gh release upload ${{ github.ref_name }} linux-x86_64-debuginfo.tar.gz --clobber
+          gh release upload ${{ github.ref_name }} linux-x86_64-debuginfo.tar.xz --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/upload-artifact@v4
@@ -668,7 +671,7 @@ jobs:
             ./dist/*.whl
             ./linux-x86_64-libchdb.tar.gz
             ./linux-x86_64-libchdb-static.tar.gz
-            ./linux-x86_64-debuginfo.tar.gz
+            ./linux-x86_64-debuginfo.tar.xz
           overwrite: true
       - name: Upload pypi
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')


### PR DESCRIPTION
The linux-x86_64 debug-symbol tarball is **~2.06 GiB as `.tar.gz`**, exceeding GitHub's **2 GiB release-asset limit** — the `gh release upload` step fails with HTTP 422 on every release, but `continue-on-error: true` masks it, so `v26.5.1-rc.1` and `v26.5.1-rc.2` both silently shipped **without** linux-x86_64 debug symbols (the other three platforms fit and upload fine).

Fix: package with multithreaded xz (`XZ_OPT='-T0 -4' tar -cJf`) instead of gzip — comfortably under the limit — and update the release/artifact references to `.tar.xz`. Other platforms are left as `.tar.gz` since they fit.

Verified against the real artifact: recompressing the rc.2 tarball with these exact options brings it well under 2 GiB (uploaded manually to the rc.2 release as `linux-x86_64-debuginfo.tar.xz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing linux-x86_64 debuginfo release asset by switching to xz compression
> The gzip-compressed debuginfo tarball exceeded GitHub's 2 GiB release asset limit, causing it to be silently dropped. The [build workflow](https://github.com/chdb-io/chdb-core/pull/104/files#diff-9d0bd289ed24cc0ae2c924282f7dd56b386d2c02b95ee8ad062596fc46f7f186) now packages debug symbols as `.tar.xz` using `XZ_OPT='-T0 -4'` (multi-threaded, level-4 compression) instead of `.tar.gz`. All references to the artifact path are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9059da6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->