### PR TITLE
Support DataLakeCatalog and Iceberg queries in the WASM build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -119,6 +119,63 @@ jobs:
           CHDB_WASM_MJS: ${{ github.workspace }}/buildwasm-st/programs/wasm/chdb.mjs
         run: node packages/chdb-wasm/test/matrix.test.mjs
 
+      # Data-lake tests are self-contained: pyiceberg writes real Iceberg tables
+      # into moto (a local in-process S3), and a ~60-line Node mock serves the
+      # Iceberg REST catalog endpoints — no external services. They only need a
+      # Python venv with the lakehouse packages (the tests skip without it).
+      - name: Set up data-lake test venv (pyiceberg + moto)
+        run: |
+          python3 -m venv "${GITHUB_WORKSPACE}/.iceberg-venv"
+          "${GITHUB_WORKSPACE}/.iceberg-venv/bin/pip" install -q "pyiceberg[sql-sqlite]" pyarrow "moto[server]" s3fs
+
+      # MinIO strictly verifies SigV4 signatures (moto does not), closing the
+      # signing loop. Downloaded once into the workspace; tests skip without it.
+      - name: Fetch MinIO
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.bin"
+          if [ ! -x "${GITHUB_WORKSPACE}/.bin/minio" ]; then
+            curl -fsSL -o "${GITHUB_WORKSPACE}/.bin/minio" https://dl.min.io/server/minio/release/linux-amd64/minio
+            chmod +x "${GITHUB_WORKSPACE}/.bin/minio"
+          fi
+
+      - name: Iceberg local table via MEMFS (mt + st)
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+        run: |
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/iceberg-local.test.mjs
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm-st/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/iceberg-local.test.mjs
+
+      - name: DataLakeCatalog + Iceberg-on-S3 (mt + st, moto)
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+        run: |
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake.test.mjs
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm-st/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake.test.mjs
+
+      - name: DataLakeCatalog + Iceberg-on-S3 (mt, MinIO — verified SigV4)
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+          MINIO_BIN: ${{ github.workspace }}/.bin/minio
+          CHDB_S3_BACKEND: minio
+          CHDB_WASM_MJS: ${{ github.workspace }}/buildwasm/programs/wasm/chdb.mjs
+        run: node packages/chdb-wasm/test/datalake.test.mjs
+
+      - name: Unity catalog + Delta Lake (mt + st)
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+        run: |
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake-unity.test.mjs
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm-st/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake-unity.test.mjs
+
+      # A REAL Iceberg REST catalog (apache/iceberg-rest-fixture in docker) +
+      # MinIO — validates against genuine catalog responses. Skips without docker.
+      - name: DataLakeCatalog against a real REST catalog (mt)
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+          MINIO_BIN: ${{ github.workspace }}/.bin/minio
+          CHDB_WASM_MJS: ${{ github.workspace }}/buildwasm/programs/wasm/chdb.mjs
+        run: node packages/chdb-wasm/test/datalake-real-catalog.test.mjs
+
       # puppeteer's bundled Chrome needs these system shared libraries (libatk,
       # libnss3, libgbm, ...); the self-hosted runner does not preinstall them.
       # Install per-package with `|| true` so Ubuntu 24.04's t64 ABI renames
@@ -150,6 +207,14 @@ jobs:
           npm run build
           ls -la dist/chdb.wasm dist/st/chdb.wasm
           node test/browser-run.mjs
+
+      # Same DataLakeCatalog flow inside a cross-origin-isolated Chrome page
+      # (exercises the sync-XHR transport branch; Node uses a different one).
+      - name: DataLakeCatalog headless-Chrome test
+        working-directory: packages/chdb-wasm
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+        run: node test/datalake-browser-run.mjs
 
       # Keep the artifact for download/inspection (kept short to save storage).
       - name: Upload wasm artifact

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Set up data-lake test venv (pyiceberg + moto)
         run: |
           python3 -m venv "${GITHUB_WORKSPACE}/.iceberg-venv"
-          "${GITHUB_WORKSPACE}/.iceberg-venv/bin/pip" install -q "pyiceberg[sql-sqlite]" pyarrow "moto[server]" s3fs
+          "${GITHUB_WORKSPACE}/.iceberg-venv/bin/pip" install -q "pyiceberg[sql-sqlite]" pyarrow "moto[server]" s3fs deltalake
 
       # MinIO strictly verifies SigV4 signatures (moto does not), closing the
       # signing loop. Downloaded once into the workspace; tests skip without it.
@@ -152,13 +152,14 @@ jobs:
           CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake.test.mjs
           CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm-st/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake.test.mjs
 
-      - name: DataLakeCatalog + Iceberg-on-S3 (mt, MinIO — verified SigV4)
+      - name: DataLakeCatalog + Iceberg-on-S3 (mt + st, MinIO — verified SigV4)
         env:
           ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
           MINIO_BIN: ${{ github.workspace }}/.bin/minio
           CHDB_S3_BACKEND: minio
-          CHDB_WASM_MJS: ${{ github.workspace }}/buildwasm/programs/wasm/chdb.mjs
-        run: node packages/chdb-wasm/test/datalake.test.mjs
+        run: |
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake.test.mjs
+          CHDB_WASM_MJS="${GITHUB_WORKSPACE}/buildwasm-st/programs/wasm/chdb.mjs" node packages/chdb-wasm/test/datalake.test.mjs
 
       - name: Unity catalog + Delta Lake (mt + st)
         env:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -125,6 +125,8 @@ jobs:
       # Python venv with the lakehouse packages (the tests skip without it).
       - name: Set up data-lake test venv (pyiceberg + moto)
         run: |
+          # The self-hosted image lacks ensurepip (Debian splits it out).
+          sudo apt-get install -y --no-install-recommends python3-venv
           python3 -m venv "${GITHUB_WORKSPACE}/.iceberg-venv"
           "${GITHUB_WORKSPACE}/.iceberg-venv/bin/pip" install -q "pyiceberg[sql-sqlite]" pyarrow "moto[server]" s3fs deltalake
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -38,6 +38,10 @@ env:
 
 jobs:
   build-and-test:
+    # Skip draft PRs — the 2h build/test cycle only runs once the PR is marked
+    # ready (`ready_for_review` is in the trigger types, so that transition
+    # starts a run). Pushes to main, tags and manual dispatch are unaffected.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     # Self-hosted Linux x86_64 runner (same pool as the native wheel builds). The
     # .wasm artifact is host-independent, so one platform is enough. No
     # free-disk-space step: that is for ephemeral GitHub-hosted images and would

--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -118,7 +118,10 @@ if (OS_WASM)
     # (native protoc bootstrap, networked object stores, heavy columnar formats).
     set (ENABLE_PROTOBUF OFF CACHE INTERNAL "")
     set (ENABLE_CAPNP OFF CACHE INTERNAL "")
-    set (ENABLE_AVRO OFF CACHE INTERNAL "")
+    # Avro ON: pure C++ (boost::iostreams + snappy, both already built for WASM).
+    # It is the gate for Iceberg/Paimon metadata reading and, together with
+    # Parquet, for the DataLakeCatalog database engine.
+    set (ENABLE_AVRO ON CACHE INTERNAL "")
     # Parquet READ via a slim Arrow build: Parquet + Thrift on, ORC off (ORC is the
     # only consumer of protobuf/protoc, which stay off) and Arrow's curl/HDFS object
     # store paths guarded out in contrib/arrow-cmake.

--- a/packages/chdb-wasm/package.json
+++ b/packages/chdb-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chdb-wasm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "chdb (ClickHouse) compiled to WebAssembly, with an async, non-blocking, worker-based API",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/chdb-wasm/test/datalake-browser-fixture.html
+++ b/packages/chdb-wasm/test/datalake-browser-fixture.html
@@ -1,0 +1,44 @@
+<!doctype html><meta charset=utf-8><title>chdb-wasm DataLakeCatalog browser fixture</title><pre id=o>running…</pre>
+<!-- Driven by test/datalake-browser-run.mjs. Creates ENGINE=DataLakeCatalog against
+     a mock Iceberg REST catalog (?catalog=port) and reads Iceberg-on-S3 data from a
+     CORS-proxied moto endpoint (?s3=port) — all through the sync-XHR bridge on wasm
+     pthreads. Publishes results on window.__RESULT__ for the driver to assert. -->
+<script type="module">
+import { AsyncChdb, selectBundle } from '../dist/index.js';
+const el = document.getElementById('o');
+const log = (m) => { el.textContent += '\n' + m; console.log(m); };
+const params = new URLSearchParams(location.search);
+const catalogPort = params.get('catalog');
+const s3Port = params.get('s3');
+(async () => {
+  const out = { ok: false };
+  try {
+    const b = selectBundle({ baseUrl: new URL('../dist', import.meta.url).href });
+    out.variant = b.variant;
+    out.coi = self.crossOriginIsolated;
+    log('coi=' + self.crossOriginIsolated + ' -> variant=' + b.variant);
+    const db = await AsyncChdb.create({ moduleUrl: b.moduleUrl, wasmUrl: b.wasmUrl });
+    const conn = await db.connect();
+    const Q = async (sql, fmt) => (await conn.query(sql, fmt || 'TabSeparated')).text().trim();
+    await Q('SET allow_experimental_database_iceberg = 1');
+    await Q(`
+      CREATE DATABASE lake
+      ENGINE = DataLakeCatalog('http://127.0.0.1:${catalogPort}/v1', 'testing', 'testing')
+      SETTINGS catalog_type = 'rest', warehouse = 'warehouse',
+               storage_endpoint = 'http://127.0.0.1:${s3Port}', vended_credentials = false`);
+    out.tables = await Q('SHOW TABLES FROM lake');
+    log('tables: ' + out.tables);
+    out.schema = await Q('DESCRIBE lake.`lakehouse.events`', 'CSV');
+    out.rows = await Q('SELECT id, name, score FROM lake.`lakehouse.events` ORDER BY id', 'CSV');
+    log('rows: ' + out.rows);
+    out.agg = await Q('SELECT count(), sum(id), round(avg(score), 2) FROM lake.`lakehouse.events`');
+    await Q('DROP DATABASE lake');
+    out.ok = true;
+    log('done');
+  } catch (e) {
+    out.fatal = String((e && e.message) || e);
+    log('FATAL: ' + out.fatal);
+  }
+  window.__RESULT__ = out;
+})();
+</script>

--- a/packages/chdb-wasm/test/datalake-browser-run.mjs
+++ b/packages/chdb-wasm/test/datalake-browser-run.mjs
@@ -48,7 +48,19 @@ function startPageServer(port) {
       res.end(await readFile(join(pkgDir, rel)));
     } catch { res.statusCode = 404; res.end('not found'); }
   });
-  return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+  return listenOrReject(server, port);
+}
+
+// Reject on listen errors (e.g. EADDRINUSE from a leaked process) so the callers'
+// try/finally cleanup runs instead of the process dying on an unhandled 'error'.
+function listenOrReject(server, port) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve(server);
+    });
+  });
 }
 
 // moto speaks no CORS; the page (COEP + cross-origin XHR with Authorization/Range
@@ -95,20 +107,36 @@ function startCorsProxy(port, upstream) {
         res.setHeader('Content-Length', body.length);
       res.end(body);
     } catch (e) {
+      // Log server-side (the page can't read a CORS-blocked body) and keep the
+      // CORS headers so the browser reports 502 instead of an opaque status 0.
+      console.error(`cors-proxy: ${req.method} ${req.url} -> ${e}`);
+      setCors();
       res.statusCode = 502;
       res.end(String(e));
     }
   });
-  return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+  return listenOrReject(server, port);
 }
 
 // --- 1. moto + table fixture ---
 const moto = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
+// Drain stderr: werkzeug logs every S3 request there, and an unread 64KB pipe
+// eventually blocks moto entirely; it's also the only diagnostics on failure.
+let motoStderr = '';
+moto.stderr.on('data', (d) => { motoStderr += d; });
 const deadline = Date.now() + 30000;
 for (;;) {
+  if (moto.exitCode !== null) {
+    console.error('moto exited early:\n' + motoStderr);
+    process.exit(1);
+  }
   try { await fetch(`http://127.0.0.1:${S3_PORT}`); break; }
   catch {
-    if (Date.now() > deadline) { console.error('moto did not come up'); process.exit(1); }
+    if (Date.now() > deadline) {
+      console.error('moto did not come up:\n' + motoStderr);
+      moto.kill('SIGKILL');
+      process.exit(1);
+    }
     await new Promise((r) => setTimeout(r, 200));
   }
 }
@@ -140,7 +168,10 @@ try {
   assert.ok(r.ok, `fixture not ok: ${r.fatal || '?'}`);
   assert.strictEqual(r.coi, true, 'page must be cross-origin isolated');
   assert.strictEqual(r.variant, 'mt', 'DataLakeCatalog needs the threaded bundle');
-  assert.strictEqual(r.tables, 'lakehouse.events', `SHOW TABLES: ${r.tables}`);
+  assert.strictEqual(
+    r.tables.split('\n').sort().join(','),
+    'lakehouse.city_events,lakehouse.deleted_events,lakehouse.events',
+    `SHOW TABLES: ${r.tables}`);
   assert.ok(r.schema.includes('"id","Nullable(Int64)"'), `schema: ${r.schema}`);
   assert.strictEqual(
     r.rows,

--- a/packages/chdb-wasm/test/datalake-browser-run.mjs
+++ b/packages/chdb-wasm/test/datalake-browser-run.mjs
@@ -1,0 +1,157 @@
+// Headless-Chrome end-to-end DataLakeCatalog test (the browser counterpart of
+// datalake.test.mjs): moto serves local S3 behind a CORS proxy, pyiceberg writes
+// a real Iceberg table into it, a mock Iceberg REST catalog serves the table, and
+// a cross-origin-isolated page (mt bundle) creates ENGINE=DataLakeCatalog and
+// reads the data — every HTTP request is a synchronous XHR on a wasm pthread.
+//
+// Requires a built dist/ (npm run build) and the pyiceberg venv (ICEBERG_PY,
+// default /tmp/iceberg-venv); skips cleanly when the venv is absent.
+//   node test/datalake-browser-run.mjs
+
+import { createServer } from 'node:http';
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert';
+import puppeteer from 'puppeteer';
+import { startMockCatalog } from './datalake/mock-rest-catalog.mjs';
+
+const pkgDir = process.env.CHDB_PKG_DIR || dirname(dirname(fileURLToPath(import.meta.url)));
+const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
+const FIXTURE = join(pkgDir, 'test/datalake/make_iceberg_table.py');
+
+const PAGE_PORT = 8141;
+const S3_PORT = 8142; // moto itself (no CORS)
+const S3_CORS_PORT = 8143; // CORS proxy in front of moto — what the page talks to
+const CATALOG_PORT = 8144;
+const BUCKET = 'lakebucket';
+
+if (!existsSync(PY)) {
+  console.log(`SKIP datalake-browser-run: no pyiceberg venv at ${PY} (set ICEBERG_PY)`);
+  process.exit(0);
+}
+
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm', '.json': 'application/json' };
+
+// Cross-origin-isolated static server for the package (COOP/COEP -> mt bundle).
+function startPageServer(port) {
+  const server = createServer(async (req, res) => {
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    try {
+      const p = decodeURIComponent((req.url || '/').split('?')[0]);
+      const rel = normalize(p).replace(/^([/\\]|\.\.[/\\])+/, '');
+      res.setHeader('Content-Type', MIME[extname(join(pkgDir, rel))] || 'application/octet-stream');
+      res.end(await readFile(join(pkgDir, rel)));
+    } catch { res.statusCode = 404; res.end('not found'); }
+  });
+  return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+}
+
+// moto speaks no CORS; the page (COEP + cross-origin XHR with Authorization/Range
+// headers) needs full CORS including preflight, so front it with a tiny proxy.
+function startCorsProxy(port, upstream) {
+  const server = createServer(async (req, res) => {
+    const setCors = () => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, PUT, POST, DELETE, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] || '*');
+      res.setHeader('Access-Control-Expose-Headers', '*');
+      res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    };
+    if (req.method === 'OPTIONS') {
+      setCors();
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+    try {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const headers = { ...req.headers };
+      delete headers.host;
+      delete headers.connection;
+      const upstreamRes = await fetch(`${upstream}${req.url}`, {
+        method: req.method,
+        headers,
+        body: chunks.length ? Buffer.concat(chunks) : undefined,
+        redirect: 'manual',
+      });
+      setCors();
+      for (const [k, v] of upstreamRes.headers) {
+        if (k === 'transfer-encoding' || k === 'content-encoding' || k === 'content-length') continue;
+        res.setHeader(k, v);
+      }
+      const body = Buffer.from(await upstreamRes.arrayBuffer());
+      res.statusCode = upstreamRes.status;
+      // A HEAD response has no body; the upstream Content-Length is the object
+      // size and must pass through (readers size their range requests off it).
+      if (req.method === 'HEAD')
+        res.setHeader('Content-Length', upstreamRes.headers.get('content-length') ?? '0');
+      else
+        res.setHeader('Content-Length', body.length);
+      res.end(body);
+    } catch (e) {
+      res.statusCode = 502;
+      res.end(String(e));
+    }
+  });
+  return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+}
+
+// --- 1. moto + table fixture ---
+const moto = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
+const deadline = Date.now() + 30000;
+for (;;) {
+  try { await fetch(`http://127.0.0.1:${S3_PORT}`); break; }
+  catch {
+    if (Date.now() > deadline) { console.error('moto did not come up'); process.exit(1); }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+
+let pageServer, corsProxy, mockCatalog, browser;
+try {
+  assert.ok((await fetch(`http://127.0.0.1:${S3_PORT}/${BUCKET}`, { method: 'PUT' })).ok, 'create bucket');
+  const descriptor = JSON.parse(
+    execFileSync(PY, [FIXTURE, `http://127.0.0.1:${S3_PORT}`, BUCKET], { encoding: 'utf8' }).trim());
+
+  // --- 2. servers ---
+  mockCatalog = await startMockCatalog({ port: CATALOG_PORT, descriptor });
+  corsProxy = await startCorsProxy(S3_CORS_PORT, `http://127.0.0.1:${S3_PORT}`);
+  pageServer = await startPageServer(PAGE_PORT);
+
+  // --- 3. drive the page ---
+  browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-gpu'] });
+  const page = await browser.newPage();
+  page.on('pageerror', (e) => console.error(`pageerror: ${e.message}`));
+  page.on('console', (m) => console.error(`[page:${m.type()}] ${m.text()}`));
+  await page.goto(
+    `http://localhost:${PAGE_PORT}/test/datalake-browser-fixture.html?catalog=${CATALOG_PORT}&s3=${S3_CORS_PORT}`,
+    { waitUntil: 'load', timeout: 30000 });
+  const r = await page
+    .waitForFunction('window.__RESULT__ !== undefined', { timeout: 180000, polling: 300 })
+    .then(() => page.evaluate('window.__RESULT__'));
+  console.log(JSON.stringify(r));
+
+  assert.ok(r.ok, `fixture not ok: ${r.fatal || '?'}`);
+  assert.strictEqual(r.coi, true, 'page must be cross-origin isolated');
+  assert.strictEqual(r.variant, 'mt', 'DataLakeCatalog needs the threaded bundle');
+  assert.strictEqual(r.tables, 'lakehouse.events', `SHOW TABLES: ${r.tables}`);
+  assert.ok(r.schema.includes('"id","Nullable(Int64)"'), `schema: ${r.schema}`);
+  assert.strictEqual(
+    r.rows,
+    ['1,"alpha",1.5', '2,"beta",2.5', '3,"gamma",3.5', '4,"delta",4.5', '5,"epsilon",5.5', '6,"zeta",6.5', '7,"eta",7.5'].join('\n'),
+    `rows: ${r.rows}`);
+  assert.strictEqual(r.agg, '7\t28\t4.5', `agg: ${r.agg}`);
+  console.log('PASS datalake-browser-run (DataLakeCatalog via sync XHR in headless Chrome)');
+} finally {
+  if (browser) await browser.close();
+  if (pageServer) pageServer.close();
+  if (corsProxy) corsProxy.close();
+  if (mockCatalog) mockCatalog.close();
+  moto.kill('SIGKILL');
+}

--- a/packages/chdb-wasm/test/datalake-real-catalog.test.mjs
+++ b/packages/chdb-wasm/test/datalake-real-catalog.test.mjs
@@ -1,0 +1,125 @@
+// DataLakeCatalog against a REAL Iceberg REST catalog service (no mock):
+// apache/iceberg-rest-fixture (the Apache Iceberg project's official test
+// catalog, used by pyiceberg's own CI) in docker, MinIO as S3 (verifies SigV4),
+// pyiceberg writing through the REST protocol, chdb-wasm reading through it.
+// This closes the mock's fidelity gap: real LoadTableResult shapes, real
+// namespace listing, real pagination behavior.
+//
+// Requires docker + minio + the pyiceberg venv; skips cleanly without them.
+//   node packages/chdb-wasm/test/datalake-real-catalog.test.mjs
+
+import assert from 'node:assert';
+import { spawn, execFileSync, execSync } from 'node:child_process';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AsyncChdb } from '../src/index.ts';
+
+const MODULE =
+  process.env.CHDB_WASM_MJS ||
+  fileURLToPath(new URL('../../../buildwasm/programs/wasm/chdb.mjs', import.meta.url));
+const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
+const FIXTURE = fileURLToPath(new URL('./datalake/make_iceberg_rest_table.py', import.meta.url));
+const MINIO_BIN = process.env.MINIO_BIN || 'minio';
+const CATALOG_IMAGE = process.env.ICEBERG_REST_IMAGE || 'apache/iceberg-rest-fixture:latest';
+
+const S3_PORT = 15976;
+// The fixture image listens on a fixed port (its REST_PORT env is ignored).
+const CATALOG_PORT = 8181;
+const S3_ENDPOINT = `http://127.0.0.1:${S3_PORT}`;
+const CATALOG_URI = `http://127.0.0.1:${CATALOG_PORT}`;
+const BUCKET = 'realcatalog';
+const KEY = 'minioadmin';
+const SECRET = 'minioadmin';
+
+if (!existsSync(PY)) {
+  console.log(`SKIP datalake-real-catalog: no pyiceberg venv at ${PY}`);
+  process.exit(0);
+}
+for (const [cmd, args] of [['docker', ['info']], [MINIO_BIN, ['--version']]]) {
+  try { execFileSync(cmd, args, { stdio: 'ignore' }); }
+  catch { console.log(`SKIP datalake-real-catalog: ${cmd} unavailable`); process.exit(0); }
+}
+
+const CONTAINER = `chdb-iceberg-rest-${process.pid}`;
+
+// --- 1. MinIO ---
+const dataDir = mkdtempSync(join(tmpdir(), 'minio-real-'));
+const minio = spawn(MINIO_BIN, ['server', dataDir, '--address', `127.0.0.1:${S3_PORT}`, '--console-address', '127.0.0.1:0'], {
+  stdio: ['ignore', 'ignore', 'pipe'],
+  env: { ...process.env, MINIO_ROOT_USER: KEY, MINIO_ROOT_PASSWORD: SECRET },
+});
+let minioStderr = '';
+minio.stderr.on('data', (d) => { minioStderr += d; });
+
+const waitHttp = async (url, what, timeoutMs = 60000) => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try { await fetch(url); return; }
+    catch {
+      if (Date.now() > deadline) throw new Error(`${what} did not come up`);
+      await new Promise((r) => setTimeout(r, 300));
+    }
+  }
+};
+
+let db;
+let catalogStarted = false;
+try {
+  await waitHttp(S3_ENDPOINT, 'minio');
+  execFileSync(PY, ['-c', `
+import boto3
+boto3.client("s3", endpoint_url="${S3_ENDPOINT}", aws_access_key_id="${KEY}",
+             aws_secret_access_key="${SECRET}", region_name="us-east-1").create_bucket(Bucket="${BUCKET}")
+`]);
+
+  // --- 2. the real REST catalog (docker, host network so it reaches MinIO) ---
+  execSync(
+    `docker run -d --rm --name ${CONTAINER} --network host ` +
+    `-e CATALOG_WAREHOUSE=s3://${BUCKET}/warehouse ` +
+    `-e CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO ` +
+    `-e CATALOG_S3_ENDPOINT=${S3_ENDPOINT} ` +
+    `-e CATALOG_S3_PATH__STYLE__ACCESS=true ` +
+    `-e AWS_ACCESS_KEY_ID=${KEY} -e AWS_SECRET_ACCESS_KEY=${SECRET} -e AWS_REGION=us-east-1 ` +
+    CATALOG_IMAGE,
+    { stdio: ['ignore', 'ignore', 'inherit'] });
+  catalogStarted = true;
+  await waitHttp(`${CATALOG_URI}/v1/config`, 'iceberg-rest-fixture', 90000);
+
+  // --- 3. pyiceberg writes THROUGH the REST catalog ---
+  const descriptor = JSON.parse(
+    execFileSync(PY, [FIXTURE, CATALOG_URI, S3_ENDPOINT, KEY, SECRET], { encoding: 'utf8' }).trim());
+  assert.strictEqual(descriptor.table, 'readings');
+
+  // --- 4. chdb-wasm against the real catalog ---
+  db = await AsyncChdb.create({ moduleUrl: MODULE });
+  const conn = await db.connect();
+  const q = async (sql, fmt = 'TabSeparated') => (await conn.query(sql, fmt)).text().trim();
+
+  await q('SET allow_experimental_database_iceberg = 1');
+  await q(`
+    CREATE DATABASE real
+    ENGINE = DataLakeCatalog('${CATALOG_URI}/v1', '${KEY}', '${SECRET}')
+    SETTINGS catalog_type = 'rest', warehouse = 's3://${BUCKET}/warehouse',
+             storage_endpoint = '${S3_ENDPOINT}', vended_credentials = false`);
+
+  const tables = await q('SHOW TABLES FROM real');
+  assert.strictEqual(tables, 'smoke.readings', `SHOW TABLES: ${tables}`);
+  console.log('ok: SHOW TABLES via the real REST catalog');
+
+  const rows = await q('SELECT sensor, value FROM real.`smoke.readings` ORDER BY value', 'CSV');
+  assert.strictEqual(rows, ['"a",10', '"b",20', '"a",30', '"c",40', '"b",50'].join('\n'), `rows: ${rows}`);
+  console.log('ok: SELECT (5 rows, 2 snapshots, MinIO-verified SigV4)');
+
+  const agg = await q("SELECT sensor, sum(value) FROM real.`smoke.readings` GROUP BY sensor ORDER BY sensor", 'CSV');
+  assert.strictEqual(agg, ['"a",40', '"b",70', '"c",40'].join('\n'), `agg: ${agg}`);
+  console.log('ok: aggregation');
+
+  await q('DROP DATABASE real');
+  console.log('PASS datalake-real-catalog.test (apache/iceberg-rest-fixture + MinIO)');
+} finally {
+  if (db) await db.terminate().catch(() => {});
+  if (catalogStarted) { try { execSync(`docker stop ${CONTAINER}`, { stdio: 'ignore' }); } catch {} }
+  minio.kill('SIGKILL');
+}

