### PR TITLE
Give macOS libchdb.so a relocatable install name (@rpath)

### DIFF
--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -213,6 +213,12 @@ if [ "${CHDB_LITE}" != "1" ]; then
     if [ "$(uname)" == "Darwin" ]; then
         # macOS: use exported_symbols_list file
         LIBCHDB_CMD="${LIBCHDB_CMD} -Wl,-exported_symbols_list,${CHDB_DIR}/libchdb_export_macos.txt"
+        # Give the dylib a relocatable install name (macOS best practice for
+        # tarball-distributed libraries; CMake's default since CMP0042). Without
+        # it the id is the bare "libchdb.so", which linked executables record
+        # verbatim and dyld then cannot resolve from e.g. /usr/local/lib.
+        # Consumers link with: -lchdb -L<dir> -Wl,-rpath,<dir>
+        LIBCHDB_CMD="${LIBCHDB_CMD} -Wl,-install_name,@rpath/libchdb.so"
     else
         # Linux: use version script
         LIBCHDB_CMD="${LIBCHDB_CMD} -Wl,--version-script=${CHDB_DIR}/libchdb_export.map"

--- a/chdb/build_mac_on_linux.sh
+++ b/chdb/build_mac_on_linux.sh
@@ -248,6 +248,9 @@ if [ "${CHDB_LITE}" != "1" ]; then
     # mutex. To expose a new C-ABI symbol, add it to libchdb_export_macos.txt
     # (never widen exports here).
     LIBCHDB_CMD="${LIBCHDB_CMD} -Wl,-exported_symbols_list,${CHDB_DIR}/libchdb_export_macos.txt"
+    # Relocatable install name — see chdb/build.sh for rationale. Consumers
+    # link with: -lchdb -L<dir> -Wl,-rpath,<dir>
+    LIBCHDB_CMD="${LIBCHDB_CMD} -Wl,-install_name,@rpath/libchdb.so"
 
     LIBCHDB_CMD=$(echo ${LIBCHDB_CMD} | sed 's/@CMakeFiles\/clickhouse.rsp/@CMakeFiles\/libchdb.rsp/g')
 


### PR DESCRIPTION
The macOS dylib shipped without an install name, so binaries linked with plain `gcc … -lchdb` recorded the bare `libchdb.so` and failed at runtime with `dyld: Library not loaded`.

Set `-Wl,-install_name,@rpath/libchdb.so` on the libchdb link command in both macOS build paths (`chdb/build.sh` Darwin branch and `chdb/build_mac_on_linux.sh`). Consumers link with `-lchdb -L<dir> -Wl,-rpath,<dir>`; dlopen-based bindings (chdb-node etc.) are unaffected.

Fixes #107

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Give macOS `libchdb.so` a relocatable install name using `@rpath`
> Sets the dyld install name of `libchdb.so` to `@rpath/libchdb.so` on macOS by appending `-Wl,-install_name,@rpath/libchdb.so` in both [build.sh](https://github.com/chdb-io/chdb-core/pull/108/files#diff-954aaac221cbc2a5091bcec6b98b647e7e91fc003cbe9fad12186c909aa4be35) and [build_mac_on_linux.sh](https://github.com/chdb-io/chdb-core/pull/108/files#diff-b8792b21f093eb040b0243e0b3907ec882e3049e86955271d211e1d396c93f3f). This replaces the default absolute install name, allowing consumers to resolve the library via their own rpath configuration at link and load time. Behavioral Change: macOS binaries linked against `libchdb.so` built from this point forward will require an appropriate `@rpath` entry (e.g. `-rpath @loader_path`) to locate the library at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce8e640.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->