### PR TITLE
Add C usage example for chdb_query_with_params

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -289,6 +289,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runQueryParamsTest.sh
       - name: Check ccache statistics
         run: |
           ccache -s

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -275,6 +275,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runQueryParamsTest.sh
       - name: Check ccache statistics
         run: |
           ccache -s

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -313,6 +313,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runQueryParamsTest.sh
       - name: Build wheels
         run: |
           rm -rf chdb/build/

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -314,6 +314,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runQueryParamsTest.sh
       - name: Build wheels
         run: |
           rm -rf chdb/build/

--- a/examples/chdbQueryParamsTest.c
+++ b/examples/chdbQueryParamsTest.c
@@ -1,0 +1,117 @@
+/**
+ * chdbQueryParamsTest.c — usage examples for the parameter-binding C API
+ * (chdb_query_with_params family).
+ *
+ * Queries use {name:Type} placeholders. Parameters are two parallel string
+ * arrays: names[i] pairs with values[i]. Values are always strings — the
+ * {name:Type} annotation does the typing — and matching is by name, so
+ * array order doesn't matter.
+ *
+ * Build: clang examples/chdbQueryParamsTest.c -I./programs/local -L. -lchdb \
+ *          -o examples/chdbQueryParamsTest
+ * Run:   LD_LIBRARY_PATH=. ./examples/chdbQueryParamsTest
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "chdb.h"
+
+static int g_failed = 0;
+
+/* Run a parameterized query and check its CSV output. */
+static void expect(chdb_connection conn, const char * label, const char * query,
+                   const char * const * names, const char * const * values,
+                   size_t count, const char * expected)
+{
+    chdb_result * r = chdb_query_with_params(conn, query, "CSV", names, values, count);
+    const char * err = r ? chdb_result_error(r) : "null result";
+    int ok = !err && chdb_result_length(r) == strlen(expected)
+                  && memcmp(chdb_result_buffer(r), expected, strlen(expected)) == 0;
+    printf("%-24s %s\n", label, ok ? "OK" : (err ? err : "MISMATCH"));
+    if (!ok) g_failed++;
+    chdb_destroy_query_result(r);
+}
+
+int main(void)
+{
+    char arg0[] = "clickhouse", arg1[] = "--multiquery";
+    char * args[] = {arg0, arg1};
+    chdb_connection * conn = chdb_connect(2, args);
+    if (!conn) return 1;
+
+    chdb_result * r = chdb_query(*conn,
+        "CREATE TABLE users (id UInt32, name String) ENGINE = Memory;"
+        "INSERT INTO users VALUES (1,'Alice'),(2,'Bob'),(3,'O''Hara')", "CSV");
+    chdb_destroy_query_result(r);
+
+    /* Basic scalars. */
+    {
+        const char * n[] = {"id", "name"}, * v[] = {"42", "Alice"};
+        expect(*conn, "scalars",
+               "SELECT {id:UInt32} AS id, {name:String} AS name", n, v, 2, "42,\"Alice\"\n");
+    }
+    /* No escaping, no SQL injection — the main reason to use parameters. */
+    {
+        const char * n[] = {"who"}, * v[] = {"O'Hara"};
+        expect(*conn, "quote-safe WHERE",
+               "SELECT id FROM users WHERE name = {who:String}", n, v, 1, "3\n");
+    }
+    /* Array parameter for IN. */
+    {
+        const char * n[] = {"ids"}, * v[] = {"[1,3]"};
+        expect(*conn, "array / IN",
+               "SELECT count() FROM users WHERE id IN {ids:Array(UInt32)}", n, v, 1, "2\n");
+    }
+    /* Identifier parameter: bind a table (or column) name. */
+    {
+        const char * n[] = {"tbl"}, * v[] = {"users"};
+        expect(*conn, "identifier",
+               "SELECT count() FROM {tbl:Identifier}", n, v, 1, "3\n");
+    }
+    /* By-name matching: array order != SQL order; one param used twice. */
+    {
+        const char * n[] = {"name", "id"}, * v[] = {"Alice", "7"};
+        expect(*conn, "by-name + reuse",
+               "SELECT {id:UInt32} + {id:UInt32}, {name:String}", n, v, 2, "14,\"Alice\"\n");
+    }
+    /* _n variant: explicit lengths, values may contain NUL bytes. */
+    {
+        const char * n[] = {"s"}, * v[] = {"a\0b"};
+        const size_t nl[] = {1}, vl[] = {3};
+        const char * q = "SELECT length({s:String})";
+        chdb_result * res = chdb_query_with_params_n(*conn, q, strlen(q), "CSV", 3, n, nl, v, vl, 1);
+        int ok = res && !chdb_result_error(res) && memcmp(chdb_result_buffer(res), "3\n", 2) == 0;
+        printf("%-24s %s\n", "_n (embedded NUL)", ok ? "OK" : "FAIL");
+        if (!ok) g_failed++;
+        chdb_destroy_query_result(res);
+    }
+    /* Streaming query with parameters: same arrays, then the usual fetch loop. */
+    {
+        const char * n[] = {"limit"}, * v[] = {"100000"};
+        chdb_result * stream = chdb_stream_query_with_params(*conn,
+            "SELECT number FROM numbers({limit:UInt64})", "CSV", n, v, 1);
+        size_t rows = 0;
+        for (;;) {
+            chdb_result * chunk = chdb_stream_fetch_result(*conn, stream);
+            size_t got = chdb_result_rows_read(chunk);
+            chdb_destroy_query_result(chunk);
+            if (got == 0) break;
+            rows += got;
+        }
+        chdb_destroy_query_result(stream);
+        printf("%-24s %s\n", "streaming + params", rows == 100000 ? "OK" : "FAIL");
+        if (rows != 100000) g_failed++;
+    }
+    /* A missing parameter is a clean error. */
+    {
+        chdb_result * res = chdb_query_with_params(*conn, "SELECT {nope:UInt32}", "CSV", NULL, NULL, 0);
+        int ok = res && chdb_result_error(res) != NULL;
+        printf("%-24s %s\n", "missing param -> error", ok ? "OK" : "FAIL");
+        if (!ok) g_failed++;
+        chdb_destroy_query_result(res);
+    }
+
+    chdb_close_conn(conn);
+    printf("summary: %d failed\n", g_failed);
+    return g_failed ? 1 : 0;
+}

