### PR TITLE
Fix named-collection DDL bypassing readonly mode

### DIFF
--- a/chdb/build/install_cctools.sh
+++ b/chdb/build/install_cctools.sh
@@ -30,6 +30,11 @@ if [ -z "${CCTOOLS:-}" ]; then
         export CCTOOLS=$(cd ~/cctools && pwd)
         cd ${CCTOOLS}
 
+        # An interrupted install leaves partial clones behind (without the
+        # <triple>-ld marker checked above), and a bare `git clone` fails on
+        # a leftover non-empty directory. Start from a clean slate.
+        rm -rf apple-libtapi cctools-port
+
         git clone https://github.com/tpoechtrager/apple-libtapi.git
         cd apple-libtapi
         git checkout 15dfc2a8c9a2a89d06ff227560a69f5265b692f9

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -791,15 +791,16 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
         const AccessFlags function_ddl = AccessType::CREATE_FUNCTION | AccessType::DROP_FUNCTION;
         const AccessFlags workload_ddl = AccessType::CREATE_WORKLOAD | AccessType::DROP_WORKLOAD;
         const AccessFlags resource_ddl = AccessType::CREATE_RESOURCE | AccessType::DROP_RESOURCE;
+        const AccessFlags named_collection_ddl = AccessType::CREATE_NAMED_COLLECTION | AccessType::DROP_NAMED_COLLECTION | AccessType::ALTER_NAMED_COLLECTION;
         const AccessFlags table_and_dictionary_ddl = table_ddl | dictionary_ddl;
         const AccessFlags table_and_dictionary_and_function_ddl = table_ddl | dictionary_ddl | function_ddl;
         const AccessFlags write_table_access = AccessType::INSERT | AccessType::OPTIMIZE;
         const AccessFlags write_dcl_access = AccessType::ACCESS_MANAGEMENT - AccessType::SHOW_ACCESS;
 
-        const AccessFlags not_readonly_flags = write_table_access | table_and_dictionary_and_function_ddl | workload_ddl | resource_ddl | write_dcl_access | AccessType::SYSTEM | AccessType::KILL_QUERY;
+        const AccessFlags not_readonly_flags = write_table_access | table_and_dictionary_and_function_ddl | workload_ddl | resource_ddl | named_collection_ddl | write_dcl_access | AccessType::SYSTEM | AccessType::KILL_QUERY;
         const AccessFlags not_readonly_1_flags = AccessType::CREATE_TEMPORARY_TABLE;
 
-        const AccessFlags ddl_flags = table_ddl | dictionary_ddl | function_ddl | workload_ddl | resource_ddl;
+        const AccessFlags ddl_flags = table_ddl | dictionary_ddl | function_ddl | workload_ddl | resource_ddl | named_collection_ddl;
         const AccessFlags introspection_flags = AccessType::INTROSPECTION;
     };
     static const PrecalculatedFlags precalc;

--- a/tests/test_named_collection.py
+++ b/tests/test_named_collection.py
@@ -150,17 +150,17 @@ class TestNamedCollectionReadonly(unittest.TestCase):
 
             sess.query("SET readonly=2")
 
-            with self.assertRaisesRegex(Exception, "readonly"):
+            with self.assertRaisesRegex(RuntimeError, "readonly"):
                 sess.query("CREATE NAMED COLLECTION x AS a=1")
-            with self.assertRaisesRegex(Exception, "readonly"):
+            with self.assertRaisesRegex(RuntimeError, "readonly"):
                 sess.query("ALTER NAMED COLLECTION aws SET url='https://evil.example.com/y.parquet'")
-            with self.assertRaisesRegex(Exception, "readonly"):
+            with self.assertRaisesRegex(RuntimeError, "readonly"):
                 sess.query("DROP NAMED COLLECTION aws")
 
             # The operator's collection is intact and no new one appeared.
             self.assertEqual(self._collection_names(sess), '"aws"\n')
             keys = sess.query(
-                "SELECT mapKeys(collection) FROM system.named_collections WHERE name = 'aws'"
+                "SELECT arraySort(mapKeys(collection)) FROM system.named_collections WHERE name = 'aws'"
             )
             self.assertEqual(str(keys), "\"['access_key_id','url']\"\n")
         finally:
@@ -170,7 +170,7 @@ class TestNamedCollectionReadonly(unittest.TestCase):
         sess = session.Session(self.test_dir)
         try:
             sess.query("SET readonly=1")
-            with self.assertRaisesRegex(Exception, "readonly"):
+            with self.assertRaisesRegex(RuntimeError, "readonly"):
                 sess.query("CREATE NAMED COLLECTION x AS a=1")
             self.assertEqual(self._collection_names(sess), "")
         finally:
@@ -180,7 +180,7 @@ class TestNamedCollectionReadonly(unittest.TestCase):
         sess = session.Session(self.test_dir)
         try:
             sess.query("SET allow_ddl=0")
-            with self.assertRaisesRegex(Exception, "DDL queries are prohibited"):
+            with self.assertRaisesRegex(RuntimeError, "DDL queries are prohibited"):
                 sess.query("CREATE NAMED COLLECTION x AS a=1")
             self.assertEqual(self._collection_names(sess), "")
         finally:

--- a/tests/test_named_collection.py
+++ b/tests/test_named_collection.py
@@ -116,5 +116,88 @@ class TestNamedCollection(unittest.TestCase):
             second.close()
 
 
+class TestNamedCollectionReadonly(unittest.TestCase):
+    """Named-collection DDL must respect readonly and allow_ddl.
+
+    See https://github.com/chdb-io/chdb-core/issues/119
+
+    CREATE/ALTER/DROP NAMED COLLECTION used to bypass ``readonly=2`` (and
+    ``allow_ddl=0``) because the named-collection access types were missing
+    from the readonly/DDL masks in ContextAccess. In embedded chDB those
+    settings are the only guard between an untrusted SQL caller and session
+    state, so the DDL must be rejected like any other DDL.
+    """
+
+    test_dir = ".test_named_collection_readonly"
+
+    def setUp(self) -> None:
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        return super().tearDown()
+
+    def _collection_names(self, sess):
+        return str(sess.query("SELECT name FROM system.named_collections ORDER BY name"))
+
+    def test_named_collection_ddl_rejected_in_readonly_2(self):
+        """The exact issue #119 repro: DDL must fail and change nothing."""
+        sess = session.Session(self.test_dir)
+        try:
+            sess.query("CREATE NAMED COLLECTION aws AS url='https://example.com/x.parquet', access_key_id='K'")
+            self.assertEqual(self._collection_names(sess), '"aws"\n')
+
+            sess.query("SET readonly=2")
+
+            with self.assertRaisesRegex(Exception, "readonly"):
+                sess.query("CREATE NAMED COLLECTION x AS a=1")
+            with self.assertRaisesRegex(Exception, "readonly"):
+                sess.query("ALTER NAMED COLLECTION aws SET url='https://evil.example.com/y.parquet'")
+            with self.assertRaisesRegex(Exception, "readonly"):
+                sess.query("DROP NAMED COLLECTION aws")
+
+            # The operator's collection is intact and no new one appeared.
+            self.assertEqual(self._collection_names(sess), '"aws"\n')
+            keys = sess.query(
+                "SELECT mapKeys(collection) FROM system.named_collections WHERE name = 'aws'"
+            )
+            self.assertEqual(str(keys), "\"['access_key_id','url']\"\n")
+        finally:
+            sess.close()
+
+    def test_named_collection_ddl_rejected_in_readonly_1(self):
+        sess = session.Session(self.test_dir)
+        try:
+            sess.query("SET readonly=1")
+            with self.assertRaisesRegex(Exception, "readonly"):
+                sess.query("CREATE NAMED COLLECTION x AS a=1")
+            self.assertEqual(self._collection_names(sess), "")
+        finally:
+            sess.close()
+
+    def test_named_collection_ddl_rejected_with_allow_ddl_0(self):
+        sess = session.Session(self.test_dir)
+        try:
+            sess.query("SET allow_ddl=0")
+            with self.assertRaisesRegex(Exception, "DDL queries are prohibited"):
+                sess.query("CREATE NAMED COLLECTION x AS a=1")
+            self.assertEqual(self._collection_names(sess), "")
+        finally:
+            sess.close()
+
+    def test_named_collection_ddl_still_works_without_readonly(self):
+        """The gate must not break the normal (non-readonly) DDL path."""
+        sess = session.Session(self.test_dir)
+        try:
+            sess.query("CREATE NAMED COLLECTION nc AS a='1'")
+            sess.query("ALTER NAMED COLLECTION nc SET a='2'")
+            self.assertEqual(self._collection_names(sess), '"nc"\n')
+            sess.query("DROP NAMED COLLECTION nc")
+            self.assertEqual(self._collection_names(sess), "")
+        finally:
+            sess.close()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix CREATE/ALTER/DROP NAMED COLLECTION bypassing `readonly` and `allow_ddl` settings.

