### PR TITLE
ci: add DPkg::Lock::Timeout to apt-get invocations

### DIFF
--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -51,8 +51,8 @@ jobs:
             echo "Waiting for dpkg lock (held by unattended-upgrades)..."
             sleep 5
           done
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make build-essential libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev wget curl llvm \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
             libffi-dev liblzma-dev libsqlite3-dev golang-go liblz4-dev
@@ -85,8 +85,8 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
-          sudo apt-get install -y make cmake ccache ninja-build yasm gawk wget
-          sudo apt-get install -y lld-21
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make cmake ccache ninja-build yasm gawk wget
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y lld-21
           if ! command -v wasm-ld &> /dev/null; then
             sudo ln -sf /usr/bin/wasm-ld-21 /usr/bin/wasm-ld || true
           fi
@@ -94,8 +94,8 @@ jobs:
       - name: Update git
         run: |
           sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y git
           git --version
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -52,8 +52,8 @@ jobs:
           fi
       - name: Install Python build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make build-essential libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev wget curl llvm \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
             libffi-dev liblzma-dev libsqlite3-dev golang-go liblz4-dev
@@ -74,7 +74,7 @@ jobs:
           mkdir -p $HOME/.local/bin
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          sudo apt-get update && sudo apt-get install -y jq lsb-release
+          sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y jq lsb-release
 
           # Detect OS distribution info
           DISTRO_ID=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
@@ -163,9 +163,9 @@ jobs:
           sudo ./llvm.sh 21
           which clang++-21
           clang++-21 --version
-          sudo apt-get install -y make cmake ccache ninja-build yasm gawk wget
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make cmake ccache ninja-build yasm gawk wget
           # Install WebAssembly linker (wasm-ld)
-          sudo apt-get install -y lld-21
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y lld-21
           # Create symlink for wasm-ld
           if ! command -v wasm-ld &> /dev/null; then
             sudo ln -sf /usr/bin/wasm-ld-21 /usr/bin/wasm-ld || true
@@ -175,8 +175,8 @@ jobs:
       - name: Update git
         run: |
           sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y git
           git --version
       - uses: actions/checkout@v3
         with:
@@ -366,7 +366,7 @@ jobs:
 
           # Install lldb for debugging when DEBUG_MODE is enabled
           if [ "$DEBUG_MODE" == "true" ]; then
-            sudo apt-get install -y lldb-21
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y lldb-21
             sudo ln -sf /usr/bin/lldb-21 /usr/bin/lldb || true
           fi
 

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - name: Install Python build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make build-essential libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev wget curl llvm \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
             libffi-dev liblzma-dev libsqlite3-dev golang-go liblz4-dev
@@ -60,7 +60,7 @@ jobs:
           mkdir -p $HOME/.local/bin
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          sudo apt-get update && sudo apt-get install -y jq lsb-release
+          sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y jq lsb-release
 
           # Detect OS distribution info
           DISTRO_ID=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
@@ -149,9 +149,9 @@ jobs:
           sudo ./llvm.sh 21
           which clang++-21
           clang++-21 --version
-          sudo apt-get install -y make cmake ccache ninja-build yasm gawk wget
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make cmake ccache ninja-build yasm gawk wget
           # Install WebAssembly linker (wasm-ld)
-          sudo apt-get install -y lld-21
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y lld-21
           # Create symlink for wasm-ld
           if ! command -v wasm-ld &> /dev/null; then
             sudo ln -sf /usr/bin/wasm-ld-21 /usr/bin/wasm-ld || true
@@ -161,8 +161,8 @@ jobs:
       - name: Update git
         run: |
           sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y git
           git --version
       - uses: actions/checkout@v3
         with:
@@ -351,7 +351,7 @@ jobs:
 
           # Install lldb for debugging when DEBUG_MODE is enabled
           if [ "$DEBUG_MODE" == "true" ]; then
-            sudo apt-get install -y lldb-21
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y lldb-21
             sudo ln -sf /usr/bin/lldb-21 /usr/bin/lldb || true
           fi
 

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - name: Install Python build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make build-essential libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
             libffi-dev liblzma-dev p7zip-full
@@ -59,9 +59,9 @@ jobs:
           sudo ./llvm.sh 21
           which clang++-21
           clang++-21 --version
-          sudo apt-get install -y make cmake ccache ninja-build yasm gawk wget
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make cmake ccache ninja-build yasm gawk wget
           # Install WebAssembly linker (wasm-ld)
-          sudo apt-get install -y lld-21
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y lld-21
           # Create symlink for wasm-ld
           if ! command -v wasm-ld &> /dev/null; then
             sudo ln -sf /usr/bin/wasm-ld-21 /usr/bin/wasm-ld || true