--- a/examples/chdbQueryParamsTest.c
+++ b/examples/chdbQueryParamsTest.c
@@ -17,11 +17,18 @@
 
 static int g_failed = 0;
 
-/* Print the result (or the error) of one call. */
-static void show(const char * label, chdb_result * r)
+/* Print one call's result and check it against the expected CSV output. */
+static void show(const char * label, const char * expected, chdb_result * r)
 {
-    if (!r || chdb_result_error(r)) { printf("%-22s ERROR: %s\n", label, r ? chdb_result_error(r) : "null"); g_failed++; }
-    else printf("%-22s -> %.*s", label, (int)chdb_result_length(r), chdb_result_buffer(r));
+    const char * err = r ? chdb_result_error(r) : "null result";
+    if (err) { printf("%-22s ERROR: %s\n", label, err); g_failed++; }
+    else {
+        int ok = chdb_result_length(r) == strlen(expected)
+              && memcmp(chdb_result_buffer(r), expected, strlen(expected)) == 0;
+        printf("%-22s -> %.*s%s", label,
+               (int)chdb_result_length(r), chdb_result_buffer(r), ok ? "" : "   [MISMATCH]\n");
+        if (!ok) g_failed++;
+    }
     chdb_destroy_query_result(r);
 }
 
@@ -41,7 +48,7 @@ int main(void)
     {
         const char * names[]  = {"id", "name"};
         const char * values[] = {"42", "Alice"};
-        show("1. scalars", chdb_query_with_params(*conn,
+        show("1. scalars", "42,\"Alice\"\n", chdb_query_with_params(*conn,
             "SELECT {id:UInt32} AS id, {name:String} AS name",
             "CSV", names, values, 2));
     }
@@ -50,7 +57,7 @@ int main(void)
     {
         const char * names[]  = {"who"};
         const char * values[] = {"O'Hara"};
-        show("2. quote-safe WHERE", chdb_query_with_params(*conn,
+        show("2. quote-safe WHERE", "3\n", chdb_query_with_params(*conn,
             "SELECT id FROM users WHERE name = {who:String}",
             "CSV", names, values, 1));
     }
@@ -59,7 +66,7 @@ int main(void)
     {
         const char * names[]  = {"ids"};
         const char * values[] = {"[1,3]"};
-        show("3. array / IN", chdb_query_with_params(*conn,
+        show("3. array / IN", "2\n", chdb_query_with_params(*conn,
             "SELECT count() FROM users WHERE id IN {ids:Array(UInt32)}",
             "CSV", names, values, 1));
     }
@@ -68,7 +75,7 @@ int main(void)
     {
         const char * names[]  = {"tbl"};
         const char * values[] = {"users"};
-        show("4. identifier", chdb_query_with_params(*conn,
+        show("4. identifier", "3\n", chdb_query_with_params(*conn,
             "SELECT count() FROM {tbl:Identifier}",
             "CSV", names, values, 1));
     }
@@ -78,7 +85,7 @@ int main(void)
     {
         const char * names[]  = {"name", "id"};
         const char * values[] = {"Alice", "7"};
-        show("5. by-name + reuse", chdb_query_with_params(*conn,
+        show("5. by-name + reuse", "14,\"Alice\"\n", chdb_query_with_params(*conn,
             "SELECT {id:UInt32} + {id:UInt32} AS twice, {name:String} AS name",
             "CSV", names, values, 2));
     }
@@ -90,7 +97,7 @@ int main(void)
         const size_t name_lens[]  = {1};
         const size_t value_lens[] = {3};
         const char * query = "SELECT length({s:String}) AS len";
-        show("6. _n, embedded NUL", chdb_query_with_params_n(*conn,
+        show("6. _n, embedded NUL", "3\n", chdb_query_with_params_n(*conn,
             query, strlen(query), "CSV", 3,
             names, name_lens, values, value_lens, 1));
     }

--- a/examples/chdbQueryParamsTest.c
+++ b/examples/chdbQueryParamsTest.c
@@ -1,6 +1,5 @@
 /**
- * chdbQueryParamsTest.c — usage examples for the parameter-binding C API
- * (chdb_query_with_params family).
+ * chdbQueryParamsTest.c — chdb_query_with_params usage at a glance.
  *
  * Queries use {name:Type} placeholders. Parameters are two parallel string
  * arrays: names[i] pairs with values[i]. Values are always strings — the
@@ -18,17 +17,11 @@
 
 static int g_failed = 0;
 
-/* Run a parameterized query and check its CSV output. */
-static void expect(chdb_connection conn, const char * label, const char * query,
-                   const char * const * names, const char * const * values,
-                   size_t count, const char * expected)
+/* Print the result (or the error) of one call. */
+static void show(const char * label, chdb_result * r)
 {
-    chdb_result * r = chdb_query_with_params(conn, query, "CSV", names, values, count);
-    const char * err = r ? chdb_result_error(r) : "null result";
-    int ok = !err && chdb_result_length(r) == strlen(expected)
-                  && memcmp(chdb_result_buffer(r), expected, strlen(expected)) == 0;
-    printf("%-24s %s\n", label, ok ? "OK" : (err ? err : "MISMATCH"));
-    if (!ok) g_failed++;
+    if (!r || chdb_result_error(r)) { printf("%-22s ERROR: %s\n", label, r ? chdb_result_error(r) : "null"); g_failed++; }
+    else printf("%-22s -> %.*s", label, (int)chdb_result_length(r), chdb_result_buffer(r));
     chdb_destroy_query_result(r);
 }
 
@@ -39,57 +32,76 @@ int main(void)
     chdb_connection * conn = chdb_connect(2, args);
     if (!conn) return 1;
 
-    chdb_result * r = chdb_query(*conn,
+    chdb_result * setup = chdb_query(*conn,
         "CREATE TABLE users (id UInt32, name String) ENGINE = Memory;"
         "INSERT INTO users VALUES (1,'Alice'),(2,'Bob'),(3,'O''Hara')", "CSV");
-    chdb_destroy_query_result(r);
+    chdb_destroy_query_result(setup);
 
-    /* Basic scalars. */
+    /* 1. Scalars: values are strings, {name:Type} does the typing. */
     {
-        const char * n[] = {"id", "name"}, * v[] = {"42", "Alice"};
-        expect(*conn, "scalars",
-               "SELECT {id:UInt32} AS id, {name:String} AS name", n, v, 2, "42,\"Alice\"\n");
+        const char * names[]  = {"id", "name"};
+        const char * values[] = {"42", "Alice"};
+        show("1. scalars", chdb_query_with_params(*conn,
+            "SELECT {id:UInt32} AS id, {name:String} AS name",
+            "CSV", names, values, 2));
     }
-    /* No escaping, no SQL injection — the main reason to use parameters. */
+
+    /* 2. Strings need no escaping — and can't inject. */
     {
-        const char * n[] = {"who"}, * v[] = {"O'Hara"};
-        expect(*conn, "quote-safe WHERE",
-               "SELECT id FROM users WHERE name = {who:String}", n, v, 1, "3\n");
+        const char * names[]  = {"who"};
+        const char * values[] = {"O'Hara"};
+        show("2. quote-safe WHERE", chdb_query_with_params(*conn,
+            "SELECT id FROM users WHERE name = {who:String}",
+            "CSV", names, values, 1));
     }
-    /* Array parameter for IN. */
+
+    /* 3. Array parameter for IN. */
     {
-        const char * n[] = {"ids"}, * v[] = {"[1,3]"};
-        expect(*conn, "array / IN",
-               "SELECT count() FROM users WHERE id IN {ids:Array(UInt32)}", n, v, 1, "2\n");
+        const char * names[]  = {"ids"};
+        const char * values[] = {"[1,3]"};
+        show("3. array / IN", chdb_query_with_params(*conn,
+            "SELECT count() FROM users WHERE id IN {ids:Array(UInt32)}",
+            "CSV", names, values, 1));
     }
-    /* Identifier parameter: bind a table (or column) name. */
+
+    /* 4. Identifier parameter: bind a table (or column) name. */
     {
-        const char * n[] = {"tbl"}, * v[] = {"users"};
-        expect(*conn, "identifier",
-               "SELECT count() FROM {tbl:Identifier}", n, v, 1, "3\n");
+        const char * names[]  = {"tbl"};
+        const char * values[] = {"users"};
+        show("4. identifier", chdb_query_with_params(*conn,
+            "SELECT count() FROM {tbl:Identifier}",
+            "CSV", names, values, 1));
     }
-    /* By-name matching: array order != SQL order; one param used twice. */
+
+    /* 5. Matching is by name: array order is independent of SQL order,
+     *    and one parameter can be referenced multiple times. */
     {
-        const char * n[] = {"name", "id"}, * v[] = {"Alice", "7"};
-        expect(*conn, "by-name + reuse",
-               "SELECT {id:UInt32} + {id:UInt32}, {name:String}", n, v, 2, "14,\"Alice\"\n");
+        const char * names[]  = {"name", "id"};
+        const char * values[] = {"Alice", "7"};
+        show("5. by-name + reuse", chdb_query_with_params(*conn,
+            "SELECT {id:UInt32} + {id:UInt32} AS twice, {name:String} AS name",
+            "CSV", names, values, 2));
     }
-    /* _n variant: explicit lengths, values may contain NUL bytes. */
+
+    /* 6. _n variant: explicit lengths, values may contain NUL bytes. */
     {
-        const char * n[] = {"s"}, * v[] = {"a\0b"};
-        const size_t nl[] = {1}, vl[] = {3};
-        const char * q = "SELECT length({s:String})";
-        chdb_result * res = chdb_query_with_params_n(*conn, q, strlen(q), "CSV", 3, n, nl, v, vl, 1);
-        int ok = res && !chdb_result_error(res) && memcmp(chdb_result_buffer(res), "3\n", 2) == 0;
-        printf("%-24s %s\n", "_n (embedded NUL)", ok ? "OK" : "FAIL");
-        if (!ok) g_failed++;
-        chdb_destroy_query_result(res);
+        const char * names[]     = {"s"};
+        const char * values[]    = {"a\0b"};                /* 3 bytes, embedded NUL */
+        const size_t name_lens[]  = {1};
+        const size_t value_lens[] = {3};
+        const char * query = "SELECT length({s:String}) AS len";
+        show("6. _n, embedded NUL", chdb_query_with_params_n(*conn,
+            query, strlen(query), "CSV", 3,
+            names, name_lens, values, value_lens, 1));
     }
-    /* Streaming query with parameters: same arrays, then the usual fetch loop. */
+
+    /* 7. Streaming query with parameters: same arrays, then the fetch loop. */
     {
-        const char * n[] = {"limit"}, * v[] = {"100000"};
+        const char * names[]  = {"limit"};
+        const char * values[] = {"100000"};
         chdb_result * stream = chdb_stream_query_with_params(*conn,
-            "SELECT number FROM numbers({limit:UInt64})", "CSV", n, v, 1);
+            "SELECT number FROM numbers({limit:UInt64})",
+            "CSV", names, values, 1);
         size_t rows = 0;
         for (;;) {
             chdb_result * chunk = chdb_stream_fetch_result(*conn, stream);
@@ -99,16 +111,18 @@ int main(void)
             rows += got;
         }
         chdb_destroy_query_result(stream);
-        printf("%-24s %s\n", "streaming + params", rows == 100000 ? "OK" : "FAIL");
+        printf("%-22s -> %zu rows\n", "7. streaming + params", rows);
         if (rows != 100000) g_failed++;
     }
-    /* A missing parameter is a clean error. */
+
+    /* 8. A missing parameter is a clean error (BAD_QUERY_PARAMETER). */
     {
-        chdb_result * res = chdb_query_with_params(*conn, "SELECT {nope:UInt32}", "CSV", NULL, NULL, 0);
-        int ok = res && chdb_result_error(res) != NULL;
-        printf("%-24s %s\n", "missing param -> error", ok ? "OK" : "FAIL");
-        if (!ok) g_failed++;
-        chdb_destroy_query_result(res);
+        chdb_result * r = chdb_query_with_params(*conn,
+            "SELECT {nope:UInt32}", "CSV", NULL, NULL, 0);
+        printf("%-22s -> %s\n", "8. missing param",
+               (r && chdb_result_error(r)) ? "error, as expected" : "NO ERROR (bug!)");
+        if (!(r && chdb_result_error(r))) g_failed++;
+        chdb_destroy_query_result(r);
     }
 
     chdb_close_conn(conn);

--- a/examples/chdbQueryParamsTest.c
+++ b/examples/chdbQueryParamsTest.c
@@ -34,7 +34,7 @@ static void expect(chdb_connection conn, const char * label, const char * query,
 
 int main(void)
 {
-    char arg0[] = "clickhouse", arg1[] = "--multiquery";
+    char arg0[] = "chdb", arg1[] = "--multiquery";
     char * args[] = {arg0, arg1};
     chdb_connection * conn = chdb_connect(2, args);
     if (!conn) return 1;

--- a/examples/runQueryParamsTest.sh
+++ b/examples/runQueryParamsTest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Compile and link"
+clang chdbQueryParamsTest.c -o chdbQueryParamsTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbQueryParamsTest
+
+echo "Run it:"
+./chdbQueryParamsTest


### PR DESCRIPTION
Adds `examples/chdbQueryParamsTest.c` (+ runner, wired into the examples CI step on all four wheel workflows): eight compact usages of the parameter-binding C API — scalars, quote-safe strings, Array/IN, Identifier, by-name matching/reuse, the `_n` binary-safe variant, streaming with parameters, and the missing-parameter error. Verified against the v26.5.1-rc.2 artifacts.

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add C usage example and CI tests for `chdb_query_with_params`
> - Adds [chdbQueryParamsTest.c](https://github.com/chdb-io/chdb-core/pull/110/files#diff-ad80614385b55a76bdc79475ab31e87d712cee351c36547afdc0626efb503f2b), a standalone C program that exercises `chdb_query_with_params`, `chdb_query_with_params_n`, and `chdb_stream_query_with_params` against a local chdb session, covering scalar bindings, array parameters, identifier binding, by-name reuse, embedded NUL via explicit-length variant, streaming row counting, and missing-parameter error handling.
> - Adds [runQueryParamsTest.sh](https://github.com/chdb-io/chdb-core/pull/110/files#diff-b7fc7401626d74e15de26754db7dc97edcfdd9725b5975598bf1bbc5659d1e3f), a shell script that detects the OS, compiles the test with clang against local build artifacts, and runs the binary.
> - Extends CI workflows for Linux x86, Linux arm64, macOS x86, and macOS arm64 to execute `runQueryParamsTest.sh` after the existing libchdb stub step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 062435d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->