---

Closes #119

### Problem

Under `SET readonly=2` (or `readonly=1`, or `allow_ddl=0`), where `CREATE VIEW` and other DDL are correctly rejected, the whole named-collection DDL family succeeded and persisted:

```python
s.query("SET readonly=2", "CSV")
s.query("CREATE NAMED COLLECTION x AS a=1", "CSV")   # succeeded
s.query("ALTER NAMED COLLECTION x SET a=2", "CSV")   # succeeded
s.query("DROP NAMED COLLECTION aws", "CSV")          # succeeded
```

In server ClickHouse this DDL is additionally gated by RBAC, but embedded chDB has no RBAC, so `readonly` is the only guard a host can put between an untrusted SQL caller and session state — a caller could silently repoint a collection's `url` (hijacking every view built on it) or drop the operator's credentials.

### Root cause

The interpreters do call `checkAccess(AccessType::{CREATE,ALTER,DROP}_NAMED_COLLECTION, ...)`, but those access types were missing from the `not_readonly_flags` and `ddl_flags` masks in `ContextAccess::checkAccessImplHelper`, so neither the readonly check nor the `allow_ddl` check ever fired for them.

### Fix

Add a `named_collection_ddl` mask (`CREATE_NAMED_COLLECTION | DROP_NAMED_COLLECTION | ALTER_NAMED_COLLECTION`) and include it in `not_readonly_flags` and `ddl_flags`, matching how table/dictionary/function/workload/resource DDL is gated. Read-only access (querying `system.named_collections`, using collections in table functions) is unchanged.

### Verification

Ran the exact issue repro against this build — all three statements now fail with `Code: 164. DB::Exception: default: Cannot execute query in readonly mode. (READONLY)` and the operator's collection stays intact.

Added `TestNamedCollectionReadonly` to `tests/test_named_collection.py` covering:
- `readonly=2`: CREATE/ALTER/DROP all rejected, existing collection unchanged (issue repro)
- `readonly=1`: CREATE rejected
- `allow_ddl=0`: CREATE rejected with `QUERY_IS_PROHIBITED`
- non-readonly sessions: CREATE/ALTER/DROP still work

All 6 tests in the file pass (including the existing issue #81 regression tests), plus `test_basic` / `test_conn_cursor` smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix named-collection DDL bypassing readonly mode and `allow_ddl` checks
> - Adds `named_collection_ddl` flag (combining `CREATE/ALTER/DROP NAMED COLLECTION`) to `not_readonly_flags` and `ddl_flags` in [`ContextAccess.cpp`](https://github.com/chdb-io/chdb-core/pull/120/files#diff-3869c849e10b17978935ead7b631cfaff4a3a88c3d8fb801ca7ddb95d0f5c817), so these operations are denied under `readonly` or `allow_ddl=0`.
> - Adds a new test class `TestNamedCollectionReadonly` in [`test_named_collection.py`](https://github.com/chdb-io/chdb-core/pull/120/files#diff-f899c2dd15d59a1d07926b5a98a8fdc3c27a1e43c468b60b95121e0559594f90) covering rejection under `readonly=1`, `readonly=2`, `allow_ddl=0`, and normal operation.
> - Also fixes [`install_cctools.sh`](https://github.com/chdb-io/chdb-core/pull/120/files#diff-7b6749182aa56478e48b0b0815846a544f75c271bc696a73e2aa9537fdfa842c) to clean up partial clones before re-running.
> - Behavioral Change: `CREATE/ALTER/DROP NAMED COLLECTION` now fail in readonly or no-DDL sessions, whereas previously they were permitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c715fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->