@@ -71,8 +71,8 @@ jobs:
       - name: Update git
         run: |
           sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y git
           git --version
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - name: Install Python build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make build-essential libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
             libffi-dev liblzma-dev p7zip-full
@@ -59,9 +59,9 @@ jobs:
           sudo ./llvm.sh 21
           which clang++-21
           clang++-21 --version
-          sudo apt-get install -y make cmake ccache ninja-build yasm gawk wget
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y make cmake ccache ninja-build yasm gawk wget
           # Install WebAssembly linker (wasm-ld)
-          sudo apt-get install -y lld-21
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y lld-21
           # Create symlink for wasm-ld
           if ! command -v wasm-ld &> /dev/null; then
             sudo ln -sf /usr/bin/wasm-ld-21 /usr/bin/wasm-ld || true
@@ -71,8 +71,8 @@ jobs:
       - name: Update git
         run: |
           sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install -y git
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y git
           git --version
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Install build deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends lld ninja-build ccache
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y --no-install-recommends lld ninja-build ccache
 
       # emcmake needs a recent cmake on PATH; the self-hosted runner does not provide
       # one for this job, so install a pinned cmake (+ninja) ourselves.
@@ -121,7 +121,7 @@ jobs:
       # (libasound2 -> libasound2t64, etc.) don't abort the whole batch.
       - name: Install headless-Chrome runtime libraries
         run: |
-          sudo apt-get update
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
           for p in \
             libnss3 libnspr4 libdbus-1-3 libxkbcommon0 libdrm2 libgbm1 \
             libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxext6 \
@@ -134,7 +134,7 @@ jobs:
             libasound2 libasound2t64 \
             libpango-1.0-0 libpangocairo-1.0-0 libcairo2 \
             libgtk-3-0 libgtk-3-0t64; do
-            sudo apt-get install -y --no-install-recommends "$p" || true
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y --no-install-recommends "$p" || true
           done
 
       # Build the npm dist (both bundles -> dist/ + dist/st/) and run the headless


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

CI apt-get steps now wait up to 5 minutes for the dpkg lock instead of failing instantly when unattended-upgrades is active on a self-hosted runner.

---

Fixes #113

### Reproduction

Main run https://github.com/chdb-io/chdb-core/actions/runs/28922736450 (`push` → `main` @ f592daa5) died in step 2 **Install Python build dependencies** with:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 362451 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
##[error]Process completed with exit code 100.
```

Generic repro on any Ubuntu host: hold the lock (`sudo flock /var/lib/dpkg/lock-frontend sleep 300 &`), then `sudo apt-get install -y <pkg>` → exit 100 immediately. With `-o DPkg::Lock::Timeout=300` apt waits for the lock to be released and proceeds.

### Root cause

The build jobs run on **persistent self-hosted runners** (`[self-hosted, linux, x64/arm64, ubuntu-latest]`). Ubuntu's `unattended-upgrades` periodically holds `/var/lib/dpkg/lock-frontend` for a few minutes while applying security updates. apt's default lock timeout is 0, so any CI job that lands on the runner during that window fails at setup. Commit-independence proven: the concurrent PR run https://github.com/chdb-io/chdb-core/actions/runs/28922964621 failed with the **same error and the same lock-holder PID 362451** 100 s later.

### Fix

Add `-o DPkg::Lock::Timeout=300` to every `sudo apt-get` invocation across the six build workflows (38 lines / 40 invocations; mechanical, uniform). Behavior:

- Lock free (normal case): no-op.
- Lock held: apt polls until the holder exits, up to 300 s, then proceeds. 5 min worst-case wait is negligible vs. a dead 4–6 h build.

Supported since apt 1.9.11; runners are on noble (apt 2.7+). Option verified against apt's config parser: `apt-config -o DPkg::Lock::Timeout=300 dump DPkg::Lock::Timeout` → `DPkg::Lock::Timeout "300";`.

An infra-side complement (not part of this PR) is disabling `unattended-upgrades` in the runner image; the workflow-side flag remains useful defense either way.

### Regression test

Workflow YAML cannot be unit-tested in-repo; validation performed:
- All 6 files parse as valid YAML after the change.
- Every `apt-get` invocation carries the flag (grep-verified: 0 unpatched remain).
- No other content touched — diff is exactly the 38 `sudo apt-get` lines.
- The flag is exercised on every subsequent CI run; the failure mode it targets is the one observed in run 28922736450.

Note: local root lock-race repro was not possible in my sandboxed environment (no sudo); the reproduction above is from the CI evidence and apt's documented semantics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DPkg::Lock::Timeout=300` to all CI `apt-get` invocations
> Adds `-o DPkg::Lock::Timeout=300` to every `apt-get update` and `apt-get install` call across all CI workflows to prevent failures caused by dpkg lock contention. Affected workflows include the Linux x86/arm64, macOS x86/arm64, FT wheels, and WASM build pipelines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 057186d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->