--- a/packages/chdb-wasm/test/datalake-unity.test.mjs
+++ b/packages/chdb-wasm/test/datalake-unity.test.mjs
@@ -1,0 +1,102 @@
+// End-to-end Unity-catalog + Delta Lake test for the chdb-wasm package, headless
+// under Node. delta-rs writes a real Delta table (Parquet + _delta_log JSON, two
+// commits) into moto; a mock Unity catalog serves it; chdb-wasm reads it through
+// ENGINE=DataLakeCatalog with catalog_type='unity' — exercising the legacy C++
+// DeltaLakeMetadata path (log replay via signed exists()/range reads, no rust
+// delta-kernel on wasm).
+//
+// Needs the pyiceberg venv with `deltalake` installed (ICEBERG_PY); skips cleanly
+// if absent.
+//   CHDB_WASM_MJS=/abs/path/to/chdb.mjs node packages/chdb-wasm/test/datalake-unity.test.mjs
+
+import assert from 'node:assert';
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { AsyncChdb } from '../src/index.ts';
+import { startMockUnityCatalog } from './datalake/mock-unity-catalog.mjs';
+
+const MODULE =
+  process.env.CHDB_WASM_MJS ||
+  fileURLToPath(new URL('../../../buildwasm/programs/wasm/chdb.mjs', import.meta.url));
+const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
+const FIXTURE = fileURLToPath(new URL('./datalake/make_delta_table.py', import.meta.url));
+
+const S3_PORT = 15972;
+const CATALOG_PORT = 15973;
+const S3_ENDPOINT = `http://127.0.0.1:${S3_PORT}`;
+const BUCKET = 'deltabucket';
+
+if (!existsSync(PY)) {
+  console.log(`SKIP datalake-unity.test: no venv at ${PY} (set ICEBERG_PY)`);
+  process.exit(0);
+}
+try {
+  execFileSync(PY, ['-c', 'import deltalake'], { stdio: 'ignore' });
+} catch {
+  console.log('SKIP datalake-unity.test: deltalake not installed in the venv');
+  process.exit(0);
+}
+
+const moto = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
+let motoStderr = '';
+moto.stderr.on('data', (d) => { motoStderr += d; });
+const deadline = Date.now() + 30000;
+for (;;) {
+  if (moto.exitCode !== null) {
+    console.error('moto exited early:\n' + motoStderr);
+    process.exit(1);
+  }
+  try { await fetch(S3_ENDPOINT); break; }
+  catch {
+    if (Date.now() > deadline) {
+      console.error('moto did not come up:\n' + motoStderr);
+      moto.kill('SIGKILL');
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+
+let mockServer;
+let db;
+try {
+  assert.ok((await fetch(`${S3_ENDPOINT}/${BUCKET}`, { method: 'PUT' })).ok, 'create bucket');
+  const descriptor = JSON.parse(execFileSync(PY, [FIXTURE, S3_ENDPOINT, BUCKET], { encoding: 'utf8' }).trim());
+
+  mockServer = await startMockUnityCatalog({ port: CATALOG_PORT, descriptor });
+
+  db = await AsyncChdb.create({ moduleUrl: MODULE });
+  const conn = await db.connect();
+  const q = async (sql, fmt = 'TabSeparated') => (await conn.query(sql, fmt)).text().trim();
+
+  await q('SET allow_experimental_database_unity_catalog = 1');
+  await q(`
+    CREATE DATABASE unity
+    ENGINE = DataLakeCatalog('http://127.0.0.1:${CATALOG_PORT}/api/2.1/unity-catalog', 'testing', 'testing')
+    SETTINGS catalog_type = 'unity', warehouse = 'unity',
+             storage_endpoint = '${S3_ENDPOINT}', vended_credentials = false`);
+
+  const tables = await q('SHOW TABLES FROM unity');
+  assert.strictEqual(tables, 'lakeschema.sales', `SHOW TABLES: ${tables}`);
+  console.log('ok: SHOW TABLES via Unity catalog');
+
+  // Two commits -> log replay over 00000000....json files (signed exists() probes).
+  const rows = await q('SELECT id, item, price FROM unity.`lakeschema.sales` ORDER BY id', 'CSV');
+  assert.strictEqual(
+    rows,
+    ['1,"book",10.5', '2,"pen",1.25', '3,"desk",99', '4,"lamp",25'].join('\n'),
+    `SELECT rows: ${rows}`);
+  console.log('ok: SELECT full scan (Delta, 2 commits)');
+
+  const agg = await q('SELECT count(), max(price) FROM unity.`lakeschema.sales`');
+  assert.strictEqual(agg, '4\t99', `aggregate: ${agg}`);
+  console.log('ok: aggregation');
+
+  await q('DROP DATABASE unity');
+  console.log('PASS datalake-unity.test (Unity catalog + Delta Lake legacy metadata via wasm web fetch)');
+} finally {
+  if (db) await db.terminate().catch(() => {});
+  if (mockServer) mockServer.close();
+  moto.kill('SIGKILL');
+}

--- a/packages/chdb-wasm/test/datalake-unity.test.mjs
+++ b/packages/chdb-wasm/test/datalake-unity.test.mjs
@@ -93,6 +93,12 @@ try {
   assert.strictEqual(agg, '4\t99', `aggregate: ${agg}`);
   console.log('ok: aggregation');
 
+  // Catalog-less direct read through the deltaLake() table function (legacy
+  // C++ log replay — no rust delta-kernel on wasm).
+  const tf = await q(`SELECT count(), max(price) FROM deltaLake('${S3_ENDPOINT}/${BUCKET}/unity/sales', 'testing', 'testing')`);
+  assert.strictEqual(tf, '4\t99', `deltaLake direct read: ${tf}`);
+  console.log('ok: deltaLake() direct read');
+
   await q('DROP DATABASE unity');
   console.log('PASS datalake-unity.test (Unity catalog + Delta Lake legacy metadata via wasm web fetch)');
 } finally {

--- a/packages/chdb-wasm/test/datalake.test.mjs
+++ b/packages/chdb-wasm/test/datalake.test.mjs
@@ -171,6 +171,16 @@ boto3.client("s3", endpoint_url="${S3_ENDPOINT}", aws_access_key_id="${KEY}",
 
   await q('DROP DATABASE lake');
 
+  // ==== catalog-less direct reads: icebergS3()/iceberg() table functions ====
+  // No catalog pins the metadata file, so the reader must DISCOVER the latest
+  // metadata version by listing the metadata/ prefix (ListObjectsV2 path).
+  const tfUrl = `${S3_ENDPOINT}/${BUCKET}/warehouse/lakehouse/events`;
+  const tf = await q(`SELECT count(), sum(id) FROM icebergS3('${tfUrl}', '${KEY}', '${SECRET}')`);
+  assert.strictEqual(tf, '7\t28', `icebergS3 direct read: ${tf}`);
+  const tfAlias = await q(`SELECT count() FROM iceberg('${tfUrl}', '${KEY}', '${SECRET}')`);
+  assert.strictEqual(tfAlias, '7', `iceberg alias: ${tfAlias}`);
+  console.log('ok: icebergS3()/iceberg() direct read (metadata discovery via ListObjectsV2)');
+
   // ==== OAuth + vended credentials + pagination (a second catalog instance) ====
   // A `broken` table (metadata-location pointing at a missing object) rides along
   // for the error-path assertions; with pageSize=2 the 4 tables need 2 pages and

--- a/packages/chdb-wasm/test/datalake.test.mjs
+++ b/packages/chdb-wasm/test/datalake.test.mjs
@@ -1,9 +1,19 @@
 // End-to-end DataLakeCatalog test for the chdb-wasm package, headless under Node.
 //
-// Pipeline: moto (local S3) <- pyiceberg writes a real Iceberg table (Parquet data,
-// Avro manifests, JSON metadata) <- mock Iceberg REST catalog serves the table ->
+// Pipeline: an S3 backend <- pyiceberg writes real Iceberg tables (Parquet data,
+// Avro manifests, JSON metadata) <- mock Iceberg REST catalog serves them ->
 // chdb-wasm creates ENGINE=DataLakeCatalog, lists tables through the catalog and
 // SELECTs the data over HTTP (SigV4-signed range reads through the JS bridge).
+//
+// Three tables cover the read paths: plain (2 snapshots), identity-partitioned
+// with partition values containing spaces (URL-encoding of object keys), and
+// delete-via-overwrite snapshots (pyiceberg cannot write positional deletes;
+// that path needs a Spark-written fixture and is a known coverage gap).
+//
+// S3 backend (CHDB_S3_BACKEND):
+//   moto  (default) — python in-process S3; fast, but does NOT verify SigV4
+//   minio           — real MinIO server (needs `minio` on PATH or MINIO_BIN);
+//                     STRICTLY verifies SigV4 signatures, closing the auth loop
 //
 // Requirements beyond the repo: a Python venv with pyiceberg + moto[server]
 // (default /tmp/iceberg-venv, override with ICEBERG_PY). Skips cleanly if absent.
@@ -12,7 +22,9 @@
 
 import assert from 'node:assert';
 import { spawn, execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { AsyncChdb } from '../src/index.ts';
 import { startMockCatalog } from './datalake/mock-rest-catalog.mjs';
@@ -23,28 +35,55 @@ const MODULE =
 const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
 const FIXTURE = fileURLToPath(new URL('./datalake/make_iceberg_table.py', import.meta.url));
 
+const BACKEND = process.env.CHDB_S3_BACKEND || 'moto';
+const MINIO_BIN = process.env.MINIO_BIN || 'minio';
+
 const S3_PORT = 15968;
 const CATALOG_PORT = 15969;
 const S3_ENDPOINT = `http://127.0.0.1:${S3_PORT}`;
 const BUCKET = 'lakebucket';
+// moto accepts any credentials; MinIO's defaults require >= 8-char secrets.
+const [KEY, SECRET] = BACKEND === 'minio' ? ['minioadmin', 'minioadmin'] : ['testing', 'testing'];
 
 if (!existsSync(PY)) {
   console.log(`SKIP datalake.test: no pyiceberg venv at ${PY} (set ICEBERG_PY)`);
   process.exit(0);
 }
 
-// --- 1. moto: local S3 ---
-const moto = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
-let motoStderr = '';
-moto.stderr.on('data', (d) => { motoStderr += d; });
+// --- 1. S3 backend ---
+let s3;
+if (BACKEND === 'minio') {
+  try {
+    execFileSync(MINIO_BIN, ['--version'], { stdio: 'ignore' });
+  } catch {
+    console.log(`SKIP datalake.test[minio]: no minio binary (set MINIO_BIN)`);
+    process.exit(0);
+  }
+  const dataDir = mkdtempSync(join(tmpdir(), 'minio-data-'));
+  s3 = spawn(MINIO_BIN, ['server', dataDir, '--address', `127.0.0.1:${S3_PORT}`, '--console-address', '127.0.0.1:0'], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: { ...process.env, MINIO_ROOT_USER: KEY, MINIO_ROOT_PASSWORD: SECRET },
+  });
+} else {
+  s3 = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
+}
+let s3Stderr = '';
+s3.stderr.on('data', (d) => { s3Stderr += d; });
 const deadline = Date.now() + 30000;
 for (;;) {
+  // A dead child means a squatter may own the port — the probe below would bind
+  // to it and silently test against stale state. Bail out instead.
+  if (s3.exitCode !== null) {
+    console.error(`${BACKEND} exited early:\n` + s3Stderr);
+    process.exit(1);
+  }
   try {
     await fetch(S3_ENDPOINT, { method: 'GET' });
     break;
   } catch {
     if (Date.now() > deadline) {
-      console.error('moto server did not come up:\n' + motoStderr);
+      console.error(`${BACKEND} server did not come up:\n` + s3Stderr);
+      s3.kill('SIGKILL');
       process.exit(1);
     }
     await new Promise((r) => setTimeout(r, 200));
@@ -54,12 +93,17 @@ for (;;) {
 let mockServer;
 let db;
 try {
-  const mkBucket = await fetch(`${S3_ENDPOINT}/${BUCKET}`, { method: 'PUT' });
-  assert.ok(mkBucket.ok, `create bucket failed: ${mkBucket.status}`);
+  // Create the bucket with a signed request (MinIO rejects anonymous PUTs).
+  execFileSync(PY, ['-c', `
+import boto3
+boto3.client("s3", endpoint_url="${S3_ENDPOINT}", aws_access_key_id="${KEY}",
+             aws_secret_access_key="${SECRET}", region_name="us-east-1").create_bucket(Bucket="${BUCKET}")
+`]);
 
-  // --- 2. pyiceberg: write a real Iceberg table into moto ---
-  const descriptor = JSON.parse(execFileSync(PY, [FIXTURE, S3_ENDPOINT, BUCKET], { encoding: 'utf8' }).trim());
-  assert.ok(descriptor.metadata_location.startsWith(`s3://${BUCKET}/`), `unexpected metadata location ${descriptor.metadata_location}`);
+  // --- 2. pyiceberg: write real Iceberg tables into the backend ---
+  const descriptor = JSON.parse(
+    execFileSync(PY, [FIXTURE, S3_ENDPOINT, BUCKET, KEY, SECRET], { encoding: 'utf8' }).trim());
+  assert.strictEqual(descriptor.tables.length, 3, 'fixture produced 3 tables');
 
   // --- 3. mock Iceberg REST catalog ---
   mockServer = await startMockCatalog({ port: CATALOG_PORT, descriptor });
@@ -72,13 +116,16 @@ try {
   await q('SET allow_experimental_database_iceberg = 1');
   await q(`
     CREATE DATABASE lake
-    ENGINE = DataLakeCatalog('http://127.0.0.1:${CATALOG_PORT}/v1', 'testing', 'testing')
+    ENGINE = DataLakeCatalog('http://127.0.0.1:${CATALOG_PORT}/v1', '${KEY}', '${SECRET}')
     SETTINGS catalog_type = 'rest', warehouse = 'warehouse',
              storage_endpoint = '${S3_ENDPOINT}', vended_credentials = false`);
 
   const tables = await q('SHOW TABLES FROM lake');
-  assert.strictEqual(tables, 'lakehouse.events', `SHOW TABLES: ${tables}`);
-  console.log('ok: SHOW TABLES via REST catalog');
+  assert.strictEqual(
+    tables.split('\n').sort().join(','),
+    'lakehouse.city_events,lakehouse.deleted_events,lakehouse.events',
+    `SHOW TABLES: ${tables}`);
+  console.log(`ok: SHOW TABLES via REST catalog (3 tables, backend=${BACKEND})`);
 
   const schema = await q('DESCRIBE lake.`lakehouse.events`', 'CSV');
   assert.ok(schema.includes('"id","Nullable(Int64)"'), `schema id: ${schema}`);
@@ -103,10 +150,27 @@ try {
   assert.strictEqual(filtered, '"zeta"\n"eta"', `filter: ${filtered}`);
   console.log('ok: filtered read');
 
+  // Partition values with spaces -> object keys like .../city=New York/... must be
+  // URL-encoded on the wire and stay consistent with the SigV4 canonical URI.
+  const cities = await q('SELECT id, city, amount FROM lake.`lakehouse.city_events` ORDER BY id', 'CSV');
+  assert.strictEqual(
+    cities,
+    ['1,"New York",10', '2,"San Francisco",20', '3,"New York",30', '4,"Los Angeles",40'].join('\n'),
+    `partitioned rows: ${cities}`);
+  const ny = await q(`SELECT count(), sum(amount) FROM lake.\`lakehouse.city_events\` WHERE city = 'New York'`);
+  assert.strictEqual(ny, '2\t40', `partition filter: ${ny}`);
+  console.log('ok: identity-partitioned table with spaces in partition values');
+
+  // Deleted rows (id=2, id=4) must be absent: the delete produced an overwrite
+  // snapshot whose manifests replace the original data file.
+  const mor = await q('SELECT id, v FROM lake.`lakehouse.deleted_events` ORDER BY id', 'CSV');
+  assert.strictEqual(mor, ['1,"a"', '3,"c"', '5,"e"'].join('\n'), `post-delete rows: ${mor}`);
+  console.log('ok: copy-on-write delete snapshot applied (deleted rows absent)');
+
   await q('DROP DATABASE lake');
-  console.log('PASS datalake.test (DataLakeCatalog REST + Iceberg-on-S3 via wasm web fetch)');
+  console.log(`PASS datalake.test (DataLakeCatalog REST + Iceberg-on-S3, backend=${BACKEND})`);
 } finally {
   if (db) await db.terminate().catch(() => {});
   if (mockServer) mockServer.close();
-  moto.kill('SIGKILL');
+  s3.kill('SIGKILL');
 }

--- a/packages/chdb-wasm/test/datalake.test.mjs
+++ b/packages/chdb-wasm/test/datalake.test.mjs
@@ -1,0 +1,112 @@
+// End-to-end DataLakeCatalog test for the chdb-wasm package, headless under Node.
+//
+// Pipeline: moto (local S3) <- pyiceberg writes a real Iceberg table (Parquet data,
+// Avro manifests, JSON metadata) <- mock Iceberg REST catalog serves the table ->
+// chdb-wasm creates ENGINE=DataLakeCatalog, lists tables through the catalog and
+// SELECTs the data over HTTP (SigV4-signed range reads through the JS bridge).
+//
+// Requirements beyond the repo: a Python venv with pyiceberg + moto[server]
+// (default /tmp/iceberg-venv, override with ICEBERG_PY). Skips cleanly if absent.
+//
+//   CHDB_WASM_MJS=/abs/path/to/chdb.mjs node packages/chdb-wasm/test/datalake.test.mjs
+
+import assert from 'node:assert';
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { AsyncChdb } from '../src/index.ts';
+import { startMockCatalog } from './datalake/mock-rest-catalog.mjs';
+
+const MODULE =
+  process.env.CHDB_WASM_MJS ||
+  fileURLToPath(new URL('../../../buildwasm/programs/wasm/chdb.mjs', import.meta.url));
+const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
+const FIXTURE = fileURLToPath(new URL('./datalake/make_iceberg_table.py', import.meta.url));
+
+const S3_PORT = 15968;
+const CATALOG_PORT = 15969;
+const S3_ENDPOINT = `http://127.0.0.1:${S3_PORT}`;
+const BUCKET = 'lakebucket';
+
+if (!existsSync(PY)) {
+  console.log(`SKIP datalake.test: no pyiceberg venv at ${PY} (set ICEBERG_PY)`);
+  process.exit(0);
+}
+
+// --- 1. moto: local S3 ---
+const moto = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
+let motoStderr = '';
+moto.stderr.on('data', (d) => { motoStderr += d; });
+const deadline = Date.now() + 30000;
+for (;;) {
+  try {
+    await fetch(S3_ENDPOINT, { method: 'GET' });
+    break;
+  } catch {
+    if (Date.now() > deadline) {
+      console.error('moto server did not come up:\n' + motoStderr);
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+
+let mockServer;
+let db;
+try {
+  const mkBucket = await fetch(`${S3_ENDPOINT}/${BUCKET}`, { method: 'PUT' });
+  assert.ok(mkBucket.ok, `create bucket failed: ${mkBucket.status}`);
+
+  // --- 2. pyiceberg: write a real Iceberg table into moto ---
+  const descriptor = JSON.parse(execFileSync(PY, [FIXTURE, S3_ENDPOINT, BUCKET], { encoding: 'utf8' }).trim());
+  assert.ok(descriptor.metadata_location.startsWith(`s3://${BUCKET}/`), `unexpected metadata location ${descriptor.metadata_location}`);
+
+  // --- 3. mock Iceberg REST catalog ---
+  mockServer = await startMockCatalog({ port: CATALOG_PORT, descriptor });
+
+  // --- 4. chdb-wasm through the catalog ---
+  db = await AsyncChdb.create({ moduleUrl: MODULE });
+  const conn = await db.connect();
+  const q = async (sql, fmt = 'TabSeparated') => (await conn.query(sql, fmt)).text().trim();
+
+  await q('SET allow_experimental_database_iceberg = 1');
+  await q(`
+    CREATE DATABASE lake
+    ENGINE = DataLakeCatalog('http://127.0.0.1:${CATALOG_PORT}/v1', 'testing', 'testing')
+    SETTINGS catalog_type = 'rest', warehouse = 'warehouse',
+             storage_endpoint = '${S3_ENDPOINT}', vended_credentials = false`);
+
+  const tables = await q('SHOW TABLES FROM lake');
+  assert.strictEqual(tables, 'lakehouse.events', `SHOW TABLES: ${tables}`);
+  console.log('ok: SHOW TABLES via REST catalog');
+
+  const schema = await q('DESCRIBE lake.`lakehouse.events`', 'CSV');
+  assert.ok(schema.includes('"id","Nullable(Int64)"'), `schema id: ${schema}`);
+  assert.ok(schema.includes('"name","Nullable(String)"'), `schema name: ${schema}`);
+  assert.ok(schema.includes('"score","Nullable(Float64)"'), `schema score: ${schema}`);
+  console.log('ok: DESCRIBE (schema from catalog)');
+
+  // Data written in two snapshots (5 + 2 rows) — exercises manifest-list + multiple
+  // manifests + multiple Parquet files, all fetched from S3 with SigV4 range reads.
+  const rows = await q('SELECT id, name, score FROM lake.`lakehouse.events` ORDER BY id', 'CSV');
+  assert.strictEqual(
+    rows,
+    ['1,"alpha",1.5', '2,"beta",2.5', '3,"gamma",3.5', '4,"delta",4.5', '5,"epsilon",5.5', '6,"zeta",6.5', '7,"eta",7.5'].join('\n'),
+    `SELECT rows: ${rows}`);
+  console.log('ok: SELECT full scan (7 rows, 2 snapshots)');
+
+  const agg = await q('SELECT count(), sum(id), round(avg(score), 2) FROM lake.`lakehouse.events`');
+  assert.strictEqual(agg, '7\t28\t4.5', `aggregate: ${agg}`);
+  console.log('ok: aggregation');
+
+  const filtered = await q("SELECT name FROM lake.`lakehouse.events` WHERE id > 5 ORDER BY id", 'CSV');
+  assert.strictEqual(filtered, '"zeta"\n"eta"', `filter: ${filtered}`);
+  console.log('ok: filtered read');
+
+  await q('DROP DATABASE lake');
+  console.log('PASS datalake.test (DataLakeCatalog REST + Iceberg-on-S3 via wasm web fetch)');
+} finally {
+  if (db) await db.terminate().catch(() => {});
+  if (mockServer) mockServer.close();
+  moto.kill('SIGKILL');
+}

--- a/packages/chdb-wasm/test/datalake.test.mjs
+++ b/packages/chdb-wasm/test/datalake.test.mjs
@@ -40,6 +40,7 @@ const MINIO_BIN = process.env.MINIO_BIN || 'minio';
 
 const S3_PORT = 15968;
 const CATALOG_PORT = 15969;
+const AUTH_CATALOG_PORT = 15971;
 const S3_ENDPOINT = `http://127.0.0.1:${S3_PORT}`;
 const BUCKET = 'lakebucket';
 // moto accepts any credentials; MinIO's defaults require >= 8-char secrets.
@@ -91,6 +92,7 @@ for (;;) {
 }
 
 let mockServer;
+let authServer;
 let db;
 try {
   // Create the bucket with a signed request (MinIO rejects anonymous PUTs).
@@ -168,9 +170,96 @@ boto3.client("s3", endpoint_url="${S3_ENDPOINT}", aws_access_key_id="${KEY}",
   console.log('ok: copy-on-write delete snapshot applied (deleted rows absent)');
 
   await q('DROP DATABASE lake');
+
+  // ==== OAuth + vended credentials + pagination (a second catalog instance) ====
+  // A `broken` table (metadata-location pointing at a missing object) rides along
+  // for the error-path assertions; with pageSize=2 the 4 tables need 2 pages and
+  // the extra empty namespace needs 2 namespace pages.
+  const brokenMeta = structuredClone(descriptor.tables.find((t) => t.name === 'events').metadata);
+  brokenMeta.location = `s3://${BUCKET}/warehouse/lakehouse/broken`;
+  const authDescriptor = {
+    namespace: descriptor.namespace,
+    tables: [
+      ...descriptor.tables,
+      {
+        name: 'broken',
+        metadata_location: `s3://${BUCKET}/warehouse/lakehouse/broken/metadata/00000-broken.metadata.json`,
+        metadata: brokenMeta,
+      },
+    ],
+  };
+  authServer = await startMockCatalog({
+    port: AUTH_CATALOG_PORT,
+    descriptor: authDescriptor,
+    auth: { clientId: 'chdb-client', clientSecret: 'chdb-secret', tokenMaxUses: 5 },
+    // NB: the vended s3.endpoint needs a trailing slash — getMetadataLocation's
+    // prefix-strip of the endpoint-based location fails without it (same in the
+    // native engine) and metadata paths would double up.
+    vend: { accessKey: KEY, secretKey: SECRET, endpoint: `${S3_ENDPOINT}/` },
+    pageSize: 2,
+    extraNamespaces: ['emptyns'],
+  });
+
+  // No storage_endpoint and no credentials in the DDL: both must arrive as
+  // vended credentials in LoadTableResult.config (s3.endpoint + key/secret).
+  await q(`
+    CREATE DATABASE lake2
+    ENGINE = DataLakeCatalog('http://127.0.0.1:${AUTH_CATALOG_PORT}/v1')
+    SETTINGS catalog_type = 'rest', warehouse = 'warehouse',
+             catalog_credential = 'chdb-client:chdb-secret'`);
+
+  const tables2 = await q('SHOW TABLES FROM lake2');
+  assert.strictEqual(
+    tables2.split('\n').sort().join(','),
+    'lakehouse.broken,lakehouse.city_events,lakehouse.deleted_events,lakehouse.events',
+    `SHOW TABLES (paginated): ${tables2}`);
+  assert.ok(authServer.stats.maxPageRequests >= 2, `pagination exercised: ${JSON.stringify(authServer.stats)}`);
+  console.log('ok: OAuth-protected catalog listing across pages (+ empty namespace)');
+
+  const rows2 = await q('SELECT count(), sum(id) FROM lake2.`lakehouse.events`');
+  assert.strictEqual(rows2, '7\t28', `vended-creds read: ${rows2}`);
+  assert.ok(authServer.stats.delegationHeaderSeen >= 1,
+    `X-Iceberg-Access-Delegation sent: ${JSON.stringify(authServer.stats)}`);
+  console.log(`ok: vended credentials (endpoint + keys from the catalog${BACKEND === 'minio' ? ', MinIO-verified' : ''})`);
+
+  // tokenMaxUses=5 guarantees mid-flight 401s: the client must fetch a fresh
+  // token and retry (RestCatalog's refresh-and-retry path).
+  assert.ok(authServer.stats.oauthTokensIssued >= 2,
+    `token refresh happened: ${JSON.stringify(authServer.stats)}`);
+  console.log(`ok: expired-token 401 -> refresh -> retry (${authServer.stats.oauthTokensIssued} tokens issued)`);
+
+  // ==== error paths ====
+  const errOf = async (sql) => { try { await q(sql); return ''; } catch (e) { return String(e.message || e); } };
+
+  const unknownErr = await errOf('SELECT * FROM lake2.`lakehouse.nope`');
+  assert.ok(/nope/.test(unknownErr) && /UNKNOWN_TABLE|doesn't exist|does not exist/i.test(unknownErr),
+    `unknown table error: ${unknownErr}`);
+  console.log('ok: unknown table -> clean UNKNOWN_TABLE error');
+
+  const brokenErr = await errOf('SELECT * FROM lake2.`lakehouse.broken`');
+  assert.ok(/404|Not found|NETWORK_ERROR/i.test(brokenErr), `missing metadata error: ${brokenErr}`);
+  assert.strictEqual(await q('SELECT 1'), '1', 'connection still usable after a failed read');
+  console.log('ok: missing metadata object -> clean error, connection survives');
+
+  const badCredsErr = await errOf(`
+    CREATE DATABASE badcreds
+    ENGINE = DataLakeCatalog('http://127.0.0.1:${AUTH_CATALOG_PORT}/v1')
+    SETTINGS catalog_type = 'rest', warehouse = 'warehouse',
+             catalog_credential = 'wrong:nope'`)
+    || await errOf('SELECT * FROM badcreds.`lakehouse.events`');
+  // Upstream wart (native behaves the same): retrieveAccessToken() extracts
+  // `access_token` from the 401 error body without checking, so the user sees
+  // Poco::InvalidAccessException instead of a clean 401. Assert it at least
+  // fails loudly; tighten to /401/ if upstream ever improves the message.
+  assert.ok(/401|invalid_client|Invalid access/i.test(badCredsErr), `bad catalog creds error: ${badCredsErr}`);
+  await errOf('DROP DATABASE badcreds');
+  console.log('ok: wrong catalog credentials -> query fails (error quality tracked upstream)');
+
+  await q('DROP DATABASE lake2');
   console.log(`PASS datalake.test (DataLakeCatalog REST + Iceberg-on-S3, backend=${BACKEND})`);
 } finally {
   if (db) await db.terminate().catch(() => {});
   if (mockServer) mockServer.close();
+  if (authServer) authServer.close();
   s3.kill('SIGKILL');
 }

--- a/packages/chdb-wasm/test/datalake/make_delta_table.py
+++ b/packages/chdb-wasm/test/datalake/make_delta_table.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Create a real Delta Lake table on an S3-compatible endpoint (moto) with delta-rs.
+
+Usage: make_delta_table.py <s3_endpoint> <bucket>
+
+Writes s3://<bucket>/unity/sales (two commits -> two _delta_log entries) and
+prints a JSON descriptor for the mock Unity catalog on stdout.
+"""
+import json
+import sys
+
+import pyarrow as pa
+from deltalake import write_deltalake
+
+
+def main() -> None:
+    endpoint, bucket = sys.argv[1], sys.argv[2]
+    location = f"s3://{bucket}/unity/sales"
+
+    storage_options = {
+        "AWS_ENDPOINT_URL": endpoint,
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_REGION": "us-east-1",
+        "AWS_ALLOW_HTTP": "true",
+        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+    }
+
+    data = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "item": pa.array(["book", "pen", "desk"]),
+            "price": pa.array([10.5, 1.25, 99.0], type=pa.float64()),
+        }
+    )
+    write_deltalake(location, data, storage_options=storage_options)
+
+    # Second commit so the log-replay path (00000...0.json + 00000...1.json) is exercised.
+    more = pa.table(
+        {
+            "id": pa.array([4], type=pa.int64()),
+            "item": pa.array(["lamp"]),
+            "price": pa.array([25.0], type=pa.float64()),
+        }
+    )
+    write_deltalake(location, more, mode="append", storage_options=storage_options)
+
+    # Columns in the shape UnityCatalog.cpp parses: type_json is either a quoted
+    # simple Delta type name (the OSS Unity quirk) or a full JSON field object.
+    print(
+        json.dumps(
+            {
+                "catalog": "unity",
+                "schema": "lakeschema",
+                "table": "sales",
+                "location": location,
+                "columns": [
+                    {"name": "id", "nullable": True, "type_json": '"long"'},
+                    {"name": "item", "nullable": True, "type_json": '"string"'},
+                    {"name": "price", "nullable": True, "type_json": '"double"'},
+                ],
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/chdb-wasm/test/datalake/make_delta_table.py
+++ b/packages/chdb-wasm/test/datalake/make_delta_table.py
@@ -24,6 +24,9 @@ def main() -> None:
         "AWS_REGION": "us-east-1",
         "AWS_ALLOW_HTTP": "true",
         "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+        # Generous timeout for slow/busy CI runners (object_store default is 30s
+        # total per request, which a loaded moto can exceed).
+        "timeout": "120s",
     }
 
     data = pa.table(

--- a/packages/chdb-wasm/test/datalake/make_iceberg_local.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_local.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Create a real Iceberg table on the local filesystem with pyiceberg.
+
+Usage: make_iceberg_local.py <warehouse_dir>
+
+Writes namespace `localns`, table `items` (2 snapshots) under <warehouse_dir>
+via a local SqlCatalog (sqlite), then prints {"table_dir": ...} on stdout —
+the table directory to mirror into the wasm MEMFS for icebergLocal().
+"""
+import json
+import sys
+import tempfile
+
+import pyarrow as pa
+from pyiceberg.catalog.sql import SqlCatalog
+
+
+def main() -> None:
+    warehouse_dir = sys.argv[1]
+
+    tmp = tempfile.mkdtemp(prefix="iceberg-sqlcat-")
+    catalog = SqlCatalog(
+        "local",
+        uri=f"sqlite:///{tmp}/catalog.db",
+        warehouse=f"file://{warehouse_dir}",
+    )
+
+    catalog.create_namespace("localns")
+    data = pa.table(
+        {
+            "k": pa.array([10, 20, 30], type=pa.int64()),
+            "v": pa.array(["ten", "twenty", "thirty"]),
+        }
+    )
+    table = catalog.create_table("localns.items", schema=data.schema)
+    table.append(data)
+    table.append(pa.table({"k": pa.array([40], type=pa.int64()), "v": pa.array(["forty"])}))
+
+    # file:///path/... -> /path/...
+    table_dir = table.location()
+    if table_dir.startswith("file://"):
+        table_dir = table_dir[len("file://") :]
+
+    print(json.dumps({"table_dir": table_dir}))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/chdb-wasm/test/datalake/make_iceberg_rest_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_rest_table.py
@@ -26,6 +26,9 @@ def main() -> None:
             "s3.access-key-id": access_key,
             "s3.secret-access-key": secret_key,
             "s3.region": "us-east-1",
+            # Generous timeouts for slow/busy CI runners (curl 28 low-speed watchdog).
+            "s3.connect-timeout": "60",
+            "s3.request-timeout": "60",
         },
     )
 

--- a/packages/chdb-wasm/test/datalake/make_iceberg_rest_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_rest_table.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Create an Iceberg table through a REAL Iceberg REST catalog (pyiceberg RestCatalog).
+
+Usage: make_iceberg_rest_table.py <catalog_uri> <s3_endpoint> <access_key> <secret_key>
+
+Creates namespace `smoke`, table `readings` (2 snapshots) via the REST protocol —
+the catalog service (e.g. apache/iceberg-rest-fixture) manages the metadata and
+writes to its configured warehouse. Prints {"namespace","table"} on stdout.
+"""
+import json
+import sys
+
+import pyarrow as pa
+from pyiceberg.catalog import load_catalog
+
+
+def main() -> None:
+    catalog_uri, s3_endpoint, access_key, secret_key = sys.argv[1:5]
+
+    catalog = load_catalog(
+        "real-rest",
+        **{
+            "type": "rest",
+            "uri": catalog_uri,
+            "s3.endpoint": s3_endpoint,
+            "s3.access-key-id": access_key,
+            "s3.secret-access-key": secret_key,
+            "s3.region": "us-east-1",
+        },
+    )
+
+    catalog.create_namespace("smoke")
+    data = pa.table(
+        {
+            "sensor": pa.array(["a", "b", "a", "c"]),
+            "value": pa.array([10, 20, 30, 40], type=pa.int64()),
+        }
+    )
+    table = catalog.create_table("smoke.readings", schema=data.schema)
+    table.append(data)
+    table.append(pa.table({"sensor": pa.array(["b"]), "value": pa.array([50], type=pa.int64())}))
+
+    print(json.dumps({"namespace": "smoke", "table": "readings"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/chdb-wasm/test/datalake/make_iceberg_rest_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_rest_table.py
@@ -26,6 +26,10 @@ def main() -> None:
             "s3.access-key-id": access_key,
             "s3.secret-access-key": secret_key,
             "s3.region": "us-east-1",
+            # fsspec (s3fs) instead of pyarrow S3FileIO: the aws-sdk-cpp multipart
+            # upload wedges against moto on loaded CI runners (curl 28 stalls);
+            # fsspec+moto is the combination pyiceberg's own CI uses.
+            "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
             # Generous timeouts for slow/busy CI runners (curl 28 low-speed watchdog).
             "s3.connect-timeout": "60",
             "s3.request-timeout": "60",

--- a/packages/chdb-wasm/test/datalake/make_iceberg_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_table.py
@@ -50,6 +50,10 @@ def main() -> None:
             "s3.access-key-id": access_key,
             "s3.secret-access-key": secret_key,
             "s3.region": "us-east-1",
+            # Generous timeouts: on a busy CI runner moto can respond slowly and
+            # the AWS SDK's low-speed watchdog (curl 28) kills uploads otherwise.
+            "s3.connect-timeout": "60",
+            "s3.request-timeout": "60",
         },
     )
 

--- a/packages/chdb-wasm/test/datalake/make_iceberg_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_table.py
@@ -50,6 +50,10 @@ def main() -> None:
             "s3.access-key-id": access_key,
             "s3.secret-access-key": secret_key,
             "s3.region": "us-east-1",
+            # fsspec (s3fs) instead of pyarrow S3FileIO: the aws-sdk-cpp multipart
+            # upload wedges against moto on loaded CI runners (curl 28 stalls);
+            # fsspec+moto is the combination pyiceberg's own CI uses.
+            "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
             # Generous timeouts: on a busy CI runner moto can respond slowly and
             # the AWS SDK's low-speed watchdog (curl 28) kills uploads otherwise.
             "s3.connect-timeout": "60",

--- a/packages/chdb-wasm/test/datalake/make_iceberg_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_table.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Create a real Iceberg table on an S3-compatible endpoint (moto) with pyiceberg.
+
+Usage: make_iceberg_table.py <s3_endpoint> <bucket>
+
+Writes namespace `lakehouse`, table `events` (3 columns, 5 rows) under
+s3://<bucket>/warehouse/ via a local SqlCatalog (sqlite), then prints a JSON
+descriptor {"metadata_location": ..., "namespace": ..., "table": ...} on stdout
+for the mock Iceberg REST catalog to serve.
+"""
+import json
+import sys
+import tempfile
+
+import pyarrow as pa
+from pyiceberg.catalog.sql import SqlCatalog
+
+
+def main() -> None:
+    endpoint, bucket = sys.argv[1], sys.argv[2]
+
+    tmp = tempfile.mkdtemp(prefix="iceberg-sqlcat-")
+    catalog = SqlCatalog(
+        "local",
+        uri=f"sqlite:///{tmp}/catalog.db",
+        warehouse=f"s3://{bucket}/warehouse",
+        **{
+            "s3.endpoint": endpoint,
+            "s3.access-key-id": "testing",
+            "s3.secret-access-key": "testing",
+            "s3.region": "us-east-1",
+        },
+    )
+
+    catalog.create_namespace("lakehouse")
+    data = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+            "name": pa.array(["alpha", "beta", "gamma", "delta", "epsilon"]),
+            "score": pa.array([1.5, 2.5, 3.5, 4.5, 5.5], type=pa.float64()),
+        }
+    )
+    table = catalog.create_table("lakehouse.events", schema=data.schema)
+    table.append(data)
+
+    # Second snapshot so manifest-list handling beyond the trivial case is exercised.
+    more = pa.table(
+        {
+            "id": pa.array([6, 7], type=pa.int64()),
+            "name": pa.array(["zeta", "eta"]),
+            "score": pa.array([6.5, 7.5], type=pa.float64()),
+        }
+    )
+    table.append(more)
+
+    # The exact on-disk metadata JSON, for the mock REST catalog's LoadTableResult.
+    with table.io.new_input(table.metadata_location).open() as f:
+        metadata_json = json.loads(f.read().decode("utf-8"))
+
+    print(
+        json.dumps(
+            {
+                "metadata_location": table.metadata_location,
+                "namespace": "lakehouse",
+                "table": "events",
+                "location": table.location(),
+                "metadata": metadata_json,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/chdb-wasm/test/datalake/make_iceberg_table.py
+++ b/packages/chdb-wasm/test/datalake/make_iceberg_table.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
-"""Create a real Iceberg table on an S3-compatible endpoint (moto) with pyiceberg.
+"""Create real Iceberg tables on an S3-compatible endpoint with pyiceberg.
 
-Usage: make_iceberg_table.py <s3_endpoint> <bucket>
+Usage: make_iceberg_table.py <s3_endpoint> <bucket> [access_key secret_key]
 
-Writes namespace `lakehouse`, table `events` (3 columns, 5 rows) under
-s3://<bucket>/warehouse/ via a local SqlCatalog (sqlite), then prints a JSON
-descriptor {"metadata_location": ..., "namespace": ..., "table": ...} on stdout
-for the mock Iceberg REST catalog to serve.
+Writes namespace `lakehouse` with three tables under s3://<bucket>/warehouse/:
+  - events:        3 columns, 2 snapshots (5 + 2 rows) — the basic read path
+  - city_events:   identity-partitioned by `city` with values containing spaces
+                   ("New York") — object keys with characters needing URL encoding
+  - deleted_events: format-version 2, rows deleted after the initial append
+                   (5 rows written, 2 deleted). NOTE: pyiceberg falls back to
+                   copy-on-write ("Merge on read is not yet supported"), so this
+                   covers delete-via-overwrite snapshots; positional-delete files
+                   need a Spark writer and are not covered here.
+
+Prints a JSON descriptor {"namespace", "tables": [{"name", "metadata_location",
+"location", "metadata"}...]} on stdout for the mock Iceberg REST catalog.
 """
 import json
 import sys
@@ -16,8 +24,21 @@ import pyarrow as pa
 from pyiceberg.catalog.sql import SqlCatalog
 
 
+def describe(table):
+    with table.io.new_input(table.metadata_location).open() as f:
+        metadata_json = json.loads(f.read().decode("utf-8"))
+    return {
+        "name": table.name()[-1],
+        "metadata_location": table.metadata_location,
+        "location": table.location(),
+        "metadata": metadata_json,
+    }
+
+
 def main() -> None:
     endpoint, bucket = sys.argv[1], sys.argv[2]
+    access_key = sys.argv[3] if len(sys.argv) > 3 else "testing"
+    secret_key = sys.argv[4] if len(sys.argv) > 4 else "testing"
 
     tmp = tempfile.mkdtemp(prefix="iceberg-sqlcat-")
     catalog = SqlCatalog(
@@ -26,13 +47,16 @@ def main() -> None:
         warehouse=f"s3://{bucket}/warehouse",
         **{
             "s3.endpoint": endpoint,
-            "s3.access-key-id": "testing",
-            "s3.secret-access-key": "testing",
+            "s3.access-key-id": access_key,
+            "s3.secret-access-key": secret_key,
             "s3.region": "us-east-1",
         },
     )
 
     catalog.create_namespace("lakehouse")
+    tables = []
+
+    # --- events: plain table, two snapshots ---
     data = pa.table(
         {
             "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
@@ -40,34 +64,56 @@ def main() -> None:
             "score": pa.array([1.5, 2.5, 3.5, 4.5, 5.5], type=pa.float64()),
         }
     )
-    table = catalog.create_table("lakehouse.events", schema=data.schema)
-    table.append(data)
-
-    # Second snapshot so manifest-list handling beyond the trivial case is exercised.
-    more = pa.table(
-        {
-            "id": pa.array([6, 7], type=pa.int64()),
-            "name": pa.array(["zeta", "eta"]),
-            "score": pa.array([6.5, 7.5], type=pa.float64()),
-        }
-    )
-    table.append(more)
-
-    # The exact on-disk metadata JSON, for the mock REST catalog's LoadTableResult.
-    with table.io.new_input(table.metadata_location).open() as f:
-        metadata_json = json.loads(f.read().decode("utf-8"))
-
-    print(
-        json.dumps(
+    events = catalog.create_table("lakehouse.events", schema=data.schema)
+    events.append(data)
+    events.append(
+        pa.table(
             {
-                "metadata_location": table.metadata_location,
-                "namespace": "lakehouse",
-                "table": "events",
-                "location": table.location(),
-                "metadata": metadata_json,
+                "id": pa.array([6, 7], type=pa.int64()),
+                "name": pa.array(["zeta", "eta"]),
+                "score": pa.array([6.5, 7.5], type=pa.float64()),
             }
         )
     )
+    tables.append(describe(events))
+
+    # --- city_events: identity partition on `city`, values with spaces ->
+    #     data file keys like .../city=New%20York/... (URL-encoding coverage) ---
+    from pyiceberg.partitioning import PartitionField, PartitionSpec
+    from pyiceberg.transforms import IdentityTransform
+
+    city_data = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4], type=pa.int64()),
+            "city": pa.array(["New York", "San Francisco", "New York", "Los Angeles"]),
+            "amount": pa.array([10.0, 20.0, 30.0, 40.0], type=pa.float64()),
+        }
+    )
+    city_events = catalog.create_table("lakehouse.city_events", schema=city_data.schema)
+    with city_events.update_spec() as update:
+        update.add_field("city", IdentityTransform(), "city")
+    city_events = catalog.load_table("lakehouse.city_events")
+    city_events.append(city_data)
+    tables.append(describe(city_events))
+
+    # --- deleted_events: delete -> copy-on-write overwrite snapshot ---
+    del_data = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+            "v": pa.array(["a", "b", "c", "d", "e"]),
+        }
+    )
+    deleted = catalog.create_table(
+        "lakehouse.deleted_events",
+        schema=del_data.schema,
+        properties={"format-version": "2"},
+    )
+    deleted.append(del_data)
+    deleted.delete(delete_filter="id = 2 or id = 4")
+    deleted = catalog.load_table("lakehouse.deleted_events")
+    tables.append(describe(deleted))
+
+    print(json.dumps({"namespace": "lakehouse", "tables": tables}))
 
 
 if __name__ == "__main__":

--- a/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
+++ b/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
@@ -1,5 +1,6 @@
-// Minimal Iceberg REST catalog serving exactly one table, for the DataLakeCatalog
-// wasm tests. Implements the subset ClickHouse's RestCatalog actually calls:
+// Minimal Iceberg REST catalog serving one namespace of tables, for the
+// DataLakeCatalog wasm tests. Implements the subset ClickHouse's RestCatalog
+// actually calls:
 //   GET /v1/config?warehouse=...            -> {defaults:{}, overrides:{}}
 //   GET /v1/namespaces[?parent=...]         -> namespace listing (one level)
 //   GET /v1/namespaces/{ns}/tables          -> table identifier listing
@@ -9,7 +10,12 @@
 import http from 'node:http';
 
 export function startMockCatalog({ port, descriptor }) {
-  const { namespace, table, metadata_location, metadata } = descriptor;
+  // descriptor: { namespace, tables: [{name, metadata_location, metadata}, ...] }
+  // (a single-table descriptor {namespace, table, metadata_location, metadata}
+  //  is accepted too, for older fixtures)
+  const { namespace } = descriptor;
+  const tables = descriptor.tables
+    ?? [{ name: descriptor.table, metadata_location: descriptor.metadata_location, metadata: descriptor.metadata }];
 
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, `http://127.0.0.1:${port}`);
@@ -51,15 +57,22 @@ export function startMockCatalog({ port, descriptor }) {
     }
 
     if (path === `/v1/namespaces/${namespace}/tables`)
-      return send(200, { identifiers: [{ namespace: [namespace], name: table }] });
+      return send(200, { identifiers: tables.map((t) => ({ namespace: [namespace], name: t.name })) });
 
-    if (path === `/v1/namespaces/${namespace}/tables/${table}`)
-      return send(200, { 'metadata-location': metadata_location, metadata, config: {} });
+    const table = tables.find((t) => path === `/v1/namespaces/${namespace}/tables/${t.name}`);
+    if (table)
+      return send(200, { 'metadata-location': table.metadata_location, metadata: table.metadata, config: {} });
 
     return send(404, { error: { message: `not found: ${req.method} ${req.url}`, type: 'NoSuchTableException', code: 404 } });
   });
 
-  return new Promise((resolve) => {
-    server.listen(port, '127.0.0.1', () => resolve(server));
+  // Reject on listen errors (e.g. EADDRINUSE from a leaked process) so callers'
+  // try/finally cleanup runs instead of the process dying on an unhandled 'error'.
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve(server);
+    });
   });
 }

--- a/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
+++ b/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
@@ -22,7 +22,9 @@ export function startMockCatalog({ port, descriptor }) {
         'Content-Length': Buffer.byteLength(payload),
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
-        'Access-Control-Allow-Headers': '*',
+        'Access-Control-Allow-Headers': req.headers['access-control-request-headers'] || '*',
+        'Access-Control-Expose-Headers': '*',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
       });
       res.end(payload);
     };
@@ -31,7 +33,9 @@ export function startMockCatalog({ port, descriptor }) {
       res.writeHead(204, {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
-        'Access-Control-Allow-Headers': '*',
+        'Access-Control-Allow-Headers': req.headers['access-control-request-headers'] || '*',
+        'Access-Control-Expose-Headers': '*',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
       });
       res.end();
       return;

--- a/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
+++ b/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
@@ -1,0 +1,61 @@
+// Minimal Iceberg REST catalog serving exactly one table, for the DataLakeCatalog
+// wasm tests. Implements the subset ClickHouse's RestCatalog actually calls:
+//   GET /v1/config?warehouse=...            -> {defaults:{}, overrides:{}}
+//   GET /v1/namespaces[?parent=...]         -> namespace listing (one level)
+//   GET /v1/namespaces/{ns}/tables          -> table identifier listing
+//   GET /v1/namespaces/{ns}/tables/{table}  -> LoadTableResult (metadata-location + metadata)
+// CORS is fully open so the same mock serves the browser fixture.
+
+import http from 'node:http';
+
+export function startMockCatalog({ port, descriptor }) {
+  const { namespace, table, metadata_location, metadata } = descriptor;
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${port}`);
+    const path = url.pathname.replace(/\/+$/, '');
+
+    const send = (code, body) => {
+      const payload = JSON.stringify(body);
+      res.writeHead(code, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
+        'Access-Control-Allow-Headers': '*',
+      });
+      res.end(payload);
+    };
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
+        'Access-Control-Allow-Headers': '*',
+      });
+      res.end();
+      return;
+    }
+
+    if (path === '/v1/config')
+      return send(200, { defaults: {}, overrides: {} });
+
+    if (path === '/v1/namespaces') {
+      // Root listing returns our one namespace; child listings are empty.
+      const parent = url.searchParams.get('parent');
+      return send(200, { namespaces: parent ? [] : [[namespace]] });
+    }
+
+    if (path === `/v1/namespaces/${namespace}/tables`)
+      return send(200, { identifiers: [{ namespace: [namespace], name: table }] });
+
+    if (path === `/v1/namespaces/${namespace}/tables/${table}`)
+      return send(200, { 'metadata-location': metadata_location, metadata, config: {} });
+
+    return send(404, { error: { message: `not found: ${req.method} ${req.url}`, type: 'NoSuchTableException', code: 404 } });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(port, '127.0.0.1', () => resolve(server));
+  });
+}

--- a/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
+++ b/packages/chdb-wasm/test/datalake/mock-rest-catalog.mjs
@@ -1,21 +1,50 @@
-// Minimal Iceberg REST catalog serving one namespace of tables, for the
-// DataLakeCatalog wasm tests. Implements the subset ClickHouse's RestCatalog
-// actually calls:
-//   GET /v1/config?warehouse=...            -> {defaults:{}, overrides:{}}
-//   GET /v1/namespaces[?parent=...]         -> namespace listing (one level)
-//   GET /v1/namespaces/{ns}/tables          -> table identifier listing
-//   GET /v1/namespaces/{ns}/tables/{table}  -> LoadTableResult (metadata-location + metadata)
+// Minimal Iceberg REST catalog for the DataLakeCatalog wasm tests. Implements
+// the subset ClickHouse's RestCatalog actually calls:
+//   POST /v1/oauth/tokens                   -> client_credentials grant (when `auth` is set)
+//   GET  /v1/config?warehouse=...           -> {defaults:{}, overrides:{}}
+//   GET  /v1/namespaces[?parent=...]        -> namespace listing (paginated)
+//   GET  /v1/namespaces/{ns}/tables         -> table identifier listing (paginated)
+//   GET  /v1/namespaces/{ns}/tables/{table} -> LoadTableResult (+ vended credentials)
 // CORS is fully open so the same mock serves the browser fixture.
+//
+// Options beyond {port, descriptor}:
+//   auth: {clientId, clientSecret, tokenMaxUses?} — enable OAuth: every catalog
+//         request must carry `Authorization: Bearer <token>` issued by
+//         /v1/oauth/tokens; a token expires after tokenMaxUses requests (401,
+//         forcing the client's refresh-and-retry path).
+//   vend: {accessKey, secretKey, endpoint} — storage credentials are vended in
+//         LoadTableResult.config, and ONLY when the client sends
+//         `X-Iceberg-Access-Delegation: vended-credentials`.
+//   pageSize: N — namespaces/tables listings return N items per page with
+//         next-page-token / pageToken pagination.
+//   extraNamespaces: ['other', ...] — additional (empty) namespaces.
+//
+// startMockCatalog() resolves to the http.Server with a `.stats` property:
+// {oauthTokensIssued, unauthorized, delegationHeaderSeen, maxPageRequests}.
 
 import http from 'node:http';
 
-export function startMockCatalog({ port, descriptor }) {
-  // descriptor: { namespace, tables: [{name, metadata_location, metadata}, ...] }
-  // (a single-table descriptor {namespace, table, metadata_location, metadata}
-  //  is accepted too, for older fixtures)
+export function startMockCatalog({ port, descriptor, auth, vend, pageSize, extraNamespaces = [] }) {
   const { namespace } = descriptor;
   const tables = descriptor.tables
     ?? [{ name: descriptor.table, metadata_location: descriptor.metadata_location, metadata: descriptor.metadata }];
+  const namespaces = [namespace, ...extraNamespaces];
+
+  const stats = { oauthTokensIssued: 0, unauthorized: 0, delegationHeaderSeen: 0, maxPageRequests: 0 };
+  // Multiple tokens can be live at once (the client lists tables from a thread
+  // pool; a refresh on one thread must not invalidate another thread's token —
+  // real OAuth servers behave this way). Each token carries its own use budget.
+  const tokenUses = new Map();
+
+  const paginate = (items, url, key, shape) => {
+    if (!pageSize || items.length <= pageSize) return { [key]: items.map(shape) };
+    const start = Number(url.searchParams.get('pageToken') || 0);
+    stats.maxPageRequests = Math.max(stats.maxPageRequests, Math.ceil(items.length / pageSize));
+    const page = items.slice(start, start + pageSize);
+    const body = { [key]: page.map(shape) };
+    if (start + pageSize < items.length) body['next-page-token'] = String(start + pageSize);
+    return body;
+  };
 
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, `http://127.0.0.1:${port}`);
@@ -47,24 +76,72 @@ export function startMockCatalog({ port, descriptor }) {
       return;
     }
 
+    // --- OAuth token endpoint (no bearer required) ---
+    if (auth && path === '/v1/oauth/tokens' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        const params = new URLSearchParams(body);
+        if (params.get('grant_type') !== 'client_credentials'
+          || params.get('client_id') !== auth.clientId
+          || params.get('client_secret') !== auth.clientSecret) {
+          stats.unauthorized += 1;
+          return send(401, { error: 'invalid_client' });
+        }
+        stats.oauthTokensIssued += 1;
+        const token = `tok-${stats.oauthTokensIssued}`;
+        tokenUses.set(token, 0);
+        send(200, { access_token: token, token_type: 'bearer', expires_in: 3600 });
+      });
+      return;
+    }
+
+    // --- bearer enforcement for every other catalog call ---
+    if (auth) {
+      const token = (req.headers.authorization || '').replace(/^Bearer /, '');
+      const uses = tokenUses.get(token);
+      if (uses === undefined || (auth.tokenMaxUses && uses >= auth.tokenMaxUses)) {
+        // An expired (over-used) token must 401 so the client refreshes and retries.
+        tokenUses.delete(token);
+        stats.unauthorized += 1;
+        return send(401, { error: { message: 'invalid or expired token', type: 'NotAuthorizedException', code: 401 } });
+      }
+      tokenUses.set(token, uses + 1);
+    }
+
     if (path === '/v1/config')
       return send(200, { defaults: {}, overrides: {} });
 
     if (path === '/v1/namespaces') {
-      // Root listing returns our one namespace; child listings are empty.
       const parent = url.searchParams.get('parent');
-      return send(200, { namespaces: parent ? [] : [[namespace]] });
+      if (parent) return send(200, { namespaces: [] });
+      return send(200, paginate(namespaces, url, 'namespaces', (n) => [n]));
     }
 
-    if (path === `/v1/namespaces/${namespace}/tables`)
-      return send(200, { identifiers: tables.map((t) => ({ namespace: [namespace], name: t.name })) });
+    for (const ns of namespaces) {
+      if (path === `/v1/namespaces/${ns}/tables`) {
+        const nsTables = ns === namespace ? tables : [];
+        return send(200, paginate(nsTables, url, 'identifiers', (t) => ({ namespace: [ns], name: t.name })));
+      }
+    }
 
     const table = tables.find((t) => path === `/v1/namespaces/${namespace}/tables/${t.name}`);
-    if (table)
-      return send(200, { 'metadata-location': table.metadata_location, metadata: table.metadata, config: {} });
+    if (table) {
+      const result = { 'metadata-location': table.metadata_location, metadata: table.metadata, config: {} };
+      if (vend && req.headers['x-iceberg-access-delegation'] === 'vended-credentials') {
+        stats.delegationHeaderSeen += 1;
+        result.config = {
+          's3.access-key-id': vend.accessKey,
+          's3.secret-access-key': vend.secretKey,
+          's3.endpoint': vend.endpoint,
+        };
+      }
+      return send(200, result);
+    }
 
     return send(404, { error: { message: `not found: ${req.method} ${req.url}`, type: 'NoSuchTableException', code: 404 } });
   });
+  server.stats = stats;
 
   // Reject on listen errors (e.g. EADDRINUSE from a leaked process) so callers'
   // try/finally cleanup runs instead of the process dying on an unhandled 'error'.

--- a/packages/chdb-wasm/test/datalake/mock-unity-catalog.mjs
+++ b/packages/chdb-wasm/test/datalake/mock-unity-catalog.mjs
@@ -1,0 +1,72 @@
+// Minimal Unity catalog serving exactly one Delta table, for the DataLakeCatalog
+// wasm tests. Implements the subset ClickHouse's UnityCatalog client calls
+// (base url = http://host:port/api/2.1/unity-catalog):
+//   GET {base}/schemas?catalog_name=W          -> schema listing
+//   GET {base}/tables?catalog_name=W&schema_name=S -> table name listing
+//   GET {base}/tables/{W}.{S}.{T}              -> table info (storage_location,
+//       securable_kind/data_source_format, columns[] with Unity's type_json)
+// CORS-open like the Iceberg mock so a browser fixture can reuse it.
+
+import http from 'node:http';
+
+export function startMockUnityCatalog({ port, descriptor }) {
+  const { catalog, schema, table, location, columns } = descriptor;
+  const base = '/api/2.1/unity-catalog';
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${port}`);
+    const path = url.pathname.replace(/\/+$/, '');
+
+    const send = (code, body) => {
+      const payload = JSON.stringify(body);
+      res.writeHead(code, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
+        'Access-Control-Allow-Headers': req.headers['access-control-request-headers'] || '*',
+        'Access-Control-Expose-Headers': '*',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+      });
+      res.end(payload);
+    };
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
+        'Access-Control-Allow-Headers': req.headers['access-control-request-headers'] || '*',
+      });
+      res.end();
+      return;
+    }
+
+    if (path === `${base}/schemas`)
+      return send(200, { schemas: [{ catalog_name: catalog, full_name: `${catalog}.${schema}` }] });
+
+    if (path === `${base}/tables`)
+      return send(200, { tables: [{ name: table }] });
+
+    if (path === `${base}/tables/${catalog}.${schema}.${table}`)
+      return send(200, {
+        name: table,
+        storage_location: location,
+        securable_kind: 'TABLE_DELTA_EXTERNAL',
+        data_source_format: 'DELTA',
+        columns,
+        table_id: '11111111-2222-3333-4444-555555555555',
+      });
+
+    return send(404, { error_code: 'NOT_FOUND', message: `not found: ${req.method} ${req.url}` });
+  });
+
+  // Reject on listen errors (e.g. EADDRINUSE from a leaked process) so callers'
+  // try/finally cleanup runs instead of the process dying on an unhandled 'error'.
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve(server);
+    });
+  });
+}

--- a/packages/chdb-wasm/test/iceberg-local.test.mjs
+++ b/packages/chdb-wasm/test/iceberg-local.test.mjs
@@ -1,0 +1,60 @@
+// icebergLocal() smoke test for the chdb-wasm package: a real Iceberg table
+// (written by pyiceberg on the host) is mirrored into the wasm MEMFS with
+// putFile, then read back with the icebergLocal table function — exercising
+// Avro manifest reading + Parquet data reading with zero networking.
+//
+// Requires a Python venv with pyiceberg (default /tmp/iceberg-venv, override
+// with ICEBERG_PY). Skips cleanly if absent.
+//
+//   CHDB_WASM_MJS=/abs/path/to/chdb.mjs node packages/chdb-wasm/test/iceberg-local.test.mjs
+
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AsyncChdb } from '../src/index.ts';
+
+const MODULE =
+  process.env.CHDB_WASM_MJS ||
+  fileURLToPath(new URL('../../../buildwasm/programs/wasm/chdb.mjs', import.meta.url));
+const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
+const FIXTURE = fileURLToPath(new URL('./datalake/make_iceberg_local.py', import.meta.url));
+
+if (!existsSync(PY)) {
+  console.log(`SKIP iceberg-local.test: no pyiceberg venv at ${PY} (set ICEBERG_PY)`);
+  process.exit(0);
+}
+
+const warehouse = mkdtempSync(join(tmpdir(), 'iceberg-wh-'));
+const { table_dir } = JSON.parse(execFileSync(PY, [FIXTURE, warehouse], { encoding: 'utf8' }).trim());
+
+const db = await AsyncChdb.create({ moduleUrl: MODULE });
+try {
+  // Mirror the table directory into MEMFS at /iceberg/items.
+  const MEMFS_TABLE = '/iceberg/items';
+  const walk = (dir) =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+      e.isDirectory() ? walk(join(dir, e.name)) : [join(dir, e.name)]);
+  const files = walk(table_dir);
+  assert.ok(files.some((f) => f.endsWith('.metadata.json')), 'fixture produced metadata json');
+  assert.ok(files.some((f) => f.endsWith('.avro')), 'fixture produced avro manifests');
+  assert.ok(files.some((f) => f.endsWith('.parquet')), 'fixture produced parquet data');
+  for (const f of files)
+    await db.putFile(join(MEMFS_TABLE, relative(table_dir, f)), new Uint8Array(readFileSync(f)));
+
+  const q = async (sql, fmt = 'TabSeparated') => (await db.query(sql, fmt)).text().trim();
+
+  const rows = await q(`SELECT k, v FROM icebergLocal('${MEMFS_TABLE}') ORDER BY k`, 'CSV');
+  assert.strictEqual(rows, '10,"ten"\n20,"twenty"\n30,"thirty"\n40,"forty"', `rows: ${rows}`);
+  console.log('ok: icebergLocal full scan (2 snapshots)');
+
+  const agg = await q(`SELECT count(), sum(k) FROM icebergLocal('${MEMFS_TABLE}')`);
+  assert.strictEqual(agg, '4\t100', `agg: ${agg}`);
+  console.log('ok: icebergLocal aggregation');
+
+  console.log('PASS iceberg-local.test (Avro manifests + Parquet data in MEMFS)');
+} finally {
+  await db.terminate().catch(() => {});
+}

--- a/packages/chdb-wasm/test/iceberg-local.test.mjs
+++ b/packages/chdb-wasm/test/iceberg-local.test.mjs
@@ -10,7 +10,7 @@
 
 import assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -57,4 +57,5 @@ try {
   console.log('PASS iceberg-local.test (Avro manifests + Parquet data in MEMFS)');
 } finally {
   await db.terminate().catch(() => {});
+  rmSync(warehouse, { recursive: true, force: true });
 }

--- a/programs/wasm/chdb_wasm.cpp
+++ b/programs/wasm/chdb_wasm.cpp
@@ -130,6 +130,14 @@ static void chdb_wasm_apply_settings(chdb_connection conn)
     chdb_result * r = chdb_query(conn, "SET max_threads = " CHDB_WASM_MAX_THREADS, "Null");
     if (r)
         chdb_destroy_query_result(r);
+    // Data-lake catalogs are a headline wasm feature: pre-enable the BETA gates
+    // (session defaults only — the engine defaults are untouched and a user
+    // SET overrides this). Paimon stays off (EXPERIMENTAL tier).
+    r = chdb_query(conn,
+        "SET allow_database_iceberg = 1, allow_experimental_database_unity_catalog = 1",
+        "Null");
+    if (r)
+        chdb_destroy_query_result(r);
 #if defined(CHDB_WASM_SINGLE_THREADED)
     // The single-threaded build has no thread pool (no -pthread), so the Parquet (V3)
     // reader's decoder/prefetch pools can't be created ("Cannot schedule a task"). Force

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,8 +143,10 @@ add_headers_and_sources(dbms Storages/ObjectStorage/Azure)
 add_headers_and_sources(dbms Storages/ObjectStorage/S3)
 add_headers_and_sources(dbms Storages/ObjectStorage/HDFS)
 add_headers_and_sources(dbms Storages/ObjectStorage/Local)
-# WASM web-fetch data plane; sources are #if defined(OS_WASM) guarded (empty TUs elsewhere).
-add_headers_and_sources(dbms Storages/ObjectStorage/WasmWeb)
+if (OS_WASM)
+    # WASM web-fetch data plane.
+    add_headers_and_sources(dbms Storages/ObjectStorage/WasmWeb)
+endif ()
 add_headers_and_sources(dbms Storages/ObjectStorage/DataLakes)
 add_headers_and_sources(dbms Storages/ObjectStorage/DataLakes/Common)
 add_headers_and_sources(dbms Storages/ObjectStorage/DataLakes/Iceberg)
@@ -190,8 +192,10 @@ add_headers_and_sources(dbms Databases/DataLake)
 add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/Cached)
 add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/Local)
 add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/Web)
-# WASM web-fetch data plane; sources are #if defined(OS_WASM) guarded (empty TUs elsewhere).
-add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/WasmWeb)
+if (OS_WASM)
+    # WASM web-fetch data plane.
+    add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/WasmWeb)
+endif ()
 
 add_headers_and_sources(dbms Storages/Cache)
 if (TARGET ch_contrib::hivemetastore)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,8 @@ add_headers_and_sources(dbms Storages/ObjectStorage/Azure)
 add_headers_and_sources(dbms Storages/ObjectStorage/S3)
 add_headers_and_sources(dbms Storages/ObjectStorage/HDFS)
 add_headers_and_sources(dbms Storages/ObjectStorage/Local)
+# WASM web-fetch data plane; sources are #if defined(OS_WASM) guarded (empty TUs elsewhere).
+add_headers_and_sources(dbms Storages/ObjectStorage/WasmWeb)
 add_headers_and_sources(dbms Storages/ObjectStorage/DataLakes)
 add_headers_and_sources(dbms Storages/ObjectStorage/DataLakes/Common)
 add_headers_and_sources(dbms Storages/ObjectStorage/DataLakes/Iceberg)
@@ -188,6 +190,8 @@ add_headers_and_sources(dbms Databases/DataLake)
 add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/Cached)
 add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/Local)
 add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/Web)
+# WASM web-fetch data plane; sources are #if defined(OS_WASM) guarded (empty TUs elsewhere).
+add_headers_and_sources(dbms Disks/DiskObjectStorage/ObjectStorages/WasmWeb)
 
 add_headers_and_sources(dbms Storages/Cache)
 if (TARGET ch_contrib::hivemetastore)

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -222,6 +222,13 @@ public:
             executeCallback(*promise, std::move(my_callback), std::move(thread_group), thread_name);
         };
 
+#ifdef CHDB_WASM_SINGLE_THREADED
+        /// Single-threaded WASM build: no worker thread can be created. These are
+        /// finite fire-and-wait tasks (callers enqueue then waitForAllToFinish),
+        /// so running them inline on the calling thread preserves the semantics;
+        /// exceptions land in the promise via executeCallback as usual.
+        task_func();
+#else
         try
         {
             /// Note: calling method scheduleOrThrowOnError in intentional, because we don't want to throw exceptions
@@ -236,6 +243,7 @@ public:
             promise->set_exception(std::current_exception());
             throw;
         }
+#endif
 
         return task;
     }

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -241,12 +241,16 @@ std::shared_ptr<DataLake::ICatalog> DatabaseDataLake::getCatalog() const
 
         case DB::DatabaseDataLakeCatalogType::GLUE:
         {
+#if USE_AWS_S3
             catalog_impl = std::make_shared<DataLake::GlueCatalog>(
                 url,
                 Context::getGlobalContextInstance(),
                 catalog_parameters,
                 table_engine_definition);
             break;
+#else
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot use 'glue' database engine: ClickHouse was compiled without USE_AWS_S3 build option");
+#endif
         }
         case DB::DatabaseDataLakeCatalogType::ICEBERG_HIVE:
         {
@@ -334,6 +338,13 @@ std::shared_ptr<StorageObjectStorageConfiguration> DatabaseDataLake::getConfigur
                 {
                     return std::make_shared<StorageS3IcebergConfiguration>(storage_settings);
                 }
+#elif defined(OS_WASM)
+                /// No AWS SDK on WASM: s3:// table locations are read over
+                /// http(s) through the host JS environment (SigV4 in C++).
+                case DB::DatabaseDataLakeStorageType::S3:
+                {
+                    return std::make_shared<StorageWasmWebIcebergConfiguration>(storage_settings);
+                }
 #endif
 #if USE_AZURE_BLOB_STORAGE
                 case DB::DatabaseDataLakeStorageType::Azure:
@@ -379,6 +390,11 @@ std::shared_ptr<StorageObjectStorageConfiguration> DatabaseDataLake::getConfigur
                 case DB::DatabaseDataLakeStorageType::S3:
                 {
                     return std::make_shared<StorageS3DeltaLakeConfiguration>(storage_settings);
+                }
+#elif defined(OS_WASM)
+                case DB::DatabaseDataLakeStorageType::S3:
+                {
+                    return std::make_shared<StorageWasmWebDeltaLakeConfiguration>(storage_settings);
                 }
 #endif
 #if USE_AZURE_BLOB_STORAGE
@@ -437,6 +453,11 @@ std::shared_ptr<StorageObjectStorageConfiguration> DatabaseDataLake::getConfigur
                 case DB::DatabaseDataLakeStorageType::S3:
                 {
                     return std::make_shared<StorageS3PaimonConfiguration>(storage_settings);
+                }
+#elif defined(OS_WASM)
+                case DB::DatabaseDataLakeStorageType::S3:
+                {
+                    return std::make_shared<StorageWasmWebPaimonConfiguration>(storage_settings);
                 }
 #endif
 #if USE_AZURE_BLOB_STORAGE

--- a/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.cpp
@@ -1,0 +1,167 @@
+#include <Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.h>
+
+#if defined(OS_WASM)
+
+#include <Common/Exception.h>
+#include <Common/ObjectStorageKeyGenerator.h>
+#include <IO/ReadBufferFromWebFetch.h>
+#include <IO/ReadSettings.h>
+#include <IO/WasmHTTPBridge.h>
+#include <IO/WasmS3Auth.h>
+
+#include <Poco/String.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+    extern const int NETWORK_ERROR;
+    extern const int FILE_DOESNT_EXIST;
+}
+
+WasmWebObjectStorage::WasmWebObjectStorage(WasmWebObjectStorageSettings settings_)
+    : settings(std::move(settings_))
+{
+    while (settings.base_url.ends_with('/'))
+        settings.base_url.pop_back();
+}
+
+String WasmWebObjectStorage::urlFor(const std::string & path) const
+{
+    if (path.starts_with('/'))
+        return settings.base_url + path;
+    return settings.base_url + "/" + path;
+}
+
+HTTPHeaderEntries WasmWebObjectStorage::headersFor(const String & method, const String & url) const
+{
+    HTTPHeaderEntries headers = settings.static_headers;
+    if (!settings.access_key_id.empty())
+    {
+        auto signed_headers
+            = WasmS3::signV4Request(method, url, settings.region, settings.access_key_id, settings.secret_access_key, settings.session_token);
+        headers.insert(headers.end(), signed_headers.begin(), signed_headers.end());
+    }
+    return headers;
+}
+
+std::unique_ptr<ReadBufferFromFileBase> WasmWebObjectStorage::readObject( /// NOLINT
+    const StoredObject & object,
+    const ReadSettings & read_settings,
+    std::optional<size_t>) const
+{
+    const String url = urlFor(object.remote_path);
+    return std::make_unique<ReadBufferFromWebFetch>(
+        url,
+        HTTPHeaderEntries{},
+        read_settings.remote_fs_buffer_size,
+        /* skip_not_found */ false,
+        /* headers_provider */ [this, url](const std::string & method) { return headersFor(method, url); });
+}
+
+std::optional<ObjectMetadata> WasmWebObjectStorage::tryGetObjectMetadata(const std::string & path, bool /* with_tags */) const
+{
+    const String url = urlFor(path);
+    HTTPHeaderEntries headers = headersFor("HEAD", url);
+    String blob;
+    for (const auto & entry : headers)
+    {
+        blob += entry.name;
+        blob += ": ";
+        blob += entry.value;
+        blob += '\n';
+    }
+    auto result = performWasmHTTPRequest("HEAD", url, blob, {});
+    if (result.status == 404)
+        return std::nullopt;
+    if (result.status < 200 || result.status >= 300)
+        throw Exception(ErrorCodes::NETWORK_ERROR, "Failed to HEAD '{}' (HTTP status {})", url, result.status);
+
+    ObjectMetadata metadata;
+    metadata.is_size_known = false;
+    size_t line_start = 0;
+    while (line_start < result.headers.size())
+    {
+        size_t line_end = result.headers.find('\n', line_start);
+        if (line_end == std::string::npos)
+            line_end = result.headers.size();
+        std::string_view line(result.headers.data() + line_start, line_end - line_start);
+        line_start = line_end + 1;
+
+        size_t colon = line.find(": ");
+        if (colon == std::string_view::npos)
+            continue;
+        std::string name(line.substr(0, colon));
+        std::string value(line.substr(colon + 2));
+        if (Poco::icompare(name, "Content-Length") == 0)
+        {
+            metadata.size_bytes = std::stoull(value);
+            metadata.is_size_known = true;
+        }
+        else if (Poco::icompare(name, "ETag") == 0)
+            metadata.etag = value;
+    }
+    return metadata;
+}
+
+ObjectMetadata WasmWebObjectStorage::getObjectMetadata(const std::string & path, bool with_tags) const
+{
+    auto metadata = tryGetObjectMetadata(path, with_tags);
+    if (!metadata)
+        throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Object '{}' does not exist (HTTP 404)", urlFor(path));
+    return *metadata;
+}
+
+bool WasmWebObjectStorage::exists(const StoredObject & object) const
+{
+    return tryGetObjectMetadata(object.remote_path, /* with_tags */ false).has_value();
+}
+
+ReadSettings WasmWebObjectStorage::patchSettings(const ReadSettings & read_settings) const
+{
+    /// Reads are plain synchronous range fetches: no threadpool reader, no
+    /// prefetch (an async wrapper would tie up scarce wasm pthreads).
+    auto modified_settings{read_settings};
+    modified_settings.remote_fs_method = RemoteFSReadMethod::read;
+    modified_settings.remote_fs_prefetch = false;
+    return IObjectStorage::patchSettings(modified_settings);
+}
+
+ObjectStorageKeyGeneratorPtr WasmWebObjectStorage::createKeyGenerator() const
+{
+    return createObjectStorageKeyGeneratorByPrefix("");
+}
+
+std::unique_ptr<WriteBufferFromFileBase> WasmWebObjectStorage::writeObject( /// NOLINT
+    const StoredObject &, WriteMode, std::optional<ObjectAttributes>, size_t, const WriteSettings &)
+{
+    throwReadOnly();
+}
+
+void WasmWebObjectStorage::removeObjectIfExists(const StoredObject &)
+{
+    throwReadOnly();
+}
+
+void WasmWebObjectStorage::removeObjectsIfExist(const StoredObjects &)
+{
+    throwReadOnly();
+}
+
+void WasmWebObjectStorage::copyObject( /// NOLINT
+    const StoredObject &, const StoredObject &, const ReadSettings &, const WriteSettings &, std::optional<ObjectAttributes>)
+{
+    throwReadOnly();
+}
+
+void WasmWebObjectStorage::throwReadOnly() const
+{
+    throw Exception(
+        ErrorCodes::NOT_IMPLEMENTED, "WasmWeb object storage '{}' is read-only: writes are not supported on WASM", settings.base_url);
+}
+
+}
+
+#endif

--- a/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.cpp
@@ -9,7 +9,14 @@
 #include <IO/WasmHTTPBridge.h>
 #include <IO/WasmS3Auth.h>
 
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/DOM/Document.h>
+#include <Poco/DOM/Element.h>
+#include <Poco/DOM/NodeList.h>
 #include <Poco/String.h>
+#include <Poco/URI.h>
+
+#include <limits>
 
 namespace DB
 {
@@ -19,6 +26,7 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int NETWORK_ERROR;
     extern const int FILE_DOESNT_EXIST;
+    extern const int INCORRECT_DATA;
 }
 
 WasmWebObjectStorage::WasmWebObjectStorage(WasmWebObjectStorageSettings settings_)
@@ -30,9 +38,15 @@ WasmWebObjectStorage::WasmWebObjectStorage(WasmWebObjectStorageSettings settings
 
 String WasmWebObjectStorage::urlFor(const std::string & path) const
 {
-    if (path.starts_with('/'))
-        return settings.base_url + path;
-    return settings.base_url + "/" + path;
+    /// Percent-encode the key with the exact AWS unreserved set: object keys may
+    /// contain spaces/'%'/'#' (Delta partition values do), which would otherwise
+    /// break the XHR URL and never match the SigV4 canonical URI. signV4Request
+    /// decodes + re-encodes the path with the same set, so the signature covers
+    /// byte-identical bytes to what the transport sends.
+    std::string_view key = path;
+    while (key.starts_with('/'))
+        key.remove_prefix(1);
+    return settings.base_url + "/" + WasmS3::uriEncode(String(key), /*encode_slash=*/false);
 }
 
 HTTPHeaderEntries WasmWebObjectStorage::headersFor(const String & method, const String & url) const
@@ -50,15 +64,22 @@ HTTPHeaderEntries WasmWebObjectStorage::headersFor(const String & method, const 
 std::unique_ptr<ReadBufferFromFileBase> WasmWebObjectStorage::readObject( /// NOLINT
     const StoredObject & object,
     const ReadSettings & read_settings,
-    std::optional<size_t>) const
+    std::optional<size_t> read_hint) const
 {
+    /// Data-lake manifests carry exact file sizes; seeding them here spares a
+    /// signed HEAD per file (and works on endpoints that only permit GET).
+    std::optional<size_t> known_size = read_hint;
+    if (!known_size && object.bytes_size != 0 && object.bytes_size != std::numeric_limits<uint64_t>::max())
+        known_size = object.bytes_size;
+
     const String url = urlFor(object.remote_path);
     return std::make_unique<ReadBufferFromWebFetch>(
         url,
         HTTPHeaderEntries{},
         read_settings.remote_fs_buffer_size,
         /* skip_not_found */ false,
-        /* headers_provider */ [this, url](const std::string & method) { return headersFor(method, url); });
+        /* headers_provider */ [this, url](const std::string & method) { return headersFor(method, url); },
+        known_size);
 }
 
 std::optional<ObjectMetadata> WasmWebObjectStorage::tryGetObjectMetadata(const std::string & path, bool /* with_tags */) const
@@ -117,6 +138,91 @@ ObjectMetadata WasmWebObjectStorage::getObjectMetadata(const std::string & path,
 bool WasmWebObjectStorage::exists(const StoredObject & object) const
 {
     return tryGetObjectMetadata(object.remote_path, /* with_tags */ false).has_value();
+}
+
+void WasmWebObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
+{
+    /// With a path-style endpoint object keys carry the bucket as their first
+    /// segment, but ListObjectsV2 addresses the bucket in the URL path and its
+    /// prefix/keys are bucket-relative — strip it here, re-prepend it below so
+    /// the returned paths keep readObject()'s key semantics.
+    String list_base = settings.base_url;
+    String key_prefix_to_readd;
+    String prefix = path;
+    if (!settings.bucket.empty() && prefix.starts_with(settings.bucket + "/"))
+    {
+        list_base += "/" + settings.bucket;
+        key_prefix_to_readd = settings.bucket + "/";
+        prefix = prefix.substr(settings.bucket.size() + 1);
+    }
+
+    String continuation_token;
+    do
+    {
+        String encoded_prefix;
+        Poco::URI::encode(prefix, "/&?=+ ", encoded_prefix);
+        String url = list_base + "/?list-type=2&prefix=" + encoded_prefix;
+        if (max_keys)
+            url += "&max-keys=" + std::to_string(max_keys);
+        if (!continuation_token.empty())
+        {
+            String encoded_token;
+            Poco::URI::encode(continuation_token, "/&?=+ ", encoded_token);
+            url += "&continuation-token=" + encoded_token;
+        }
+
+        HTTPHeaderEntries headers = headersFor("GET", url);
+        String blob;
+        for (const auto & entry : headers)
+        {
+            blob += entry.name;
+            blob += ": ";
+            blob += entry.value;
+            blob += '\n';
+        }
+        auto result = performWasmHTTPRequest("GET", url, blob, {});
+        if (result.status < 200 || result.status >= 300)
+            throw Exception(ErrorCodes::NETWORK_ERROR, "Failed to list '{}' (HTTP status {})", url, result.status);
+
+        Poco::XML::DOMParser parser;
+        Poco::AutoPtr<Poco::XML::Document> document;
+        try
+        {
+            document = parser.parseString(result.body);
+        }
+        catch (const Poco::Exception & e)
+        {
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse ListObjectsV2 response for '{}': {}", url, e.displayText());
+        }
+
+        Poco::AutoPtr<Poco::XML::NodeList> contents = document->getElementsByTagName("Contents");
+        for (unsigned long i = 0; i < contents->length(); ++i)
+        {
+            const auto * element = dynamic_cast<Poco::XML::Element *>(contents->item(i));
+            if (!element)
+                continue;
+            const auto * key_node = element->getChildElement("Key");
+            if (!key_node)
+                continue;
+            ObjectMetadata metadata;
+            metadata.is_size_known = false;
+            if (const auto * size_node = element->getChildElement("Size"))
+            {
+                metadata.size_bytes = std::stoull(size_node->innerText());
+                metadata.is_size_known = true;
+            }
+            if (const auto * etag_node = element->getChildElement("ETag"))
+                metadata.etag = etag_node->innerText();
+            children.emplace_back(std::make_shared<RelativePathWithMetadata>(key_prefix_to_readd + key_node->innerText(), std::move(metadata)));
+            if (max_keys && children.size() >= max_keys)
+                return;
+        }
+
+        continuation_token.clear();
+        Poco::AutoPtr<Poco::XML::NodeList> token_nodes = document->getElementsByTagName("NextContinuationToken");
+        if (token_nodes->length() > 0)
+            continuation_token = token_nodes->item(0)->innerText();
+    } while (!continuation_token.empty());
 }
 
 ReadSettings WasmWebObjectStorage::patchSettings(const ReadSettings & read_settings) const

--- a/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.cpp
@@ -5,6 +5,7 @@
 #include <Common/Exception.h>
 #include <Common/ObjectStorageKeyGenerator.h>
 #include <IO/ReadBufferFromWebFetch.h>
+#include <IO/ReadHelpers.h>
 #include <IO/ReadSettings.h>
 #include <IO/WasmHTTPBridge.h>
 #include <IO/WasmS3Auth.h>
@@ -118,8 +119,10 @@ std::optional<ObjectMetadata> WasmWebObjectStorage::tryGetObjectMetadata(const s
         std::string value(line.substr(colon + 2));
         if (Poco::icompare(name, "Content-Length") == 0)
         {
-            metadata.size_bytes = std::stoull(value);
-            metadata.is_size_known = true;
+            /// tryParse: a malformed server-supplied length must degrade to
+            /// "size unknown", not escape as std::invalid_argument.
+            if (tryParse(metadata.size_bytes, value))
+                metadata.is_size_known = true;
         }
         else if (Poco::icompare(name, "ETag") == 0)
             metadata.etag = value;
@@ -208,8 +211,8 @@ void WasmWebObjectStorage::listObjects(const std::string & path, RelativePathsWi
             metadata.is_size_known = false;
             if (const auto * size_node = element->getChildElement("Size"))
             {
-                metadata.size_bytes = std::stoull(size_node->innerText());
-                metadata.is_size_known = true;
+                if (tryParse(metadata.size_bytes, size_node->innerText()))
+                    metadata.is_size_known = true;
             }
             if (const auto * etag_node = element->getChildElement("ETag"))
                 metadata.etag = etag_node->innerText();

--- a/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#if defined(OS_WASM)
+
+#include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
+#include <IO/HTTPHeaderEntries.h>
+
+namespace DB
+{
+
+struct WasmWebObjectStorageSettings
+{
+    /// http(s) URL prefix that object keys are appended to, without a trailing
+    /// slash. For S3 this is the (virtual-hosted or path-style) bucket root.
+    String base_url;
+
+    /// When access_key_id is set, every request carries AWS SigV4 headers
+    /// (computed per request — the signature covers the method and expires).
+    String region;
+    String access_key_id;
+    String secret_access_key;
+    String session_token;
+
+    /// Extra headers attached to every request (e.g. a vended Bearer token).
+    HTTPHeaderEntries static_headers;
+};
+
+/// Read-only object storage for the WASM build: objects are fetched over
+/// http(s) through the host JavaScript environment (ReadBufferFromWebFetch /
+/// WasmHTTPBridge), since neither raw sockets nor the AWS SDK exist here.
+/// Serves the data plane of data-lake tables (Iceberg/Paimon/DeltaLake) whose
+/// object keys are known from catalog + table metadata, so listing is not
+/// required; writes and listing throw NOT_IMPLEMENTED.
+class WasmWebObjectStorage : public IObjectStorage
+{
+public:
+    explicit WasmWebObjectStorage(WasmWebObjectStorageSettings settings_);
+
+    std::string getName() const override { return "WasmWeb"; }
+
+    ObjectStorageType getType() const override { return ObjectStorageType::Web; }
+
+    std::string getCommonKeyPrefix() const override { return ""; }
+
+    std::string getDescription() const override { return settings.base_url; }
+
+    bool isReadOnly() const override { return true; }
+
+    bool isRemote() const override { return true; }
+
+    bool exists(const StoredObject & object) const override;
+
+    std::unique_ptr<ReadBufferFromFileBase> readObject( /// NOLINT
+        const StoredObject & object,
+        const ReadSettings & read_settings,
+        std::optional<size_t> read_hint = {}) const override;
+
+    std::unique_ptr<WriteBufferFromFileBase> writeObject( /// NOLINT
+        const StoredObject & object,
+        WriteMode mode,
+        std::optional<ObjectAttributes> attributes = {},
+        size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
+        const WriteSettings & write_settings = {}) override;
+
+    void removeObjectIfExists(const StoredObject & object) override;
+
+    void removeObjectsIfExist(const StoredObjects & objects) override;
+
+    ObjectMetadata getObjectMetadata(const std::string & path, bool with_tags) const override;
+
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path, bool with_tags) const override;
+
+    void copyObject( /// NOLINT
+        const StoredObject & object_from,
+        const StoredObject & object_to,
+        const ReadSettings & read_settings,
+        const WriteSettings & write_settings,
+        std::optional<ObjectAttributes> object_to_attributes = {}) override;
+
+    void shutdown() override {}
+
+    void startup() override {}
+
+    String getObjectsNamespace() const override { return ""; }
+
+    ObjectStorageKeyGeneratorPtr createKeyGenerator() const override;
+
+    ReadSettings patchSettings(const ReadSettings & read_settings) const override;
+
+private:
+    String urlFor(const std::string & path) const;
+    HTTPHeaderEntries headersFor(const String & method, const String & url) const;
+    [[noreturn]] void throwReadOnly() const;
+
+    WasmWebObjectStorageSettings settings;
+};
+
+}
+
+#endif

--- a/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.h
@@ -14,6 +14,11 @@ struct WasmWebObjectStorageSettings
     /// slash. For S3 this is the (virtual-hosted or path-style) bucket root.
     String base_url;
 
+    /// S3 bucket name, used by listObjects (ListObjectsV2). With a path-style
+    /// endpoint the bucket is the first segment of every object key; with a
+    /// virtual-hosted URL it is part of the host and absent from keys.
+    String bucket;
+
     /// When access_key_id is set, every request carries AWS SigV4 headers
     /// (computed per request — the signature covers the method and expires).
     String region;
@@ -69,6 +74,10 @@ public:
     ObjectMetadata getObjectMetadata(const std::string & path, bool with_tags) const override;
 
     std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path, bool with_tags) const override;
+
+    /// S3 ListObjectsV2 with pagination (data lakes use it to discover metadata
+    /// versions / log files when the catalog does not pin them explicitly).
+    void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
 
     void copyObject( /// NOLINT
         const StoredObject & object_from,

--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -6,6 +6,10 @@
 
 #include "config.h"
 
+#if defined(OS_WASM)
+#    include <IO/WasmHTTPSession.h>
+#endif
+
 #if USE_SSL
 #    include <Poco/Net/AcceptCertificateHandler.h>
 #    include <Poco/Net/Context.h>
@@ -54,8 +58,19 @@ HTTPSessionPtr makeHTTPSession(
     const ProxyConfiguration & proxy_configuration,
     UInt64 * connect_time)
 {
+#if defined(OS_WASM)
+    /// Raw sockets don't exist on WASM, so the pool (and Poco's socket-backed
+    /// sessions) can never connect. Every HTTP client path gets a session that
+    /// performs the exchange through the host JS environment instead.
+    (void)group;
+    (void)timeouts;
+    (void)proxy_configuration;
+    (void)connect_time;
+    return std::make_shared<WasmHTTPSession>(uri);
+#else
     auto connection_pool = HTTPConnectionPools::instance().getPool(group, uri, proxy_configuration);
     return connection_pool->getConnection(timeouts, connect_time);
+#endif
 }
 
 bool isRedirect(const Poco::Net::HTTPResponse::HTTPStatus status) { return status == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY  || status == Poco::Net::HTTPResponse::HTTP_FOUND || status == Poco::Net::HTTPResponse::HTTP_SEE_OTHER  || status == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT; }

--- a/src/IO/ReadBufferFromWebFetch.cpp
+++ b/src/IO/ReadBufferFromWebFetch.cpp
@@ -2,8 +2,10 @@
 
 #if defined(OS_WASM)
 
+#include <IO/WasmHTTPBridge.h>
 #include <Common/Exception.h>
-#include <emscripten.h>
+
+#include <Poco/String.h>
 
 namespace DB
 {
@@ -14,100 +16,52 @@ namespace ErrorCodes
     extern const int CANNOT_SEEK_THROUGH_FILE;
 }
 
-/// Synchronous XHR helpers, run in the module's JS runtime (a Web Worker, where
-/// synchronous XHR with a binary responseType is permitted). Return -1 on error.
-/// Pointer arguments arrive as BigInt under -sMEMORY64, so they are normalized
-/// with Number() before use. `headers_ptr` is a newline-delimited "Name: value"
-/// blob; each line is applied via setRequestHeader (used by s3() for SigV4 auth).
-/// chdb_web_read copies the fetched bytes into the wasm heap at `dst`.
+namespace
+{
 
-EM_JS(double, chdb_web_read, (const char * url_ptr, double offset, double length, const char * headers_ptr, char * dst), {
-    try {
-        var url = UTF8ToString(Number(url_ptr));
-        var off = offset;
-        var len = length;
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', url, false);  // synchronous
-        xhr.responseType = 'arraybuffer';
-        var hp = Number(headers_ptr);
-        if (hp) {
-            var blob = UTF8ToString(hp);
-            if (blob) {
-                var lines = blob.split('\n');
-                for (var i = 0; i < lines.length; i++) {
-                    var line = lines[i];
-                    if (!line) continue;
-                    var c = line.indexOf(': ');
-                    if (c > 0) { try { xhr.setRequestHeader(line.substring(0, c), line.substring(c + 2)); } catch (e) {} }
-                }
-            }
-        }
-        xhr.setRequestHeader('Range', 'bytes=' + off + '-' + (off + len - 1));
-        xhr.send();
-        if (xhr.status === 416) return 0;            // range not satisfiable -> EOF
-        if (xhr.status === 404) return -404;         // not found -> caller may skip (vs generic error)
-        if (xhr.status !== 200 && xhr.status !== 206) return -1;
-        var all = new Uint8Array(xhr.response);
-        // A 206 returns just the requested range; a 200 means the server ignored
-        // Range and returned the whole body, so slice out the [off, off+len) window
-        // (empty once off is past the end -> EOF) to keep sequential reads correct.
-        var src = (xhr.status === 200) ? all.subarray(off, off + len) : all.subarray(0, len);
-        var n = src.length;
-        HEAPU8.set(src, Number(dst));
-        return n;
-    } catch (e) {
-        return -1;
+void appendHeadersBlob(std::string & blob, const HTTPHeaderEntries & entries)
+{
+    for (const auto & entry : entries)
+    {
+        blob += entry.name;
+        blob += ": ";
+        blob += entry.value;
+        blob += '\n';
     }
-});
+}
 
-EM_JS(double, chdb_web_size, (const char * url_ptr, const char * headers_ptr), {
-    try {
-        var url = UTF8ToString(Number(url_ptr));
-        var xhr = new XMLHttpRequest();
-        xhr.open('HEAD', url, false);
-        var hp = Number(headers_ptr);
-        if (hp) {
-            var blob = UTF8ToString(hp);
-            if (blob) {
-                var lines = blob.split('\n');
-                for (var i = 0; i < lines.length; i++) {
-                    var line = lines[i];
-                    if (!line) continue;
-                    var c = line.indexOf(': ');
-                    if (c > 0) { try { xhr.setRequestHeader(line.substring(0, c), line.substring(c + 2)); } catch (e) {} }
-                }
-            }
-        }
-        xhr.send();
-        if (xhr.status >= 200 && xhr.status < 300) {
-            var cl = xhr.getResponseHeader('Content-Length');
-            if (cl) return parseInt(cl, 10);
-        }
-        return -1;
-    } catch (e) {
-        return -1;
-    }
-});
+}
 
 ReadBufferFromWebFetch::ReadBufferFromWebFetch(
-    std::string url_, HTTPHeaderEntries headers_, size_t buffer_size, bool skip_not_found_)
-    : SeekableReadBuffer(nullptr, 0), url(std::move(url_)), headers(std::move(headers_)), buffer(buffer_size)
+    std::string url_, HTTPHeaderEntries headers_, size_t buffer_size, bool skip_not_found_, HeadersProvider headers_provider_)
+    : ReadBufferFromFileBase(buffer_size, nullptr, 0)
+    , url(std::move(url_))
+    , headers(std::move(headers_))
+    , headers_provider(std::move(headers_provider_))
     , skip_not_found(skip_not_found_)
 {
-    for (const auto & entry : headers)
-    {
-        headers_blob += entry.name;
-        headers_blob += ": ";
-        headers_blob += entry.value;
-        headers_blob += '\n';
-    }
+    appendHeadersBlob(headers_blob, headers);
+}
+
+std::string ReadBufferFromWebFetch::headersBlobFor(const std::string & method) const
+{
+    if (!headers_provider)
+        return headers_blob;
+    std::string blob = headers_blob;
+    appendHeadersBlob(blob, headers_provider(method));
+    return blob;
 }
 
 bool ReadBufferFromWebFetch::nextImpl()
 {
-    double n = chdb_web_read(
-        url.c_str(), static_cast<double>(read_offset), static_cast<double>(buffer.size()), headers_blob.c_str(), buffer.data());
-    if (n == -404)
+    /// The bridge adds the Range header and, if the server ignores it (200),
+    /// slices the requested window out before copying into wasm memory.
+    auto result = performWasmHTTPRequest(
+        "GET", url, headersBlobFor("GET"), {}, static_cast<long long>(read_offset), static_cast<long long>(memory.size()));
+
+    if (result.status == 416)
+        return false;  /// range not satisfiable -> EOF
+    if (result.status == 404)
     {
         /// 404: when skipping is requested (http_skip_not_found_url_for_globs), treat it as
         /// an empty file so the URL is skipped rather than failing the read.
@@ -115,13 +69,17 @@ bool ReadBufferFromWebFetch::nextImpl()
             return false;
         throw Exception(ErrorCodes::NETWORK_ERROR, "Not found (HTTP 404): '{}'", url);
     }
-    if (n < 0)
-        throw Exception(ErrorCodes::NETWORK_ERROR, "Failed to fetch '{}' (range at offset {})", url, read_offset);
+    if (result.status != 200 && result.status != 206)
+        throw Exception(
+            ErrorCodes::NETWORK_ERROR, "Failed to fetch '{}' (range at offset {}, HTTP status {})", url, read_offset, result.status);
+
+    size_t n = std::min(result.body.size(), memory.size());
     if (n == 0)
-        return false;  // EOF
+        return false;  /// EOF
+    memcpy(memory.data(), result.body.data(), n);
 
     read_offset += static_cast<off_t>(n);
-    working_buffer = internal_buffer = Buffer(buffer.data(), buffer.data() + static_cast<size_t>(n));
+    working_buffer = internal_buffer = Buffer(memory.data(), memory.data() + n);
     pos = working_buffer.begin();
     return true;
 }
@@ -150,12 +108,31 @@ off_t ReadBufferFromWebFetch::getPosition()
 
 std::optional<size_t> ReadBufferFromWebFetch::tryGetFileSize()
 {
-    if (!file_size_queried)
+    if (!file_size_queried && !file_size)
     {
         file_size_queried = true;
-        double sz = chdb_web_size(url.c_str(), headers_blob.c_str());
-        if (sz >= 0)
-            file_size = static_cast<size_t>(sz);
+        auto result = performWasmHTTPRequest("HEAD", url, headersBlobFor("HEAD"), {});
+        if (result.status >= 200 && result.status < 300)
+        {
+            size_t line_start = 0;
+            while (line_start < result.headers.size())
+            {
+                size_t line_end = result.headers.find('\n', line_start);
+                if (line_end == std::string::npos)
+                    line_end = result.headers.size();
+                std::string_view line(result.headers.data() + line_start, line_end - line_start);
+                line_start = line_end + 1;
+
+                size_t colon = line.find(": ");
+                if (colon == std::string_view::npos)
+                    continue;
+                if (Poco::icompare(std::string(line.substr(0, colon)), "Content-Length") == 0)
+                {
+                    file_size = std::stoull(std::string(line.substr(colon + 2)));
+                    break;
+                }
+            }
+        }
     }
     return file_size;
 }

--- a/src/IO/ReadBufferFromWebFetch.cpp
+++ b/src/IO/ReadBufferFromWebFetch.cpp
@@ -33,8 +33,9 @@ void appendHeadersBlob(std::string & blob, const HTTPHeaderEntries & entries)
 }
 
 ReadBufferFromWebFetch::ReadBufferFromWebFetch(
-    std::string url_, HTTPHeaderEntries headers_, size_t buffer_size, bool skip_not_found_, HeadersProvider headers_provider_)
-    : ReadBufferFromFileBase(buffer_size, nullptr, 0)
+    std::string url_, HTTPHeaderEntries headers_, size_t buffer_size, bool skip_not_found_, HeadersProvider headers_provider_,
+    std::optional<size_t> known_file_size_)
+    : ReadBufferFromFileBase(buffer_size, nullptr, 0, known_file_size_)
     , url(std::move(url_))
     , headers(std::move(headers_))
     , headers_provider(std::move(headers_provider_))

--- a/src/IO/ReadBufferFromWebFetch.cpp
+++ b/src/IO/ReadBufferFromWebFetch.cpp
@@ -2,6 +2,7 @@
 
 #if defined(OS_WASM)
 
+#include <IO/ReadHelpers.h>
 #include <IO/WasmHTTPBridge.h>
 #include <Common/Exception.h>
 
@@ -129,7 +130,11 @@ std::optional<size_t> ReadBufferFromWebFetch::tryGetFileSize()
                     continue;
                 if (Poco::icompare(std::string(line.substr(0, colon)), "Content-Length") == 0)
                 {
-                    file_size = std::stoull(std::string(line.substr(colon + 2)));
+                    /// tryParse: a malformed Content-Length degrades to "size
+                    /// unknown" instead of escaping as std::invalid_argument.
+                    UInt64 parsed_size = 0;
+                    if (tryParse(parsed_size, std::string(line.substr(colon + 2))))
+                        file_size = parsed_size;
                     break;
                 }
             }

--- a/src/IO/ReadBufferFromWebFetch.h
+++ b/src/IO/ReadBufferFromWebFetch.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <IO/SeekableReadBuffer.h>
-#include <IO/WithFileName.h>
-#include <IO/WithFileSize.h>
+#include <IO/ReadBufferFromFileBase.h>
 #include <IO/HTTPHeaderEntries.h>
 #include <Core/Defines.h>
 
+#include <functional>
 #include <optional>
 #include <string>
-#include <vector>
 
 namespace DB
 {
@@ -19,14 +17,21 @@ namespace DB
 /// socket — it asks JS to fetch a byte range and copies the bytes into wasm memory.
 /// Reads are sequential-friendly (CSV/JSON/etc.); seek() is supported via Range.
 /// Optional request headers are forwarded to the XHR (used by s3() for SigV4 auth).
-class ReadBufferFromWebFetch : public SeekableReadBuffer, public WithFileName, public WithFileSize
+/// Inherits ReadBufferFromFileBase so it can serve as an IObjectStorage read buffer.
+class ReadBufferFromWebFetch : public ReadBufferFromFileBase
 {
 public:
+    /// Called per HTTP request with the method ("GET" for range reads, "HEAD" for
+    /// size queries) to produce fresh request headers. Needed for AWS SigV4, whose
+    /// signature covers the method and expires after a clock-skew window — static
+    /// headers would go stale over long scans and be invalid for HEAD.
+    using HeadersProvider = std::function<HTTPHeaderEntries(const std::string & method)>;
+
     /// skip_not_found_: when true, a 404 is treated as end-of-file (empty) instead of an
     /// error — mirrors the native withSkipNotFound() used for http_skip_not_found_url_for_globs.
     explicit ReadBufferFromWebFetch(
         std::string url_, HTTPHeaderEntries headers_ = {}, size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE,
-        bool skip_not_found_ = false);
+        bool skip_not_found_ = false, HeadersProvider headers_provider_ = {});
 
     off_t seek(off_t off, int whence) override;
     off_t getPosition() override;
@@ -36,14 +41,15 @@ public:
 private:
     bool nextImpl() override;
 
+    std::string headersBlobFor(const std::string & method) const;
+
     std::string url;
     HTTPHeaderEntries headers;
     /// Pre-serialized "Name: value\n..." blob handed to the JS side (XHR setRequestHeader).
     std::string headers_blob;
-    std::vector<char> buffer;
+    HeadersProvider headers_provider;
     /// Absolute byte offset of the next range read (i.e. of internal_buffer's start once filled).
     off_t read_offset = 0;
-    std::optional<size_t> file_size;
     bool file_size_queried = false;
     bool skip_not_found = false;
 };

--- a/src/IO/ReadBufferFromWebFetch.h
+++ b/src/IO/ReadBufferFromWebFetch.h
@@ -29,9 +29,12 @@ public:
 
     /// skip_not_found_: when true, a 404 is treated as end-of-file (empty) instead of an
     /// error — mirrors the native withSkipNotFound() used for http_skip_not_found_url_for_globs.
+    /// known_file_size_: pre-known object size (e.g. from data-lake manifests); avoids the
+    /// HEAD request tryGetFileSize() would otherwise issue (some endpoints only permit GET).
     explicit ReadBufferFromWebFetch(
         std::string url_, HTTPHeaderEntries headers_ = {}, size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE,
-        bool skip_not_found_ = false, HeadersProvider headers_provider_ = {});
+        bool skip_not_found_ = false, HeadersProvider headers_provider_ = {},
+        std::optional<size_t> known_file_size_ = std::nullopt);
 
     off_t seek(off_t off, int whence) override;
     off_t getPosition() override;

--- a/src/IO/WasmHTTPBridge.cpp
+++ b/src/IO/WasmHTTPBridge.cpp
@@ -1,0 +1,168 @@
+#include <IO/WasmHTTPBridge.h>
+
+#if defined(OS_WASM)
+
+#include <cstdint>
+#include <cstdlib>
+
+#include <emscripten.h>
+
+namespace DB
+{
+
+/// Performs one synchronous HTTP request in the calling pthread's JS context.
+/// Browser: synchronous XMLHttpRequest (legal on worker threads, where every
+/// wasm pthread lives). Node: no in-process synchronous fetch exists, so a
+/// short-lived `node -e` child performs the fetch and streams the response back
+/// over stdout as JSON (status / headers / base64 body).
+///
+/// Pointer arguments arrive as BigInt under -sMEMORY64 and are normalized with
+/// Number(). Variable-size outputs (headers, body) are _malloc'ed by JS and
+/// their {ptr,len} written into the 5x int64 `out` struct:
+///   [0] status  [1] headers ptr  [2] headers len  [3] body ptr  [4] body len
+/// The C++ caller owns (frees) the two allocations. Returns 0 on success, -1
+/// when no transport is available or the request failed outright.
+EM_JS(int, chdb_wasm_http_request_js, (
+    const char * method_ptr, const char * url_ptr, const char * headers_ptr,
+    const char * body_ptr, double body_len,
+    double range_offset, double range_length,
+    char * out_ptr), {
+    try {
+        var method = UTF8ToString(Number(method_ptr));
+        var url = UTF8ToString(Number(url_ptr));
+        var headersBlob = UTF8ToString(Number(headers_ptr));
+        var bodyLen = Number(body_len);
+        var reqBody = null;
+        if (bodyLen > 0) {
+            // Copy out of the (possibly shared) wasm heap: XHR/fetch reject SAB views.
+            reqBody = new Uint8Array(bodyLen);
+            reqBody.set(HEAPU8.subarray(Number(body_ptr), Number(body_ptr) + bodyLen));
+        }
+        var rangeOff = range_offset;
+        var rangeLen = range_length;
+        var status = -1;
+        var respHeaders = "";
+        var respBytes = null;
+        if (typeof XMLHttpRequest !== 'undefined') {
+            var xhr = new XMLHttpRequest();
+            xhr.open(method, url, false);  // synchronous; wasm pthreads run on worker threads where this is permitted
+            xhr.responseType = 'arraybuffer';
+            var lines = headersBlob ? headersBlob.split('\n') : [];
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i];
+                if (!line) continue;
+                var c = line.indexOf(': ');
+                // Forbidden request headers (Host, Connection, ...) make setRequestHeader throw; skip them.
+                if (c > 0) { try { xhr.setRequestHeader(line.substring(0, c), line.substring(c + 2)); } catch (e) {} }
+            }
+            if (rangeOff >= 0) xhr.setRequestHeader('Range', 'bytes=' + rangeOff + '-' + (rangeOff + rangeLen - 1));
+            xhr.send(reqBody);
+            status = xhr.status;
+            if (status === 0) return -1;  // network / CORS failure
+            // No regex literal here: EM_JS bodies survive string escapes but not regex escapes.
+            respHeaders = (xhr.getAllResponseHeaders() || "").split('\r\n').join('\n');
+            respBytes = xhr.response ? new Uint8Array(xhr.response) : new Uint8Array(0);
+        } else if (typeof process !== 'undefined' && typeof require !== 'undefined') {
+            var cp = require('node:child_process');
+            // NB: no backslash escapes in this script — EM_JS embedding + the JS
+            // minifier reprocess escape sequences and corrupt them; newlines are
+            // spelled String.fromCharCode(10) ("NL") so the text survives verbatim.
+            var script =
+                'var NL=String.fromCharCode(10);' +
+                'var m=process.argv[1],u=process.argv[2],hb=Buffer.from(process.argv[3],"base64").toString();' +
+                'var cs=[];process.stdin.on("data",function(c){cs.push(c)});' +
+                'process.stdin.on("end",function(){' +
+                'var h={};hb.split(NL).forEach(function(l){var i=l.indexOf(": ");if(i>0)h[l.slice(0,i)]=l.slice(i+2)});' +
+                'var b=Buffer.concat(cs);' +
+                'fetch(u,{method:m,headers:h,body:(b.length?b:undefined),redirect:"follow"}).then(async function(r){' +
+                'var ab=Buffer.from(await r.arrayBuffer());' +
+                'var hs="";r.headers.forEach(function(v,k){hs+=k+": "+v+NL});' +
+                'process.stdout.write(JSON.stringify({s:r.status,h:hs,b:ab.toString("base64")}));' +
+                '}).catch(function(e){process.stdout.write(JSON.stringify({s:-1,h:"",b:""}))});});';
+            var fullBlob = headersBlob || "";
+            if (rangeOff >= 0) fullBlob += (fullBlob ? "\n" : "") + 'Range: bytes=' + rangeOff + '-' + (rangeOff + rangeLen - 1);
+            var res = cp.spawnSync(
+                process.execPath, ['-e', script, method, url, Buffer.from(fullBlob).toString('base64')],
+                { input: reqBody ? Buffer.from(reqBody) : Buffer.alloc(0), maxBuffer: 1 << 30 });
+            if (res.status !== 0 || !res.stdout || !res.stdout.length) {
+                if (typeof console !== 'undefined')
+                    console.error('chdb wasm http bridge: fetch child failed', method, url, res.status, res.error || '', res.stderr ? res.stderr.toString() : '');
+                return -1;
+            }
+            var parsed = JSON.parse(res.stdout.toString());
+            if (parsed.s < 0) {
+                if (typeof console !== 'undefined') console.error('chdb wasm http bridge: fetch failed', method, url);
+                return -1;
+            }
+            status = parsed.s;
+            respHeaders = parsed.h;
+            respBytes = new Uint8Array(Buffer.from(parsed.b, 'base64'));
+        } else {
+            if (typeof console !== 'undefined')
+                console.error('chdb wasm http bridge: no transport (no XMLHttpRequest and no Node require) for', method, url);
+            return -1;
+        }
+        // A ranged request answered with 200 means the server ignored Range and
+        // sent the whole body; slice the requested window out here so only those
+        // bytes cross into wasm memory.
+        if (rangeOff >= 0 && status === 200 && respBytes)
+            respBytes = respBytes.subarray(rangeOff, rangeOff + rangeLen);
+        var hdrBytes = new TextEncoder().encode(respHeaders);
+        var hdrPtr = 0;
+        var bodyPtr = 0;
+        if (hdrBytes.length) { hdrPtr = _malloc(BigInt(hdrBytes.length)); HEAPU8.set(hdrBytes, Number(hdrPtr)); }
+        if (respBytes && respBytes.length) { bodyPtr = _malloc(BigInt(respBytes.length)); HEAPU8.set(respBytes, Number(bodyPtr)); }
+        var dv = new DataView(HEAPU8.buffer);
+        var out = Number(out_ptr);
+        dv.setBigInt64(out, BigInt(status), true);
+        dv.setBigInt64(out + 8, BigInt(hdrPtr), true);
+        dv.setBigInt64(out + 16, BigInt(hdrBytes.length), true);
+        dv.setBigInt64(out + 24, BigInt(bodyPtr), true);
+        dv.setBigInt64(out + 32, BigInt(respBytes ? respBytes.length : 0), true);
+        return 0;
+    } catch (e) {
+        // Surface the host-side cause (the C++ layer only sees "-1"): CORS
+        // rejections, missing transports, heap-view surprises all land here.
+        if (typeof console !== 'undefined') console.error('chdb wasm http bridge:', e);
+        return -1;
+    }
+});
+
+WasmHTTPResult performWasmHTTPRequest(
+    const std::string & method,
+    const std::string & url,
+    const std::string & headers_blob,
+    const std::string & body,
+    long long range_offset,
+    long long range_length)
+{
+    int64_t out[5] = {};
+    int rc = chdb_wasm_http_request_js(
+        method.c_str(), url.c_str(), headers_blob.c_str(),
+        body.data(), static_cast<double>(body.size()),
+        static_cast<double>(range_offset), static_cast<double>(range_length),
+        reinterpret_cast<char *>(out));
+
+    WasmHTTPResult result;
+    if (rc != 0)
+        return result;
+
+    result.status = static_cast<int>(out[0]);
+    if (out[1] != 0)
+    {
+        if (out[2] > 0)
+            result.headers.assign(reinterpret_cast<const char *>(out[1]), static_cast<size_t>(out[2]));
+        std::free(reinterpret_cast<void *>(out[1]));  /// NOLINT
+    }
+    if (out[3] != 0)
+    {
+        if (out[4] > 0)
+            result.body.assign(reinterpret_cast<const char *>(out[3]), static_cast<size_t>(out[4]));
+        std::free(reinterpret_cast<void *>(out[3]));  /// NOLINT
+    }
+    return result;
+}
+
+}
+
+#endif

--- a/src/IO/WasmHTTPBridge.cpp
+++ b/src/IO/WasmHTTPBridge.cpp
@@ -86,7 +86,7 @@ EM_JS(int, chdb_wasm_http_request_js, (
                 { input: reqBody ? Buffer.from(reqBody) : Buffer.alloc(0), maxBuffer: 1 << 30 });
             if (res.status !== 0 || !res.stdout || !res.stdout.length) {
                 if (typeof console !== 'undefined')
-                    console.error('chdb wasm http bridge: fetch child failed', method, url, res.status, res.error || '', res.stderr ? res.stderr.toString() : '');
+                    console.error('chdb wasm http bridge: fetch child failed', method, url, res.status, res.error || "", res.stderr ? res.stderr.toString() : "");
                 return -1;
             }
             var parsed = JSON.parse(res.stdout.toString());

--- a/src/IO/WasmHTTPBridge.cpp
+++ b/src/IO/WasmHTTPBridge.cpp
@@ -78,7 +78,7 @@ EM_JS(int, chdb_wasm_http_request_js, (
                 'var ab=Buffer.from(await r.arrayBuffer());' +
                 'var hs="";r.headers.forEach(function(v,k){hs+=k+": "+v+NL});' +
                 'process.stdout.write(JSON.stringify({s:r.status,h:hs,b:ab.toString("base64")}));' +
-                '}).catch(function(e){process.stdout.write(JSON.stringify({s:-1,h:"",b:""}))});});';
+                '}).catch(function(e){process.stdout.write(JSON.stringify({s:-1,h:"",b:"",m:String(e&&e.message||e)}))});});';
             var fullBlob = headersBlob || "";
             if (rangeOff >= 0) fullBlob += (fullBlob ? "\n" : "") + 'Range: bytes=' + rangeOff + '-' + (rangeOff + rangeLen - 1);
             var res = cp.spawnSync(
@@ -91,7 +91,10 @@ EM_JS(int, chdb_wasm_http_request_js, (
             }
             var parsed = JSON.parse(res.stdout.toString());
             if (parsed.s < 0) {
-                if (typeof console !== 'undefined') console.error('chdb wasm http bridge: fetch failed', method, url);
+                // parsed.m carries the child-side cause (DNS failure, connection refused,
+                // V8 string cap on huge unranged bodies, ...) — without it every failure
+                // would be an indistinguishable NETWORK_ERROR.
+                if (typeof console !== 'undefined') console.error('chdb wasm http bridge: fetch failed', method, url, parsed.m || "");
                 return -1;
             }
             status = parsed.s;
@@ -110,8 +113,18 @@ EM_JS(int, chdb_wasm_http_request_js, (
         var hdrBytes = new TextEncoder().encode(respHeaders);
         var hdrPtr = 0;
         var bodyPtr = 0;
-        if (hdrBytes.length) { hdrPtr = _malloc(BigInt(hdrBytes.length)); HEAPU8.set(hdrBytes, Number(hdrPtr)); }
-        if (respBytes && respBytes.length) { bodyPtr = _malloc(BigInt(respBytes.length)); HEAPU8.set(respBytes, Number(bodyPtr)); }
+        // With ALLOW_MEMORY_GROWTH malloc returns 0 on OOM instead of aborting;
+        // writing at address 0 would smash static data and surface as silent EOF.
+        if (hdrBytes.length) {
+            hdrPtr = _malloc(BigInt(hdrBytes.length));
+            if (!Number(hdrPtr)) throw new Error('bridge OOM allocating ' + hdrBytes.length + ' header bytes');
+            HEAPU8.set(hdrBytes, Number(hdrPtr));
+        }
+        if (respBytes && respBytes.length) {
+            bodyPtr = _malloc(BigInt(respBytes.length));
+            if (!Number(bodyPtr)) { if (Number(hdrPtr)) _free(hdrPtr); throw new Error('bridge OOM allocating ' + respBytes.length + ' body bytes'); }
+            HEAPU8.set(respBytes, Number(bodyPtr));
+        }
         var dv = new DataView(HEAPU8.buffer);
         var out = Number(out_ptr);
         dv.setBigInt64(out, BigInt(status), true);

--- a/src/IO/WasmHTTPBridge.h
+++ b/src/IO/WasmHTTPBridge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(OS_WASM)
+
 #include <string>
 
 namespace DB
@@ -37,3 +39,5 @@ WasmHTTPResult performWasmHTTPRequest(
     long long range_length = -1);
 
 }
+
+#endif

--- a/src/IO/WasmHTTPBridge.h
+++ b/src/IO/WasmHTTPBridge.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+
+namespace DB
+{
+
+/// One synchronous HTTP request performed by the host JavaScript environment,
+/// for the WASM build where raw sockets (and thus Poco/curl based HTTP) are
+/// unavailable. In a browser this is a synchronous XMLHttpRequest running on
+/// the calling pthread's Web Worker (where sync XHR with a binary responseType
+/// is permitted); under Node.js it shells out to a short-lived `node -e` child
+/// process that runs fetch() and returns the response over stdout. TLS,
+/// redirects and content decoding are all handled by the host.
+struct WasmHTTPResult
+{
+    /// HTTP status code, or -1 when the request could not be performed at all
+    /// (network error, environment without a usable transport, ...).
+    int status = -1;
+    /// Raw response headers, newline-delimited "Name: value" lines.
+    std::string headers;
+    std::string body;
+};
+
+/// headers_blob is a newline-delimited "Name: value" blob (same wire format as
+/// ReadBufferFromWebFetch); forbidden/hop-by-hop headers are skipped by the host.
+/// When range_offset >= 0, a "Range: bytes=<offset>-<offset+length-1>" header is
+/// added and, if the server ignores it (HTTP 200 instead of 206), the host slices
+/// the [offset, offset+length) window out of the full body *before* copying it
+/// into wasm memory, so callers never haul the whole file across per read.
+WasmHTTPResult performWasmHTTPRequest(
+    const std::string & method,
+    const std::string & url,
+    const std::string & headers_blob,
+    const std::string & body,
+    long long range_offset = -1,
+    long long range_length = -1);
+
+}

--- a/src/IO/WasmHTTPSession.cpp
+++ b/src/IO/WasmHTTPSession.cpp
@@ -1,0 +1,138 @@
+#include <IO/WasmHTTPSession.h>
+
+#if defined(OS_WASM)
+
+#include <IO/WasmHTTPBridge.h>
+#include <Common/Exception.h>
+
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/String.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NETWORK_ERROR;
+}
+
+namespace
+{
+
+/// Headers the host HTTP stack manages itself; forwarding them is at best a
+/// no-op (XHR rejects forbidden headers) and at worst inconsistent with the
+/// re-framed body (Content-Length/Transfer-Encoding after buffering).
+bool isHopByHopHeader(const std::string & name)
+{
+    return Poco::icompare(name, "Host") == 0
+        || Poco::icompare(name, "Connection") == 0
+        || Poco::icompare(name, "Content-Length") == 0
+        || Poco::icompare(name, "Transfer-Encoding") == 0
+        || Poco::icompare(name, "Keep-Alive") == 0
+        || Poco::icompare(name, "Proxy-Connection") == 0
+        || Poco::icompare(name, "Expect") == 0;
+}
+
+}
+
+WasmHTTPSession::WasmHTTPSession(const Poco::URI & uri)
+    : Poco::Net::HTTPClientSession(uri.getHost(), uri.getPort())
+    , base_url(uri.getScheme() + "://" + uri.getAuthority())
+    , https(Poco::icompare(uri.getScheme(), "https") == 0)
+{
+}
+
+std::ostream & WasmHTTPSession::sendRequest(Poco::Net::HTTPRequest & request, uint64_t *, uint64_t *)
+{
+    pending_method = request.getMethod();
+    pending_uri = request.getURI();
+    pending_headers.clear();
+    for (const auto & [name, value] : request)
+    {
+        if (isHopByHopHeader(name))
+            continue;
+        pending_headers += name;
+        pending_headers += ": ";
+        pending_headers += value;
+        pending_headers += '\n';
+    }
+    response_stream.reset();
+    response_buf.reset();
+    request_body.emplace();
+    return *request_body;
+}
+
+std::istream & WasmHTTPSession::receiveResponse(Poco::Net::HTTPResponse & response)
+{
+    /// The request URI is normally in origin form (path + query); proxy requests
+    /// may carry an absolute URL — pass those through untouched.
+    std::string url;
+    if (pending_uri.starts_with("http://") || pending_uri.starts_with("https://"))
+        url = pending_uri;
+    else if (pending_uri.empty() || pending_uri[0] != '/')
+        url = base_url + "/" + pending_uri;
+    else
+        url = base_url + pending_uri;
+
+    auto result = performWasmHTTPRequest(pending_method, url, pending_headers, request_body ? request_body->str() : std::string{});
+    request_body.reset();
+
+    if (result.status < 0)
+        throw Exception(ErrorCodes::NETWORK_ERROR, "Failed to perform HTTP request to '{}' through the WASM host environment", url);
+
+    response.clear();
+    response.setStatusAndReason(static_cast<Poco::Net::HTTPResponse::HTTPStatus>(result.status));
+    size_t line_start = 0;
+    while (line_start < result.headers.size())
+    {
+        size_t line_end = result.headers.find('\n', line_start);
+        if (line_end == std::string::npos)
+            line_end = result.headers.size();
+        std::string_view line(result.headers.data() + line_start, line_end - line_start);
+        line_start = line_end + 1;
+
+        size_t colon = line.find(": ");
+        if (colon == std::string_view::npos || colon == 0)
+            continue;
+        std::string name(line.substr(0, colon));
+        std::string value(line.substr(colon + 2));
+        /// The host already decoded the body and its length may differ from the
+        /// wire values; the real length is set below.
+        if (Poco::icompare(name, "Content-Length") == 0
+            || Poco::icompare(name, "Content-Encoding") == 0
+            || Poco::icompare(name, "Transfer-Encoding") == 0)
+            continue;
+        response.add(name, value);
+    }
+    response.setContentLength(static_cast<std::streamsize>(result.body.size()));
+
+    response_stream.reset();
+    response_buf.emplace(std::move(result.body));
+    response_stream.emplace(&*response_buf);
+    return *response_stream;
+}
+
+void WasmHTTPSession::flushRequest()
+{
+    /// The body is buffered until receiveResponse(); nothing to flush.
+}
+
+void WasmHTTPSession::reset()
+{
+    pending_method.clear();
+    pending_uri.clear();
+    pending_headers.clear();
+    request_body.reset();
+    response_stream.reset();
+    response_buf.reset();
+}
+
+bool WasmHTTPSession::secure() const
+{
+    return https;
+}
+
+}
+
+#endif

--- a/src/IO/WasmHTTPSession.h
+++ b/src/IO/WasmHTTPSession.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#if defined(OS_WASM)
+
+#include <Poco/Net/HTTPBasicStreamBuf.h>
+#include <Poco/Net/HTTPClientSession.h>
+#include <Poco/URI.h>
+
+#include <cstring>
+#include <istream>
+#include <optional>
+#include <sstream>
+#include <string>
+
+namespace DB
+{
+
+/// HTTP "session" for the WASM build: no socket is ever opened. sendRequest()
+/// only records the request line/headers and hands back a buffer for the body;
+/// receiveResponse() then performs the whole exchange as one synchronous HTTP
+/// request through the host JavaScript environment (WasmHTTPBridge) and returns
+/// an in-memory stream over the fully-buffered response body. Plugged in behind
+/// makeHTTPSession(), so every ClickHouse HTTP client path (ReadWriteBufferFromHTTP,
+/// data-lake REST catalogs, OAuth token fetches, ...) transparently rides the
+/// browser's fetch stack — which also supplies TLS, redirects and proxying.
+/// Intended for small control-plane exchanges; bulk data reads should keep using
+/// the range-based ReadBufferFromWebFetch, which never buffers whole files.
+class WasmHTTPSession : public Poco::Net::HTTPClientSession
+{
+public:
+    explicit WasmHTTPSession(const Poco::URI & uri);
+
+    std::ostream & sendRequest(Poco::Net::HTTPRequest & request, uint64_t * connect_time, uint64_t * first_byte_time) override;
+    std::istream & receiveResponse(Poco::Net::HTTPResponse & response) override;
+    void flushRequest() override;
+    void reset() override;
+    bool secure() const override;
+
+private:
+    /// In-memory "device" for the fully-buffered response body. Consumers
+    /// (ReadBufferFromIStream) require the response istream to be backed by an
+    /// HTTPBasicStreamBuf and read through readFromDevice() directly.
+    class ResponseStreamBuf : public Poco::Net::HTTPBasicStreamBuf
+    {
+    public:
+        explicit ResponseStreamBuf(std::string body_)
+            : Poco::Net::HTTPBasicStreamBuf(Poco::Net::HTTP_DEFAULT_BUFFER_SIZE, std::ios::in), body(std::move(body_))
+        {
+        }
+
+        int readFromDevice(char * buffer, std::streamsize length) override
+        {
+            size_t n = std::min(static_cast<size_t>(length), body.size() - offset);
+            if (n == 0)
+                return 0;  /// EOF
+            memcpy(buffer, body.data() + offset, n);
+            offset += n;
+            return static_cast<int>(n);
+        }
+
+    private:
+        std::string body;
+        size_t offset = 0;
+    };
+
+    /// scheme://host[:port]; the per-request URI (path + query) is appended.
+    std::string base_url;
+    bool https = false;
+
+    std::string pending_method;
+    std::string pending_uri;
+    std::string pending_headers;
+    std::optional<std::ostringstream> request_body;
+    std::optional<ResponseStreamBuf> response_buf;
+    std::optional<std::istream> response_stream;
+};
+
+}
+
+#endif

--- a/src/IO/WasmS3Auth.cpp
+++ b/src/IO/WasmS3Auth.cpp
@@ -79,6 +79,28 @@ void rewriteS3Source(const String & source, String & out_url, String & out_regio
     }
 }
 
+String uriEncode(const String & s, bool encode_slash)
+{
+    static const char hexu[] = "0123456789ABCDEF";
+    String out;
+    out.reserve(s.size());
+    for (unsigned char c : s)
+    {
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+            || c == '-' || c == '_' || c == '.' || c == '~')
+            out += static_cast<char>(c);
+        else if (c == '/' && !encode_slash)
+            out += '/';
+        else
+        {
+            out += '%';
+            out += hexu[c >> 4];
+            out += hexu[c & 0xf];
+        }
+    }
+    return out;
+}
+
 #if USE_SSL
 
 namespace
@@ -101,29 +123,6 @@ String sha256HexLower(const String & s)
 {
     const String raw = encodeSHA256(s); /// 32 raw bytes
     return toLowerHex(reinterpret_cast<const uint8_t *>(raw.data()), raw.size());
-}
-
-/// AWS RFC3986 percent-encoding. Leaves unreserved bytes; '/' is preserved in paths.
-String uriEncode(const String & s, bool encode_slash)
-{
-    static const char hexu[] = "0123456789ABCDEF";
-    String out;
-    out.reserve(s.size());
-    for (unsigned char c : s)
-    {
-        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
-            || c == '-' || c == '_' || c == '.' || c == '~')
-            out += static_cast<char>(c);
-        else if (c == '/' && !encode_slash)
-            out += '/';
-        else
-        {
-            out += '%';
-            out += hexu[c >> 4];
-            out += hexu[c & 0xf];
-        }
-    }
-    return out;
 }
 
 }

--- a/src/IO/WasmS3Auth.cpp
+++ b/src/IO/WasmS3Auth.cpp
@@ -1,0 +1,227 @@
+#include <IO/WasmS3Auth.h>
+
+#if defined(OS_WASM)
+
+#include "config.h"
+
+#include <Common/Exception.h>
+#include <Common/OpenSSLHelpers.h>
+#include <Poco/String.h>
+#include <Poco/URI.h>
+
+#include <algorithm>
+#include <cctype>
+#include <ctime>
+#include <vector>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int SUPPORT_IS_DISABLED;
+}
+
+namespace WasmS3
+{
+
+String extractRegionFromHost(const String & host)
+{
+    std::vector<String> tok;
+    size_t start = 0;
+    for (size_t i = 0; i <= host.size(); ++i)
+    {
+        if (i == host.size() || host[i] == '.')
+        {
+            tok.push_back(host.substr(start, i - start));
+            start = i + 1;
+        }
+    }
+    for (size_t i = 0; i < tok.size(); ++i)
+    {
+        if (tok[i] == "s3")
+        {
+            if (i + 1 < tok.size() && tok[i + 1] != "amazonaws")
+                return tok[i + 1];
+            return "us-east-1";
+        }
+        if (tok[i].rfind("s3-", 0) == 0 && tok[i].size() > 3)
+            return tok[i].substr(3);
+    }
+    return "us-east-1";
+}
+
+void rewriteS3Source(const String & source, String & out_url, String & out_region)
+{
+    Poco::URI uri(source);
+    String scheme = uri.getScheme();
+    std::transform(scheme.begin(), scheme.end(), scheme.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (scheme == "s3")
+    {
+        /// An s3:// URL carries no region: map to the region-agnostic virtual-hosted
+        /// endpoint (matching src/IO/S3/URI.cpp) and default the SigV4 region to us-east-1.
+        /// For a bucket outside us-east-1 *with credentials*, pass the full regional URL
+        /// (https://bucket.s3.<region>.amazonaws.com/...) so signing uses the right region.
+        out_region = "us-east-1";
+        const String bucket = uri.getHost();
+        String path = uri.getPath();
+        if (path.empty())
+            path = "/";
+        out_url = "https://" + bucket + ".s3.amazonaws.com" + path;
+        if (!uri.getRawQuery().empty())
+            out_url += "?" + uri.getRawQuery();
+    }
+    else
+    {
+        out_url = source;
+        out_region = extractRegionFromHost(uri.getHost());
+    }
+}
+
+#if USE_SSL
+
+namespace
+{
+
+String toLowerHex(const uint8_t * data, size_t n)
+{
+    static const char digits[] = "0123456789abcdef";
+    String out;
+    out.resize(n * 2);
+    for (size_t i = 0; i < n; ++i)
+    {
+        out[2 * i] = digits[data[i] >> 4];
+        out[2 * i + 1] = digits[data[i] & 0xf];
+    }
+    return out;
+}
+
+String sha256HexLower(const String & s)
+{
+    const String raw = encodeSHA256(s); /// 32 raw bytes
+    return toLowerHex(reinterpret_cast<const uint8_t *>(raw.data()), raw.size());
+}
+
+/// AWS RFC3986 percent-encoding. Leaves unreserved bytes; '/' is preserved in paths.
+String uriEncode(const String & s, bool encode_slash)
+{
+    static const char hexu[] = "0123456789ABCDEF";
+    String out;
+    out.reserve(s.size());
+    for (unsigned char c : s)
+    {
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+            || c == '-' || c == '_' || c == '.' || c == '~')
+            out += static_cast<char>(c);
+        else if (c == '/' && !encode_slash)
+            out += '/';
+        else
+        {
+            out += '%';
+            out += hexu[c >> 4];
+            out += hexu[c & 0xf];
+        }
+    }
+    return out;
+}
+
+}
+
+HTTPHeaderEntries signV4Request(
+    const String & method,
+    const String & url,
+    const String & region,
+    const String & access_key_id,
+    const String & secret_access_key,
+    const String & session_token)
+{
+    Poco::URI uri(url);
+    /// The signed host header must match what the transport sends: browsers and
+    /// fetch() include a non-default port ("127.0.0.1:9000" for MinIO/moto) and
+    /// omit the scheme's default port.
+    String host = uri.getHost();
+    const auto port = uri.getPort();  /// the scheme's well-known port when unspecified
+    const bool is_https = Poco::icompare(uri.getScheme(), "https") == 0;
+    if (port != 0 && port != (is_https ? 443 : 80))
+        host += ":" + std::to_string(port);
+    String path = uri.getPath();
+    if (path.empty())
+        path = "/";
+    const String canonical_uri = uriEncode(path, /*encode_slash=*/false);
+
+    std::vector<std::pair<String, String>> qparams;
+    for (const auto & p : uri.getQueryParameters())
+        qparams.emplace_back(uriEncode(p.first, true), uriEncode(p.second, true));
+    std::sort(qparams.begin(), qparams.end());
+    String canonical_query;
+    for (size_t i = 0; i < qparams.size(); ++i)
+    {
+        if (i)
+            canonical_query += '&';
+        canonical_query += qparams[i].first;
+        canonical_query += '=';
+        canonical_query += qparams[i].second;
+    }
+
+    const time_t now = time(nullptr);
+    struct tm tm_utc;
+    gmtime_r(&now, &tm_utc);
+    char amz_date[32];
+    char date_stamp[16];
+    strftime(amz_date, sizeof(amz_date), "%Y%m%dT%H%M%SZ", &tm_utc);
+    strftime(date_stamp, sizeof(date_stamp), "%Y%m%d", &tm_utc);
+
+    const String payload_hash = "UNSIGNED-PAYLOAD";
+    String signed_headers = "host;x-amz-content-sha256;x-amz-date";
+    String canonical_headers
+        = "host:" + host + "\n" + "x-amz-content-sha256:" + payload_hash + "\n" + "x-amz-date:" + String(amz_date) + "\n";
+    if (!session_token.empty())
+    {
+        signed_headers += ";x-amz-security-token";
+        canonical_headers += "x-amz-security-token:" + session_token + "\n";
+    }
+
+    const String canonical_request
+        = method + "\n" + canonical_uri + "\n" + canonical_query + "\n" + canonical_headers + "\n" + signed_headers + "\n" + payload_hash;
+
+    const String scope = String(date_stamp) + "/" + region + "/s3/aws4_request";
+    const String string_to_sign
+        = "AWS4-HMAC-SHA256\n" + String(amz_date) + "\n" + scope + "\n" + sha256HexLower(canonical_request);
+
+    const String key0 = "AWS4" + secret_access_key;
+    std::vector<uint8_t> k_secret(key0.begin(), key0.end());
+    const auto k_date = hmacSHA256(k_secret, String(date_stamp));
+    const auto k_region = hmacSHA256(k_date, region);
+    const auto k_service = hmacSHA256(k_region, "s3");
+    const auto k_signing = hmacSHA256(k_service, "aws4_request");
+    const auto sig = hmacSHA256(k_signing, string_to_sign);
+    const String signature = toLowerHex(sig.data(), sig.size());
+
+    const String authorization = "AWS4-HMAC-SHA256 Credential=" + access_key_id + "/" + scope
+        + ", SignedHeaders=" + signed_headers + ", Signature=" + signature;
+
+    HTTPHeaderEntries headers;
+    headers.emplace_back("x-amz-date", String(amz_date));
+    headers.emplace_back("x-amz-content-sha256", payload_hash);
+    headers.emplace_back("Authorization", authorization);
+    if (!session_token.empty())
+        headers.emplace_back("x-amz-security-token", session_token);
+    return headers;
+}
+
+#else
+
+HTTPHeaderEntries signV4Request(const String &, const String &, const String &, const String &, const String &, const String &)
+{
+    throw Exception(
+        ErrorCodes::SUPPORT_IS_DISABLED, "AWS SigV4 signing requires OpenSSL support, which is disabled in this build");
+}
+
+#endif
+
+}
+
+}
+
+#endif

--- a/src/IO/WasmS3Auth.h
+++ b/src/IO/WasmS3Auth.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(OS_WASM)
+
 #include <IO/HTTPHeaderEntries.h>
 #include <base/types.h>
 
@@ -32,3 +34,5 @@ HTTPHeaderEntries signV4Request(
     const String & session_token);
 
 }
+
+#endif

--- a/src/IO/WasmS3Auth.h
+++ b/src/IO/WasmS3Auth.h
@@ -22,6 +22,12 @@ String extractRegionFromHost(const String & host);
 /// http(s):// URLs are passed through unchanged.
 void rewriteS3Source(const String & source, String & out_url, String & out_region);
 
+/// AWS RFC3986 percent-encoding (the exact set SigV4 canonicalization uses).
+/// Leaves unreserved bytes; '/' is preserved in paths when encode_slash=false.
+/// Also used to build wire URLs for object keys, so what the transport sends is
+/// byte-identical to what the signature covers.
+String uriEncode(const String & s, bool encode_slash);
+
 /// AWS Signature V4 headers for a request with UNSIGNED-PAYLOAD (read-only use:
 /// GET / HEAD). The Range header is deliberately not signed, so one signature
 /// covers every range read of an object within the SigV4 clock-skew window.

--- a/src/IO/WasmS3Auth.h
+++ b/src/IO/WasmS3Auth.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <IO/HTTPHeaderEntries.h>
+#include <base/types.h>
+
+namespace DB::WasmS3
+{
+
+/// AWS auth helpers for the WASM build, where the AWS SDK is not compiled and
+/// S3 access rides plain HTTPS through the host JavaScript environment.
+/// Shared by the wasm s3() table function and the wasm data-lake object storage.
+
+/// Extract the AWS region from an S3 host, e.g.
+///   bucket.s3.eu-west-3.amazonaws.com -> eu-west-3
+///   bucket.s3.amazonaws.com           -> us-east-1
+///   s3.us-west-2.amazonaws.com        -> us-west-2
+String extractRegionFromHost(const String & host);
+
+/// s3://bucket/key -> https://bucket.s3.<region>.amazonaws.com/key (virtual-hosted).
+/// http(s):// URLs are passed through unchanged.
+void rewriteS3Source(const String & source, String & out_url, String & out_region);
+
+/// AWS Signature V4 headers for a request with UNSIGNED-PAYLOAD (read-only use:
+/// GET / HEAD). The Range header is deliberately not signed, so one signature
+/// covers every range read of an object within the SigV4 clock-skew window.
+HTTPHeaderEntries signV4Request(
+    const String & method,
+    const String & url,
+    const String & region,
+    const String & access_key_id,
+    const String & secret_access_key,
+    const String & session_token);
+
+}

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -17,6 +17,9 @@
 #include <Storages/ObjectStorage/HDFS/Configuration.h>
 #include <Storages/ObjectStorage/Local/Configuration.h>
 #include <Storages/ObjectStorage/S3/Configuration.h>
+#if defined(OS_WASM)
+#include <Storages/ObjectStorage/WasmWeb/Configuration.h>
+#endif
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/ColumnsDescription.h>
@@ -445,6 +448,14 @@ using StorageHDFSPaimonConfiguration = DataLakeConfiguration<StorageHDFSConfigur
 
 using StorageLocalIcebergConfiguration = DataLakeConfiguration<StorageLocalConfiguration, IcebergMetadata>;
 using StorageLocalPaimonConfiguration = DataLakeConfiguration<StorageLocalConfiguration, PaimonMetadata>;
+
+#if defined(OS_WASM)
+/// WASM data plane: table data is fetched over http(s) through the host JS
+/// environment (no AWS SDK / raw sockets), so s3:// table locations from a
+/// data-lake catalog map to these instead of the StorageS3Configuration ones.
+using StorageWasmWebIcebergConfiguration = DataLakeConfiguration<StorageWasmWebConfiguration, IcebergMetadata>;
+using StorageWasmWebPaimonConfiguration = DataLakeConfiguration<StorageWasmWebConfiguration, PaimonMetadata>;
+#endif
 #endif
 
 #if USE_PARQUET
@@ -457,6 +468,10 @@ using StorageAzureDeltaLakeConfiguration = DataLakeConfiguration<StorageAzureCon
 #endif
 
 using StorageLocalDeltaLakeConfiguration = DataLakeConfiguration<StorageLocalConfiguration, DeltaLakeMetadata>;
+
+#if defined(OS_WASM)
+using StorageWasmWebDeltaLakeConfiguration = DataLakeConfiguration<StorageWasmWebConfiguration, DeltaLakeMetadata>;
+#endif
 
 #endif
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -287,6 +287,10 @@ IcebergIterator::IcebergIterator(
     LOG_DEBUG(logger, "Taken {} position deletes file and {} equality deletes files in iceberg iterator", position_deletes_files.size(), equality_deletes_files.size());
     std::sort(equality_deletes_files.begin(), equality_deletes_files.end());
     std::sort(position_deletes_files.begin(), position_deletes_files.end());
+#ifdef CHDB_WASM_SINGLE_THREADED
+    /// Single-threaded WASM build: no thread can be spawned, so next() pulls
+    /// from data_files_iterator synchronously instead of via the producer.
+#else
     producer_task.emplace(
         [this, thread_group = CurrentThread::getGroup()]()
         {
@@ -320,13 +324,26 @@ IcebergIterator::IcebergIterator(
             }
             blocking_queue.finish();
         });
+#endif
 }
 
 ObjectInfoPtr IcebergIterator::next(size_t)
 {
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::IcebergMetadataReadWaitTimeMicroseconds);
     Iceberg::ProcessedManifestFileEntryPtr manifest_file_entry;
+#ifdef CHDB_WASM_SINGLE_THREADED
+    /// No producer thread on the single-threaded WASM build: pull the next
+    /// manifest entry synchronously (exceptions propagate directly).
+    bool has_manifest_file_entry = false;
+    if (auto entry = data_files_iterator.next(); entry.has_value())
+    {
+        manifest_file_entry = std::move(entry.value());
+        has_manifest_file_entry = true;
+    }
+    if (has_manifest_file_entry)
+#else
     if (blocking_queue.pop(manifest_file_entry))
+#endif
     {
         IcebergDataObjectInfoPtr object_info
             = std::make_shared<IcebergDataObjectInfo>(

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -778,6 +778,15 @@ SchemaCache & StorageObjectStorage::getSchemaCache(const ContextPtr & context, c
             context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_local", DEFAULT_SCHEMA_CACHE_ELEMENTS));
         return schema_cache;
     }
+#if defined(OS_WASM)
+    if (storage_engine_name == "web")
+    {
+        /// The WASM web-fetch data plane (StorageWasmWebConfiguration); reuse the url limit.
+        static SchemaCache schema_cache(
+            context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_url", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+        return schema_cache;
+    }
+#endif
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported storage type: {}", storage_engine_name);
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -772,12 +772,6 @@ SchemaCache & StorageObjectStorage::getSchemaCache(const ContextPtr & context, c
             context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_azure", DEFAULT_SCHEMA_CACHE_ELEMENTS));
         return schema_cache;
     }
-    if (storage_engine_name == "local")
-    {
-        static SchemaCache schema_cache(
-            context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_local", DEFAULT_SCHEMA_CACHE_ELEMENTS));
-        return schema_cache;
-    }
 #if defined(OS_WASM)
     if (storage_engine_name == "web")
     {
@@ -787,6 +781,12 @@ SchemaCache & StorageObjectStorage::getSchemaCache(const ContextPtr & context, c
         return schema_cache;
     }
 #endif
+    if (storage_engine_name == "local")
+    {
+        static SchemaCache schema_cache(
+            context->getConfigRef().getUInt("schema_inference_cache_max_elements_for_local", DEFAULT_SCHEMA_CACHE_ELEMENTS));
+        return schema_cache;
+    }
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported storage type: {}", storage_engine_name);
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -914,7 +914,23 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
 
 std::future<StorageObjectStorageSource::ReaderHolder> StorageObjectStorageSource::createReaderAsync()
 {
+#ifdef CHDB_WASM_SINGLE_THREADED
+    /// Single-threaded WASM build: the reader-ahead pool can never run a task.
+    /// Create the reader inline and hand back a ready future — callers only
+    /// .get() it (fire-then-wait), so the semantics are preserved.
+    std::promise<ReaderHolder> reader_promise;
+    try
+    {
+        reader_promise.set_value(createReader());
+    }
+    catch (...)
+    {
+        reader_promise.set_exception(std::current_exception());
+    }
+    return reader_promise.get_future();
+#else
     return create_reader_scheduler([=, this] { return createReader(); }, Priority{});
+#endif
 }
 
 std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
@@ -925,7 +941,17 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     const std::optional<ReadSettings> & read_settings)
 {
     const auto & settings = context_->getSettingsRef();
+#if defined(OS_WASM)
+    /// Let the object storage veto read methods it cannot serve before the
+    /// use_prefetch/use_async_buffer decisions below: the WASM web-fetch
+    /// storage downgrades remote_fs_method to plain synchronous reads (no
+    /// threadpool reader, no prefetch — pool pthreads are scarce and the
+    /// single-threaded bundle has none at all).
+    const auto effective_read_settings
+        = object_storage->patchSettings(read_settings.has_value() ? read_settings.value() : context_->getReadSettings());
+#else
     const auto & effective_read_settings = read_settings.has_value() ? read_settings.value() : context_->getReadSettings();
+#endif
 
     bool use_distributed_cache = false;
 #if ENABLE_DISTRIBUTED_CACHE

--- a/src/Storages/ObjectStorage/WasmWeb/Configuration.cpp
+++ b/src/Storages/ObjectStorage/WasmWeb/Configuration.cpp
@@ -117,9 +117,32 @@ void StorageWasmWebConfiguration::fromAST(ASTs & args, ContextPtr context, bool 
         key_prefix = key_prefix.substr(1);
 
     if (raw_uri.starts_with("s3://") || raw_uri.starts_with("S3://"))
+    {
+        /// Virtual-hosted rewrite: the bucket lives in the hostname, keys don't carry it.
         bucket = Poco::URI(raw_uri).getHost();
+        keys_carry_bucket = false;
+    }
     else
-        bucket = key_prefix.substr(0, key_prefix.find('/'));
+    {
+        /// http(s) endpoint. Virtual-hosted hosts (bucket.s3.region.amazonaws.com,
+        /// bucket.s3-accesspoint..., MinIO vhost setups) embed the bucket as the
+        /// first host label; everything else is path-style and the bucket is the
+        /// first segment of every key.
+        const String host = uri.getHost();
+        const size_t first_dot = host.find('.');
+        const bool virtual_hosted = first_dot != String::npos
+            && (host.compare(first_dot, 4, ".s3.") == 0 || host.compare(first_dot, 4, ".s3-") == 0);
+        if (virtual_hosted)
+        {
+            bucket = host.substr(0, first_dot);
+            keys_carry_bucket = false;
+        }
+        else
+        {
+            bucket = key_prefix.substr(0, key_prefix.find('/'));
+            keys_carry_bucket = true;
+        }
+    }
 
     path = key_prefix;
     paths = {path};
@@ -149,6 +172,9 @@ ObjectStoragePtr StorageWasmWebConfiguration::createObjectStorage(
 {
     WasmWebObjectStorageSettings storage_settings;
     storage_settings.base_url = base_url;
+    /// listObjects strips the bucket from key prefixes; only meaningful when
+    /// keys actually carry it (path-style). Virtual-hosted keys are bucket-free.
+    storage_settings.bucket = keys_carry_bucket ? bucket : String{};
     storage_settings.region = region;
     if (!no_sign)
     {

--- a/src/Storages/ObjectStorage/WasmWeb/Configuration.cpp
+++ b/src/Storages/ObjectStorage/WasmWeb/Configuration.cpp
@@ -24,6 +24,11 @@ namespace Setting
     extern const SettingsBool schema_inference_use_cache_for_url;
 }
 
+namespace DataLakeStorageSetting
+{
+    extern const DataLakeStorageSettingsString storage_region;
+}
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
@@ -83,6 +88,9 @@ void StorageWasmWebConfiguration::fromAST(ASTs & args, ContextPtr context, bool 
         }
         literal_args.push_back(evaluateConstantExpressionOrIdentifierAsLiteral(arg, context));
     }
+
+    if (literal_args.empty())
+        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "WasmWeb storage requires a url argument");
 
     raw_uri = checkAndGetLiteralArgument<String>(literal_args[0], "url");
 
@@ -170,6 +178,20 @@ StorageObjectStorageQuerySettings StorageWasmWebConfiguration::getQuerySettings(
 ObjectStoragePtr StorageWasmWebConfiguration::createObjectStorage(
     ContextPtr, bool /* readonly */, CredentialsConfigurationCallback /* refresh_credentials_callback */)
 {
+    /// An explicit SETTINGS storage_region overrides the hostname-derived SigV4
+    /// region (S3-compatible endpoints often don't encode their region in the
+    /// host). Only reachable through DataLakeConfiguration, which implements
+    /// getDataLakeSettings(); the base fallback throws, hence the guard.
+    try
+    {
+        const auto & lake_settings = getDataLakeSettings();
+        if (lake_settings[DataLakeStorageSetting::storage_region].changed)
+            region = lake_settings[DataLakeStorageSetting::storage_region].value;
+    }
+    catch (...) /// NOLINT(bugprone-empty-catch)
+    {
+    }
+
     WasmWebObjectStorageSettings storage_settings;
     storage_settings.base_url = base_url;
     /// listObjects strips the bucket from key prefixes; only meaningful when

--- a/src/Storages/ObjectStorage/WasmWeb/Configuration.cpp
+++ b/src/Storages/ObjectStorage/WasmWeb/Configuration.cpp
@@ -1,0 +1,165 @@
+#include <Storages/ObjectStorage/WasmWeb/Configuration.h>
+
+#if defined(OS_WASM)
+
+#include <Core/Settings.h>
+#include <IO/WasmS3Auth.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/evaluateConstantExpression.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/checkAndGetLiteralArgument.h>
+
+#include <Poco/URI.h>
+
+#include <algorithm>
+#include <cctype>
+
+namespace DB
+{
+namespace Setting
+{
+    extern const SettingsBool engine_url_skip_empty_files;
+    extern const SettingsSchemaInferenceMode schema_inference_mode;
+    extern const SettingsBool schema_inference_use_cache_for_url;
+}
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int NOT_IMPLEMENTED;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace
+{
+
+bool iequalsNoSign(const String & s)
+{
+    if (s.size() != 6)
+        return false;
+    String u = s;
+    std::transform(u.begin(), u.end(), u.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return u == "NOSIGN";
+}
+
+/// headers('Name' = 'value', ...) — the form vended credentials are injected in
+/// (see GCSCredentials::addCredentialsToEngineArgs).
+HTTPHeaderEntries parseHeadersFunction(const ASTFunction & func)
+{
+    HTTPHeaderEntries entries;
+    if (!func.arguments)
+        return entries;
+    for (const auto & child : func.arguments->children)
+    {
+        const auto * equals = child->as<ASTFunction>();
+        if (!equals || equals->name != "equals" || !equals->arguments || equals->arguments->children.size() != 2)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "headers(...) arguments must be 'Name' = 'value' pairs");
+        auto name = checkAndGetLiteralArgument<String>(equals->arguments->children[0], "header name");
+        auto value = checkAndGetLiteralArgument<String>(equals->arguments->children[1], "header value");
+        entries.emplace_back(std::move(name), std::move(value));
+    }
+    return entries;
+}
+
+}
+
+void StorageWasmWebConfiguration::fromAST(ASTs & args, ContextPtr context, bool /* with_structure */)
+{
+    if (args.empty() || args.size() > 4)
+        throw Exception(
+            ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+            "WasmWeb storage requires 1 to 4 arguments: "
+            "url[, access_key_id, secret_access_key[, session_token]] or url, NOSIGN[, headers(...)]");
+
+    /// headers(...) is a function, not a constant — pull it out before evaluation.
+    ASTs literal_args;
+    for (auto & arg : args)
+    {
+        if (const auto * func = arg->as<ASTFunction>(); func && func->name == "headers")
+        {
+            static_headers = parseHeadersFunction(*func);
+            continue;
+        }
+        literal_args.push_back(evaluateConstantExpressionOrIdentifierAsLiteral(arg, context));
+    }
+
+    raw_uri = checkAndGetLiteralArgument<String>(literal_args[0], "url");
+
+    if (literal_args.size() > 1)
+    {
+        const auto a1 = checkAndGetLiteralArgument<String>(literal_args[1], "access_key_id/NOSIGN");
+        if (iequalsNoSign(a1))
+        {
+            no_sign = true;
+            if (literal_args.size() > 2)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected arguments after NOSIGN");
+        }
+        else
+        {
+            if (literal_args.size() < 3)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "access_key_id requires a secret_access_key argument");
+            access_key_id = a1;
+            secret_access_key = checkAndGetLiteralArgument<String>(literal_args[2], "secret_access_key");
+            if (literal_args.size() > 3)
+                session_token = checkAndGetLiteralArgument<String>(literal_args[3], "session_token");
+        }
+    }
+
+    /// s3://bucket/key -> https virtual-hosted URL; http(s):// passes through.
+    String url;
+    WasmS3::rewriteS3Source(raw_uri, url, region);
+
+    Poco::URI uri(url);
+    base_url = uri.getScheme() + "://" + uri.getAuthority();
+    String key_prefix = uri.getPath();
+    while (key_prefix.starts_with('/'))
+        key_prefix = key_prefix.substr(1);
+
+    if (raw_uri.starts_with("s3://") || raw_uri.starts_with("S3://"))
+        bucket = Poco::URI(raw_uri).getHost();
+    else
+        bucket = key_prefix.substr(0, key_prefix.find('/'));
+
+    path = key_prefix;
+    paths = {path};
+}
+
+void StorageWasmWebConfiguration::fromNamedCollection(const NamedCollection &, ContextPtr)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Named collections are not supported for WasmWeb storage");
+}
+
+StorageObjectStorageQuerySettings StorageWasmWebConfiguration::getQuerySettings(const ContextPtr & context) const
+{
+    const auto & settings = context->getSettingsRef();
+    return StorageObjectStorageQuerySettings{
+        .truncate_on_insert = false,
+        .create_new_file_on_insert = false,
+        .schema_inference_use_cache = settings[Setting::schema_inference_use_cache_for_url],
+        .schema_inference_mode = settings[Setting::schema_inference_mode],
+        .skip_empty_files = settings[Setting::engine_url_skip_empty_files],
+        .list_object_keys_size = 0,
+        .throw_on_zero_files_match = false,
+        .ignore_non_existent_file = false};
+}
+
+ObjectStoragePtr StorageWasmWebConfiguration::createObjectStorage(
+    ContextPtr, bool /* readonly */, CredentialsConfigurationCallback /* refresh_credentials_callback */)
+{
+    WasmWebObjectStorageSettings storage_settings;
+    storage_settings.base_url = base_url;
+    storage_settings.region = region;
+    if (!no_sign)
+    {
+        storage_settings.access_key_id = access_key_id;
+        storage_settings.secret_access_key = secret_access_key;
+        storage_settings.session_token = session_token;
+    }
+    storage_settings.static_headers = static_headers;
+    return std::make_shared<WasmWebObjectStorage>(std::move(storage_settings));
+}
+
+}
+
+#endif

--- a/src/Storages/ObjectStorage/WasmWeb/Configuration.h
+++ b/src/Storages/ObjectStorage/WasmWeb/Configuration.h
@@ -63,6 +63,9 @@ private:
     String base_url;
     /// Bucket (S3) or first path segment; informational (IcebergPathResolver namespace).
     String bucket;
+    /// Whether object keys start with "<bucket>/" (path-style endpoints) — drives
+    /// listObjects' bucket stripping; false for virtual-hosted URLs.
+    bool keys_carry_bucket = false;
     String region;
     String access_key_id;
     String secret_access_key;

--- a/src/Storages/ObjectStorage/WasmWeb/Configuration.h
+++ b/src/Storages/ObjectStorage/WasmWeb/Configuration.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#if defined(OS_WASM)
+
+#include <Disks/DiskObjectStorage/ObjectStorages/WasmWeb/WasmWebObjectStorage.h>
+
+#include <Storages/ObjectStorage/Common.h>
+#include <Storages/ObjectStorage/StorageObjectStorage.h>
+
+namespace DB
+{
+
+/// Object storage configuration for the WASM build's web-fetch data plane.
+/// Understands the table endpoints a data-lake catalog hands out:
+///   - s3://bucket/key        -> https virtual-hosted URL + SigV4 (when credentials given)
+///   - http(s)://host/prefix  -> used as-is (storage_endpoint overrides, S3-compatible
+///                               services, plain web servers); signed when credentials given
+/// Engine args mirror what DatabaseDataLake passes: (url[, access_key_id,
+/// secret_access_key[, session_token]]) or (url, NOSIGN[, headers(...)]).
+/// Read-only: creates WasmWebObjectStorage.
+class StorageWasmWebConfiguration : public StorageObjectStorageConfiguration
+{
+public:
+    static constexpr auto type = ObjectStorageType::Web;
+    static constexpr auto type_name = "web";
+
+    StorageWasmWebConfiguration() = default;
+    StorageWasmWebConfiguration(const StorageWasmWebConfiguration & other) = default;
+
+    ObjectStorageType getType() const override { return type; }
+    std::string getTypeName() const override { return type_name; }
+    std::string getEngineName() const override { return "WasmWeb"; }
+
+    Path getRawPath() const override { return path; }
+    void setRawPath(const Path & p) override { path = p; }
+    const String & getRawURI() const override { return raw_uri; }
+
+    const Paths & getPaths() const override { return paths; }
+    void setPaths(const Paths & paths_) override
+    {
+        paths = paths_;
+        path = paths_[0];
+    }
+
+    String getNamespace() const override { return bucket; }
+    String getDataSourceDescription() const override { return base_url; }
+    StorageObjectStorageQuerySettings getQuerySettings(const ContextPtr &) const override;
+
+    ObjectStoragePtr createObjectStorage(ContextPtr, bool readonly, CredentialsConfigurationCallback refresh_credentials_callback) override;
+
+    void addStructureAndFormatToArgsIfNeeded(ASTs &, const String &, const String &, ContextPtr, bool) override { }
+
+    bool supportsWrites() const override { return false; }
+
+protected:
+    void fromAST(ASTs & args, ContextPtr context, bool with_structure) override;
+    void fromNamedCollection(const NamedCollection & collection, ContextPtr context) override;
+
+private:
+    /// Original endpoint from the engine args (s3:// or http(s)://).
+    String raw_uri;
+    /// http(s) URL the object keys get appended to (bucket root), no trailing slash.
+    String base_url;
+    /// Bucket (S3) or first path segment; informational (IcebergPathResolver namespace).
+    String bucket;
+    String region;
+    String access_key_id;
+    String secret_access_key;
+    String session_token;
+    bool no_sign = false;
+    HTTPHeaderEntries static_headers;
+
+    /// Key prefix of the table inside base_url (what IcebergMetadata sees as table_path).
+    Path path;
+    Paths paths;
+};
+
+}
+
+#endif

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -246,6 +246,9 @@ void registerStorageIceberg(StorageFactory & factory)
             else
 #if USE_AWS_S3
                 configuration = std::make_shared<StorageS3IcebergConfiguration>(storage_settings);
+#elif defined(OS_WASM)
+                /// WASM has no AWS SDK: s3:// tables go through the web-fetch data plane.
+                configuration = std::make_shared<StorageWasmWebIcebergConfiguration>(storage_settings);
 #endif
             if (configuration == nullptr)
             {
@@ -286,6 +289,24 @@ void registerStorageIceberg(StorageFactory & factory)
             }
             else
                 configuration = std::make_shared<StorageS3IcebergConfiguration>(storage_settings);
+            return createStorageObjectStorage(args, configuration);
+        },
+        {
+            .supports_settings = true,
+            .supports_sort_order = true,
+            .supports_schema_inference = true,
+            .source_access_type = AccessTypeObjects::Source::S3,
+            .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+        });
+#    elif defined(OS_WASM)
+    /// WASM has no AWS SDK: the IcebergS3 engine reads via the web-fetch data
+    /// plane (the `disk` setting is not supported here).
+    factory.registerStorage(
+        IcebergS3Definition::storage_engine_name,
+        [&](const StorageFactory::Arguments & args)
+        {
+            const auto storage_settings = getDataLakeStorageSettings(*args.storage_def);
+            auto configuration = std::make_shared<StorageWasmWebIcebergConfiguration>(storage_settings);
             return createStorageObjectStorage(args, configuration);
         },
         {
@@ -758,6 +779,28 @@ void registerStorageDeltaLake(StorageFactory & factory)
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::FILE,
             .has_builtin_setting_fn = StorageObjectStorageSettings::hasBuiltin,
+        });
+}
+#endif
+
+#if USE_PARQUET && !USE_DELTA_KERNEL_RS && defined(OS_WASM)
+/// WASM has no rust delta-kernel: the legacy C++ DeltaLakeMetadata replays the
+/// log, and data is read through the web-fetch data plane.
+void registerStorageDeltaLake(StorageFactory & factory)
+{
+    factory.registerStorage(
+        DeltaLakeDefinition::storage_engine_name,
+        [&](const StorageFactory::Arguments & args)
+        {
+            const auto storage_settings = getDataLakeStorageSettings(*args.storage_def);
+            auto configuration = std::make_shared<StorageWasmWebDeltaLakeConfiguration>(storage_settings);
+            return createStorageObjectStorage(args, configuration);
+        },
+        {
+            .supports_settings = true,
+            .supports_schema_inference = true,
+            .source_access_type = AccessTypeObjects::Source::S3,
+            .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
         });
 }
 #endif

--- a/src/Storages/registerStorages.cpp
+++ b/src/Storages/registerStorages.cpp
@@ -45,6 +45,8 @@ void registerStorageS3Queue(StorageFactory & factory);
 
 #if USE_PARQUET && USE_DELTA_KERNEL_RS
 void registerStorageDeltaLake(StorageFactory & factory);
+#elif USE_PARQUET && defined(OS_WASM)
+void registerStorageDeltaLake(StorageFactory & factory);
 #endif
 
 #if USE_AVRO
@@ -166,6 +168,8 @@ void registerStorages()
 #endif
 
 #if USE_PARQUET && USE_DELTA_KERNEL_RS
+    registerStorageDeltaLake(factory);
+#elif USE_PARQUET && defined(OS_WASM)
     registerStorageDeltaLake(factory);
 #endif
 

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -458,6 +458,17 @@ void registerTableFunctionIceberg(TableFunctionFactory & factory)
             .category = FunctionDocumentation::Category::TableFunction},
         {.allow_readonly = false});
 
+#elif defined(OS_WASM)
+    factory.registerFunction<TableFunctionIceberg>(
+         {.description = R"(The table function can be used to read the Iceberg table stored on S3 object store (via the WASM web-fetch data plane). Alias to icebergS3)",
+            .examples{{IcebergDefinition::name, "SELECT * FROM iceberg(url, access_key_id, secret_access_key)", ""}},
+            .category = FunctionDocumentation::Category::TableFunction},
+        {.allow_readonly = false});
+    factory.registerFunction<TableFunctionIcebergS3>(
+         {.description = R"(The table function can be used to read the Iceberg table stored on S3 object store (via the WASM web-fetch data plane).)",
+            .examples{{IcebergS3Definition::name, "SELECT * FROM icebergS3(url, access_key_id, secret_access_key)", ""}},
+            .category = FunctionDocumentation::Category::TableFunction},
+        {.allow_readonly = false});
 #endif
 #if USE_AZURE_BLOB_STORAGE
     factory.registerFunction<TableFunctionIcebergAzure>(
@@ -554,6 +565,17 @@ void registerTableFunctionDeltaLake(TableFunctionFactory & factory)
 }
 #endif
 
+#if USE_PARQUET && !USE_DELTA_KERNEL_RS && defined(OS_WASM)
+void registerTableFunctionDeltaLake(TableFunctionFactory & factory)
+{
+    factory.registerFunction<TableFunctionDeltaLake>(
+         {.description = R"(The table function can be used to read the DeltaLake table stored on S3 (via the WASM web-fetch data plane and the legacy metadata reader).)",
+            .examples{{DeltaLakeDefinition::name, "SELECT * FROM deltaLake(url, access_key_id, secret_access_key)", ""}},
+            .category = FunctionDocumentation::Category::TableFunction},
+         {.allow_readonly = false});
+}
+#endif
+
 #if USE_AWS_S3
 void registerTableFunctionHudi(TableFunctionFactory & factory)
 {
@@ -577,6 +599,8 @@ void registerDataLakeTableFunctions(TableFunctionFactory & factory)
 #endif
 
 #if USE_PARQUET && USE_DELTA_KERNEL_RS
+    registerTableFunctionDeltaLake(factory);
+#elif USE_PARQUET && defined(OS_WASM)
     registerTableFunctionDeltaLake(factory);
 #endif
 #if USE_AWS_S3

--- a/src/TableFunctions/TableFunctionObjectStorage.h
+++ b/src/TableFunctions/TableFunctionObjectStorage.h
@@ -126,6 +126,10 @@ using TableFunctionHDFS = TableFunctionObjectStorage<HDFSDefinition, StorageHDFS
 #    if USE_AWS_S3
 using TableFunctionIceberg = TableFunctionObjectStorage<IcebergDefinition, StorageS3IcebergConfiguration, true>;
 using TableFunctionIcebergS3 = TableFunctionObjectStorage<IcebergS3Definition, StorageS3IcebergConfiguration, true>;
+#    elif defined(OS_WASM)
+/// WASM has no AWS SDK: s3:// tables are read through the web-fetch data plane.
+using TableFunctionIceberg = TableFunctionObjectStorage<IcebergDefinition, StorageWasmWebIcebergConfiguration, true>;
+using TableFunctionIcebergS3 = TableFunctionObjectStorage<IcebergS3Definition, StorageWasmWebIcebergConfiguration, true>;
 #    endif
 #    if USE_AZURE_BLOB_STORAGE
 using TableFunctionIcebergAzure = TableFunctionObjectStorage<IcebergAzureDefinition, StorageAzureIcebergConfiguration, true>;
@@ -158,6 +162,11 @@ using TableFunctionDeltaLakeAzure = TableFunctionObjectStorage<DeltaLakeAzureDef
 #endif
 // New alias for local Delta Lake table function
 using TableFunctionDeltaLakeLocal = TableFunctionObjectStorage<DeltaLakeLocalDefinition, StorageLocalDeltaLakeConfiguration, true>;
+#endif
+#if USE_PARQUET && !USE_DELTA_KERNEL_RS && defined(OS_WASM)
+/// WASM has no rust delta-kernel: the legacy C++ DeltaLakeMetadata replays the
+/// log, and data is read through the web-fetch data plane.
+using TableFunctionDeltaLake = TableFunctionObjectStorage<DeltaLakeDefinition, StorageWasmWebDeltaLakeConfiguration, true>;
 #endif
 #if USE_AWS_S3
 using TableFunctionHudi = TableFunctionObjectStorage<HudiDefinition, StorageS3HudiConfiguration, true>;

--- a/src/TableFunctions/TableFunctionS3.cpp
+++ b/src/TableFunctions/TableFunctionS3.cpp
@@ -13,12 +13,11 @@
 #include <Formats/FormatFactory.h>
 #include <IO/CompressionMethod.h>
 #include <IO/HTTPHeaderEntries.h>
-#include <Common/OpenSSLHelpers.h>
+#include <IO/WasmS3Auth.h>
 #include <Poco/URI.h>
 
 #include <algorithm>
 #include <cctype>
-#include <ctime>
 #include <unordered_map>
 #include <vector>
 
@@ -49,183 +48,6 @@ bool isFormatName(const String & s)
 {
     return s == "auto" || FormatFactory::instance().exists(s);
 }
-
-/// Extract the AWS region from an S3 host, e.g.
-///   bucket.s3.eu-west-3.amazonaws.com -> eu-west-3
-///   bucket.s3.amazonaws.com           -> us-east-1
-///   s3.us-west-2.amazonaws.com         -> us-west-2
-String extractRegionFromHost(const String & host)
-{
-    std::vector<String> tok;
-    size_t start = 0;
-    for (size_t i = 0; i <= host.size(); ++i)
-    {
-        if (i == host.size() || host[i] == '.')
-        {
-            tok.push_back(host.substr(start, i - start));
-            start = i + 1;
-        }
-    }
-    for (size_t i = 0; i < tok.size(); ++i)
-    {
-        if (tok[i] == "s3")
-        {
-            if (i + 1 < tok.size() && tok[i + 1] != "amazonaws")
-                return tok[i + 1];
-            return "us-east-1";
-        }
-        if (tok[i].rfind("s3-", 0) == 0 && tok[i].size() > 3)
-            return tok[i].substr(3);
-    }
-    return "us-east-1";
-}
-
-/// s3://bucket/key -> https://bucket.s3.<region>.amazonaws.com/key (virtual-hosted).
-/// http(s):// URLs are passed through unchanged.
-void rewriteS3Source(const String & source, String & out_url, String & out_region)
-{
-    Poco::URI uri(source);
-    String scheme = uri.getScheme();
-    std::transform(scheme.begin(), scheme.end(), scheme.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-
-    if (scheme == "s3")
-    {
-        /// An s3:// URL carries no region: map to the region-agnostic virtual-hosted
-        /// endpoint (matching src/IO/S3/URI.cpp) and default the SigV4 region to us-east-1.
-        /// For a bucket outside us-east-1 *with credentials*, pass the full regional URL
-        /// (https://bucket.s3.<region>.amazonaws.com/...) so signing uses the right region.
-        out_region = "us-east-1";
-        const String bucket = uri.getHost();
-        String path = uri.getPath();
-        if (path.empty())
-            path = "/";
-        out_url = "https://" + bucket + ".s3.amazonaws.com" + path;
-        if (!uri.getRawQuery().empty())
-            out_url += "?" + uri.getRawQuery();
-    }
-    else
-    {
-        out_url = source;
-        out_region = extractRegionFromHost(uri.getHost());
-    }
-}
-
-#if USE_SSL
-
-String toLowerHex(const uint8_t * data, size_t n)
-{
-    static const char digits[] = "0123456789abcdef";
-    String out;
-    out.resize(n * 2);
-    for (size_t i = 0; i < n; ++i)
-    {
-        out[2 * i] = digits[data[i] >> 4];
-        out[2 * i + 1] = digits[data[i] & 0xf];
-    }
-    return out;
-}
-
-String sha256HexLower(const String & s)
-{
-    const String raw = encodeSHA256(s); /// 32 raw bytes
-    return toLowerHex(reinterpret_cast<const uint8_t *>(raw.data()), raw.size());
-}
-
-/// AWS RFC3986 percent-encoding. Leaves unreserved bytes; '/' is preserved in paths.
-String uriEncode(const String & s, bool encode_slash)
-{
-    static const char hexu[] = "0123456789ABCDEF";
-    String out;
-    out.reserve(s.size());
-    for (unsigned char c : s)
-    {
-        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
-            || c == '-' || c == '_' || c == '.' || c == '~')
-            out += static_cast<char>(c);
-        else if (c == '/' && !encode_slash)
-            out += '/';
-        else
-        {
-            out += '%';
-            out += hexu[c >> 4];
-            out += hexu[c & 0xf];
-        }
-    }
-    return out;
-}
-
-/// AWS Signature V4 headers for a GET with UNSIGNED-PAYLOAD.
-HTTPHeaderEntries signV4Get(const String & url, const String & region,
-    const String & access_key_id, const String & secret_access_key, const String & session_token)
-{
-    Poco::URI uri(url);
-    const String host = uri.getHost();
-    String path = uri.getPath();
-    if (path.empty())
-        path = "/";
-    const String canonical_uri = uriEncode(path, /*encode_slash=*/false);
-
-    std::vector<std::pair<String, String>> qparams;
-    for (const auto & p : uri.getQueryParameters())
-        qparams.emplace_back(uriEncode(p.first, true), uriEncode(p.second, true));
-    std::sort(qparams.begin(), qparams.end());
-    String canonical_query;
-    for (size_t i = 0; i < qparams.size(); ++i)
-    {
-        if (i)
-            canonical_query += '&';
-        canonical_query += qparams[i].first;
-        canonical_query += '=';
-        canonical_query += qparams[i].second;
-    }
-
-    const time_t now = time(nullptr);
-    struct tm tm_utc;
-    gmtime_r(&now, &tm_utc);
-    char amz_date[32];
-    char date_stamp[16];
-    strftime(amz_date, sizeof(amz_date), "%Y%m%dT%H%M%SZ", &tm_utc);
-    strftime(date_stamp, sizeof(date_stamp), "%Y%m%d", &tm_utc);
-
-    const String payload_hash = "UNSIGNED-PAYLOAD";
-    String signed_headers = "host;x-amz-content-sha256;x-amz-date";
-    String canonical_headers
-        = "host:" + host + "\n" + "x-amz-content-sha256:" + payload_hash + "\n" + "x-amz-date:" + String(amz_date) + "\n";
-    if (!session_token.empty())
-    {
-        signed_headers += ";x-amz-security-token";
-        canonical_headers += "x-amz-security-token:" + session_token + "\n";
-    }
-
-    const String canonical_request
-        = "GET\n" + canonical_uri + "\n" + canonical_query + "\n" + canonical_headers + "\n" + signed_headers + "\n" + payload_hash;
-
-    const String scope = String(date_stamp) + "/" + region + "/s3/aws4_request";
-    const String string_to_sign
-        = "AWS4-HMAC-SHA256\n" + String(amz_date) + "\n" + scope + "\n" + sha256HexLower(canonical_request);
-
-    const String key0 = "AWS4" + secret_access_key;
-    std::vector<uint8_t> k_secret(key0.begin(), key0.end());
-    const auto k_date = hmacSHA256(k_secret, String(date_stamp));
-    const auto k_region = hmacSHA256(k_date, region);
-    const auto k_service = hmacSHA256(k_region, "s3");
-    const auto k_signing = hmacSHA256(k_service, "aws4_request");
-    const auto sig = hmacSHA256(k_signing, string_to_sign);
-    const String signature = toLowerHex(sig.data(), sig.size());
-
-    const String authorization = "AWS4-HMAC-SHA256 Credential=" + access_key_id + "/" + scope
-        + ", SignedHeaders=" + signed_headers + ", Signature=" + signature;
-
-    HTTPHeaderEntries headers;
-    headers.emplace_back("x-amz-date", String(amz_date));
-    headers.emplace_back("x-amz-content-sha256", payload_hash);
-    headers.emplace_back("Authorization", authorization);
-    if (!session_token.empty())
-        headers.emplace_back("x-amz-security-token", session_token);
-    return headers;
-}
-
-#endif
 
 }
 
@@ -338,7 +160,7 @@ void TableFunctionS3::parseArgumentsImpl(ASTs & args, const ContextPtr & context
         compression_method = comp;
 
     const String source = checkAndGetLiteralArgument<String>(args[0], "url");
-    rewriteS3Source(source, filename, region);
+    WasmS3::rewriteS3Source(source, filename, region);
 
     if (format == "auto")
     {
@@ -352,7 +174,7 @@ HTTPHeaderEntries TableFunctionS3::computeAuthHeaders() const
     if (no_sign || access_key_id.empty() || secret_access_key.empty())
         return {};
 #if USE_SSL
-    return signV4Get(filename, region, access_key_id, secret_access_key, session_token);
+    return WasmS3::signV4Request("GET", filename, region, access_key_id, secret_access_key, session_token);
 #else
     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "s3() with credentials requires SSL support (SigV4 signing)");
 #endif


### PR DESCRIPTION
Closes #105.

DataLakeCatalog and open-table-format reads now work in chdb-wasm, verified end to end in Node and headless Chrome, on both the threaded (mt) and single-threaded (st) bundles.

- **JS-hosted HTTP transport**: `makeHTTPSession()` returns a `WasmHTTPSession` under OS_WASM — one synchronous exchange per request through the host (sync XHR on the pthread's worker in browsers, a `node -e` fetch child under Node). Covers ReadWriteBufferFromHTTP, all REST catalogs and OAuth; TLS/redirects come from the browser.
- **Avro enabled** for OS_WASM (gates Iceberg/Paimon metadata and the engine registration), plus a `#if USE_AWS_S3` guard for the Glue case that never compiled without the SDK.
- **Web-fetch data plane**: read-only `WasmWebObjectStorage` + `StorageWasmWebConfiguration` map `s3://` and `http(s)://` table locations to SigV4-signed range reads and ListObjectsV2 (the AWS SDK cannot build under Emscripten); `storage_endpoint`/`storage_region` overrides work for S3-compatible services.
- **Table functions & engines**: `iceberg()`/`icebergS3()`/`deltaLake()` registered for wasm (OS_WASM-only branches; the upstream `USE_AWS_S3`/`USE_DELTA_KERNEL_RS` gates are untouched). DeltaLake uses the legacy C++ log replay — no rust delta-kernel on wasm.
- **Single-threaded bundle support**: three inline degradations under `CHDB_WASM_SINGLE_THREADED` (ThreadPoolCallbackRunnerLocal, IcebergIterator producer, reader-ahead future) plus an OS_WASM `patchSettings` hook so reads stay synchronous.
- The BETA gates (`allow_database_iceberg`, `allow_experimental_database_unity_catalog`) are pre-enabled per connection in the wasm glue (engine defaults untouched; user `SET` overrides).

## What works (verified)

| Entry point | Status |
|---|---|
| `CREATE DATABASE ... ENGINE=DataLakeCatalog` with `catalog_type='rest'` (Iceberg REST) | ✅ mock + real catalog (apache/iceberg-rest-fixture), OAuth client_credentials incl. 401 refresh-and-retry, vended credentials (endpoint+keys from LoadTableResult.config), paginated listings |
| `catalog_type='unity'` → Delta tables | ✅ legacy C++ log replay (delta-rs–written fixture) |
| `icebergS3()` / `iceberg()` direct reads | ✅ incl. metadata-version discovery via ListObjectsV2; verified against the public 100M-row `lake_formats/iceberg` dataset with NOSIGN |
| `deltaLake()` direct reads | ✅ verified against the public `lake_formats/delta_lake` dataset |
| `icebergLocal()` (MEMFS) | ✅ |
| Iceberg specifics | ✅ multiple snapshots, identity partitions (incl. values with spaces → URL-encoded keys), delete-via-overwrite snapshots |
| Auth/transport | ✅ SigV4 GET/HEAD/ListObjectsV2 (MinIO-verified signatures), NOSIGN, vended credentials, Bearer `headers(...)`, `storage_region` override, HTTP range reads |
| Environments | ✅ mt + st bundles, Node + browsers (target endpoints need CORS; mt needs a cross-origin-isolated page) |

## What does not work (and why)

| Item | Reason |
|---|---|
| Writes (INSERT / metadata commits) | object storage is read-only by design |
| `catalog_type='glue'` | AWS SDK cannot build under Emscripten (epoll event loops, CRT bootstrap) |
| `catalog_type='hive'` (HMS) | Thrift over raw TCP — no raw sockets in browsers |
| OneLake / BigLake | need the Azure SDK / AWS-S3-only init paths |
| `hudi()` | upstream registration is S3-only; no wasm branch (feasible follow-up) |
| `deltaLakeLocal()` | not registered on wasm (remote `deltaLake()` only) |
| Delta protocol features beyond the legacy reader (deletion vectors, column mapping, v2 checkpoints) | rust delta-kernel cannot link into wasm |
| Iceberg positional-delete reads | code compiles but untested — writing such fixtures requires Spark (pyiceberg falls back to copy-on-write) |
| ORC data files | `USE_ORC=0` (sole protobuf consumer, kept off on wasm) |
| Paimon (`paimon_rest`, `paimonLocal`) | compiled in but unverified (no non-Java fixture writer) |

## Testing

Self-contained CI rounds (moto in-process S3 + pyiceberg/delta-rs–written real tables + protocol mocks; MinIO round strictly verifies SigV4; docker round runs the real apache/iceberg-rest-fixture): `iceberg-local`, `datalake` (moto mt+st, MinIO mt+st), `datalake-unity` (mt+st), `datalake-real-catalog`, headless-Chrome datalake. All skip cleanly when their host dependency (venv/minio/docker) is absent. Native builds are unaffected — every change is OS_WASM-guarded or compiled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Closes #105.
>
> DataLakeCatalog and open-table-format reads now work in chdb-wasm, verified end to end in Node and headless Chrome, on both the threaded (mt) and single-threaded (st) bundles.
>
> - **JS-hosted HTTP transport**: `makeHTTPSession()` returns a `WasmHTTPSession` under OS_WASM — one synchronous exchange per request through the host (sync XHR on the pthread's worker in browsers, a `node -e` fetch child under Node). Covers ReadWriteBufferFromHTTP, all REST catalogs and OAuth; TLS/redirects come from the browser.
> - **Avro enabled** for OS_WASM (gates Iceberg/Paimon metadata and the engine registration), plus a `#if USE_AWS_S3` guard for the Glue case that never compiled without the SDK.
> - **Web-fetch data plane**: read-only `WasmWebObjectStorage` + `StorageWasmWebConfiguration` map `s3://` and `http(s)://` table locations to SigV4-signed range reads and ListObjectsV2 (the AWS SDK cannot build under Emscripten); `storage_endpoint`/`storage_region` overrides work for S3-compatible services.
> - **Table functions & engines**: `iceberg()`/`icebergS3()`/`deltaLake()` registered for wasm (OS_WASM-only branches; the upstream `USE_AWS_S3`/`USE_DELTA_KERNEL_RS` gates are untouched). DeltaLake uses the legacy C++ log replay — no rust delta-kernel on wasm.
> - **Single-threaded bundle support**: three inline degradations under `CHDB_WASM_SINGLE_THREADED` (ThreadPoolCallbackRunnerLocal, IcebergIterator producer, reader-ahead future) plus an OS_WASM `patchSettings` hook so reads stay synchronous.
> - The BETA gates (`allow_database_iceberg`, `allow_experimental_database_unity_catalog`) are pre-enabled per connection in the wasm glue (engine defaults untouched; user `SET` overrides).
>
> ## What works (verified)
>
> | Entry point | Status |
> |---|---|
> | `CREATE DATABASE ... ENGINE=DataLakeCatalog` with `catalog_type='rest'` (Iceberg REST) | ✅ mock + real catalog (apache/iceberg-rest-fixture), OAuth client_credentials incl. 401 refresh-and-retry, vended credentials (endpoint+keys from LoadTableResult.config), paginated listings |
> | `catalog_type='unity'` → Delta tables | ✅ legacy C++ log replay (delta-rs–written fixture) |
> | `icebergS3()` / `iceberg()` direct reads | ✅ incl. metadata-version discovery via ListObjectsV2; verified against the public 100M-row `lake_formats/iceberg` dataset with NOSIGN |
> | `deltaLake()` direct reads | ✅ verified against the public `lake_formats/delta_lake` dataset |
> | `icebergLocal()` (MEMFS) | ✅ |
> | Iceberg specifics | ✅ multiple snapshots, identity partitions (incl. values with spaces → URL-encoded keys), delete-via-overwrite snapshots |
> | Auth/transport | ✅ SigV4 GET/HEAD/ListObjectsV2 (MinIO-verified signatures), NOSIGN, vended credentials, Bearer `headers(...)`, `storage_region` override, HTTP range reads |
> | Environments | ✅ mt + st bundles, Node + browsers (target endpoints need CORS; mt needs a cross-origin-isolated page) |
>
> ## What does not work (and why)
>
> | Item | Reason |
> |---|---|
> | Writes (INSERT / metadata commits) | object storage is read-only by design |
> | `catalog_type='glue'` | AWS SDK cannot build under Emscripten (epoll event loops, CRT bootstrap) |
> | `catalog_type='hive'` (HMS) | Thrift over raw TCP — no raw sockets in browsers |
> | OneLake / BigLake | need the Azure SDK / AWS-S3-only init paths |
> | `hudi()` | upstream registration is S3-only; no wasm branch (feasible follow-up) |
> | `deltaLakeLocal()` | not registered on wasm (remote `deltaLake()` only) |
> | Delta protocol features beyond the legacy reader (deletion vectors, column mapping, v2 checkpoints) | rust delta-kernel cannot link into wasm |
> | Iceberg positional-delete reads | code compiles but untested — writing such fixtures requires Spark (pyiceberg falls back to copy-on-write) |
> | ORC data files | `USE_ORC=0` (sole protobuf consumer, kept off on wasm) |
> | Paimon (`paimon_rest`, `paimonLocal`) | compiled in but unverified (no non-Java fixture writer) |
>
> ## Testing
>
> Self-contained CI rounds (moto in-process S3 + pyiceberg/delta-rs–written real tables + protocol mocks; MinIO round strictly verifies SigV4; docker round runs the real apache/iceberg-rest-fixture): `iceberg-local`, `datalake` (moto mt+st, MinIO mt+st), `datalake-unity` (mt+st), `datalake-real-catalog`, headless-Chrome datalake. All skip cleanly when their host dependency (venv/minio/docker) is absent. Native builds are unaffected — every change is OS_WASM-guarded or compiled out.
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #106 opened
>
> - Registered `IcebergS3`, `Iceberg`, and `DeltaLake` storage engines for `OS_WASM` builds using `StorageWasmWebIcebergConfiguration` and `StorageWasmWebDeltaLakeConfiguration` instead of AWS SDK-based configurations, and registered corresponding `iceberg()`, `icebergS3()`, and `deltaLake()` table functions with web-fetch data plane support [697d1ce]
> - Defined `OS_WASM`-specific type aliases mapping `TableFunctionIceberg`, `TableFunctionIcebergS3`, and `TableFunctionDeltaLake` to `StorageWasmWebIcebergConfiguration` and `StorageWasmWebDeltaLakeConfiguration` for web-fetch-based data plane routing [697d1ce]
> - Added test cases verifying catalog-less direct reads for `deltaLake()`, `icebergS3()`, and `iceberg()` table functions against S3 URLs [697d1ce]
> - Incremented the version of the `chdb-wasm` package from 0.2.0 to 0.3.0 [c0e1d44]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->