### PR TITLE
Fix on_null="skip" invoking UDFs on NULL rows with placeholder values

### DIFF
--- a/programs/local/PythonScalarUDF.cpp
+++ b/programs/local/PythonScalarUDF.cpp
@@ -834,6 +834,26 @@ DB::ColumnPtr PythonScalarUDF::executeImpl(
 
     for (size_t row = 0; row < input_rows_count; ++row)
     {
+        if (null_handling == NullHandling::SKIP)
+        {
+            bool has_null_arg = false;
+            for (const auto & arg : arguments)
+            {
+                if (arg.column->isNullAt(row))
+                {
+                    has_null_arg = true;
+                    break;
+                }
+            }
+
+            if (has_null_arg)
+            {
+                /// The return type is always Nullable, so the default value is NULL.
+                result_column->insertDefault();
+                continue;
+            }
+        }
+
         py::tuple py_args(arguments.size());
         for (size_t i = 0; i < arguments.size(); ++i)
         {

--- a/programs/local/PythonScalarUDF.h
+++ b/programs/local/PythonScalarUDF.h
@@ -40,7 +40,11 @@ public:
     size_t getNumberOfArguments() const override { return num_args; }
     bool isSuitableForShortCircuitArgumentsExecution(const DB::DataTypesWithConstInfo &) const override { return false; }
     bool isDeterministic() const override { return false; }
-    bool useDefaultImplementationForNulls() const override { return null_handling == NullHandling::SKIP; }
+    /// NULL handling is done in executeImpl for both modes. The default implementation
+    /// for NULLs would still call the function on NULL rows with placeholder values
+    /// (discarding the results), which is observable for Python UDFs through side
+    /// effects and exceptions (with on_error=propagate).
+    bool useDefaultImplementationForNulls() const override { return false; }
 
     DB::DataTypePtr getReturnTypeImpl(const DB::DataTypes & arguments) const override;
 

--- a/tests/test_func_udf.py
+++ b/tests/test_func_udf.py
@@ -128,6 +128,65 @@ class TestNullAndExceptionHandling(unittest.TestCase):
         self.assertEqual(str(ret).strip(), "5")
         chdb.drop_function("add_two")
 
+    # ── on_null="skip" over mixed NULL/non-NULL columns: function must not be
+    #    called for NULL rows (not even with discarded placeholder values) ──
+
+    def test_null_skip_mixed_column_skips_calls(self):
+        calls = []
+
+        def tracked(x):
+            calls.append(x)
+            return x * 10
+
+        chdb.create_function("tracked_skip", tracked, arg_types=[INT64], return_type=INT64, on_null="skip")
+        ret = self.session.query(
+            "SELECT tracked_skip(x) FROM (SELECT CAST(arrayJoin([1, 2, NULL]) AS Nullable(Int64)) AS x)", "CSV")
+        self.assertEqual(str(ret).strip(), "10\n20\n\\N")
+        self.assertEqual(sorted(calls), [1, 2])
+        chdb.drop_function("tracked_skip")
+
+    def test_null_skip_propagate_no_placeholder_exception(self):
+        # With skip + propagate (the defaults), a NULL row must not fail the
+        # query by invoking the function with a placeholder value (0 here,
+        # which would raise ZeroDivisionError).
+        chdb.create_function("recip_skip", lambda x: 100 // x, arg_types=[INT64], return_type=INT64)
+        ret = self.session.query(
+            "SELECT recip_skip(x) FROM (SELECT CAST(arrayJoin([50, NULL, 20]) AS Nullable(Int64)) AS x)", "CSV")
+        self.assertEqual(str(ret).strip(), "2\n\\N\n5")
+        chdb.drop_function("recip_skip")
+
+    def test_null_skip_multi_arg_mixed_column(self):
+        calls = []
+
+        def tracked_add(a, b):
+            calls.append((a, b))
+            return a + b
+
+        chdb.create_function("tracked_add", tracked_add, arg_types=[INT64, INT64], return_type=INT64, on_null="skip")
+        self.session.query(
+            "CREATE TABLE null_pairs (id Int64, a Nullable(Int64), b Nullable(Int64)) ENGINE = Memory")
+        self.session.query(
+            "INSERT INTO null_pairs VALUES (1, 1, 10), (2, NULL, 20), (3, 3, NULL), (4, NULL, NULL), (5, 5, 50)")
+        ret = self.session.query("SELECT tracked_add(a, b) FROM null_pairs ORDER BY id", "CSV")
+        self.assertEqual(str(ret).strip(), "11\n\\N\n\\N\n\\N\n55")
+        self.assertEqual(sorted(calls), [(1, 10), (5, 50)])
+        self.session.query("DROP TABLE null_pairs")
+        chdb.drop_function("tracked_add")
+
+    def test_null_pass_mixed_column_receives_none(self):
+        calls = []
+
+        def collect(x):
+            calls.append(x)
+            return -1 if x is None else x * 10
+
+        chdb.create_function("collect_pass", collect, arg_types=[INT64], return_type=INT64, on_null="pass")
+        ret = self.session.query(
+            "SELECT collect_pass(x) FROM (SELECT CAST(arrayJoin([1, NULL, 3]) AS Nullable(Int64)) AS x)", "CSV")
+        self.assertEqual(str(ret).strip(), "10\n-1\n30")
+        self.assertEqual(calls, [1, None, 3])
+        chdb.drop_function("collect_pass")
+
     # ── on_null="pass": NULL input → None passed to function ──
 
     def test_null_pass_receives_none(self):


### PR DESCRIPTION
Fixes #111.

## Summary

`on_null="skip"` relied on the generic `useDefaultImplementationForNulls()`, which evaluates the UDF on all rows with placeholder values substituted at NULL positions and discards the results (per-row skipping only triggers when 100% of rows are NULL). For Python UDFs this is observable: side effects run on bogus inputs, and with `on_error="propagate"` an exception raised on a placeholder value (e.g. `ZeroDivisionError` on `0`) fails the whole query.

SKIP mode now handles NULLs directly in `executeImpl`, like PASS mode already does: rows with any NULL argument produce NULL without invoking the function. The declared return type is always Nullable, so result types are unchanged.

## Tests

New cases in `tests/test_func_udf.py`, all red before this fix (verified against the released 4.2.0 wheel):

- mixed NULL/non-NULL column: function called only for non-NULL rows (call log assertion)
- skip + propagate (the defaults): a NULL row no longer fails the query via a raising placeholder call
- multi-arg: rows with any NULL argument are skipped, only fully non-NULL rows invoked
- pass mode over a mixed column: unchanged behavior (regression guard)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `on_null='skip'` UDFs being invoked on NULL rows with placeholder values
> - Adds explicit NULL row detection inside `executeImpl` in [PythonScalarUDF.cpp](https://github.com/chdb-io/chdb-core/pull/112/files#diff-15a92bfc453d48a634f28e83e87266a457063d77479647d9c25962db9e75494f): when any argument column is NULL for a given row, the result is set to NULL directly and the Python function is skipped.
> - Disables the framework's default NULL handling (`useDefaultImplementationForNulls` now returns `false`) in [PythonScalarUDF.h](https://github.com/chdb-io/chdb-core/pull/112/files#diff-99d08be06747cd6acd08e83ce265f51c9df87992429d340e91a2021c116abeaf), centralizing NULL handling in `executeImpl` for both `SKIP` and `PASS` modes.
> - Adds tests in [test_func_udf.py](https://github.com/chdb-io/chdb-core/pull/112/files#diff-1aa6aa6f6e8bd0893d14e6c40ad026b96ba11ac9122ec34ac4754f1472ca8c3b) covering single- and multi-argument UDFs with `on_null='skip'` and `on_null='pass'`, verifying the Python function is never called with placeholder values for NULL rows.
> - Behavioral Change: `on_null='skip'` UDFs previously received placeholder values for NULL rows; they now receive no call at all and the result column gets NULL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3c0ffd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->