### PR TITLE
Split chdb.wasm into a hot primary and a lazily-loaded deferred module

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -287,7 +287,7 @@ jobs:
             split-out-st/chdb.mjs
             split-out-st/chdb.wasm
             split-out-st/chdb.deferred.wasm
-          retention-days: 7
+          retention-days: 1
           if-no-files-found: error
 
       # ---- Publish to npm, only on a v* tag. Everything above (build + all Node

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -12,6 +12,15 @@ name: wasm
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to npm after build + all tests pass'
+        type: boolean
+        default: false
+      version:
+        description: 'npm version to publish (e.g. 0.3.1); required when publish is checked'
+        type: string
+        default: ''
   push:
     branches:
       - main
@@ -284,23 +293,31 @@ jobs:
       # ---- Publish to npm, only on a v* tag. Everything above (build + all Node
       # and headless-Chrome tests) ran first, so a tag that fails tests never ships.
       # dist/ is already built by the npm step above; the version is taken from the tag. ----
-      - name: Set npm version from tag
-        # was: startsWith(github.ref, 'refs/tags/v') — disabled: chdb-wasm is not
-        # distributed on tags (neither npm nor GitHub Release asset) for now.
-        if: false
+      # ---- npm publish: MANUAL ONLY. Run the workflow via workflow_dispatch with
+      # `publish` checked and a `version`; everything above (build, the full test
+      # matrix, the split pipeline) must have passed to reach here. Tag-driven
+      # publishing stays disabled (was: startsWith(github.ref, 'refs/tags/v')).
+      - name: Set npm version (manual publish)
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
         working-directory: packages/chdb-wasm
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]] \
+            || { echo "publish requires a semver 'version' input, got: '$VERSION'"; exit 1; }
           echo "Publishing chdb-wasm@$VERSION"
           npm pkg set version="$VERSION"
 
       - name: Publish to npm
-        # was: startsWith(github.ref, 'refs/tags/v') — disabled: chdb-wasm is not
-        # distributed on tags (neither npm nor GitHub Release asset) for now.
-        if: false
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
         working-directory: packages/chdb-wasm
+        env:
+          VERSION: ${{ inputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          # setup-node was not given registry-url, so NODE_AUTH_TOKEN alone is
+          # inert; write the registry auth explicitly.
+          npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           # Prerelease tags (e.g. v0.2.0-beta.1, semver versions containing '-') go
           # under the `next` dist-tag so `npm install chdb-wasm` (which resolves
           # `latest`) keeps getting the last STABLE release; stable tags get `latest`.
@@ -313,15 +330,14 @@ jobs:
           npm publish "$TGZ" --tag "$TAG"
           # Hand the tarball path to the release-upload step below.
           echo "CHDB_TGZ=${GITHUB_WORKSPACE}/packages/chdb-wasm/${TGZ}" >> "$GITHUB_ENV"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Best-effort: attach the published npm tarball (chdb-wasm-<version>.tgz — it embeds
       # both wasm bundles) to the GitHub release, creating the release if the tag has none
       # yet. continue-on-error — the npm publish above is the real deliverable.
       - name: Attach the npm tarball to the GitHub release
-        # was: startsWith(github.ref, 'refs/tags/v') — disabled: chdb-wasm is not
-        # distributed on tags (neither npm nor GitHub Release asset) for now.
+        # Tag runs only (a manual-dispatch publish has no tag/release to attach
+        # to) and tag-driven distribution stays disabled for now
+        # (was: startsWith(github.ref, 'refs/tags/v')).
         if: false
         continue-on-error: true
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -230,6 +230,57 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      # ---- wasm-split lazy-loading pipeline (tools/split/README.md). Runs AFTER
+      # the npm dist build + artifact upload: the relink turns the build trees'
+      # chdb.wasm into the profiling-INSTRUMENTED module (copy-artifacts refuses
+      # such a tree by design), so dist/ must be final before this point. Sits
+      # before the tag-publish steps on purpose — if split ever regresses, a
+      # release run goes red instead of shipping quietly. Adds ~25min: two
+      # relinks (objects are reused), profiling runs, two wasm-split invocations.
+      - name: Relink with WASM_SPLIT_MODULE=ON (both bundles)
+        run: |
+          source "${EMSDK}/emsdk_env.sh"
+          cmake -DWASM_SPLIT_MODULE=ON buildwasm >/dev/null
+          ninja -C buildwasm chdb_wasm
+          cmake -DWASM_SPLIT_MODULE=ON buildwasm-st >/dev/null
+          ninja -C buildwasm-st chdb_wasm
+          ls -la buildwasm/programs/wasm/chdb.wasm.orig buildwasm-st/programs/wasm/chdb.wasm.orig
+
+      # st first: its single instance sees the whole pipeline execute inline, so
+      # its hot set is complete; the mt split mixes it in via --extra-hot (mt
+      # pool workers park in Atomics.wait and are invisible to profiling).
+      - name: wasm-split pipeline (profile + split, st hot-set -> mt)
+        env:
+          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
+        run: |
+          export WASM_SPLIT="${EMSDK}/upstream/bin/wasm-split"
+          node packages/chdb-wasm/tools/split/split-wasm.mjs \
+            --build buildwasm-st/programs/wasm --out "${GITHUB_WORKSPACE}/split-out-st" \
+            --emit-hot-names "${GITHUB_WORKSPACE}/split-out-st/hot-names.txt"
+          node packages/chdb-wasm/tools/split/split-wasm.mjs \
+            --build buildwasm/programs/wasm --out "${GITHUB_WORKSPACE}/split-out-mt" \
+            --extra-hot "${GITHUB_WORKSPACE}/split-out-st/hot-names.txt"
+
+      - name: Split bundle tests
+        env:
+          CHDB_SPLIT_MT_DIR: ${{ github.workspace }}/split-out-mt
+          CHDB_SPLIT_ST_DIR: ${{ github.workspace }}/split-out-st
+        run: node packages/chdb-wasm/test/split.test.mjs
+
+      - name: Upload split wasm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chdb-wasm-split
+          path: |
+            split-out-mt/chdb.mjs
+            split-out-mt/chdb.wasm
+            split-out-mt/chdb.deferred.wasm
+            split-out-st/chdb.mjs
+            split-out-st/chdb.wasm
+            split-out-st/chdb.deferred.wasm
+          retention-days: 7
+          if-no-files-found: error
+
       # ---- Publish to npm, only on a v* tag. Everything above (build + all Node
       # and headless-Chrome tests) ran first, so a tag that fails tests never ships.
       # dist/ is already built by the npm step above; the version is taken from the tag. ----

--- a/packages/chdb-wasm/scripts/copy-artifacts.mjs
+++ b/packages/chdb-wasm/scripts/copy-artifacts.mjs
@@ -7,7 +7,7 @@
 //   stBuildDir = ../../buildwasm-st/programs/wasm (single-threaded, OFF)       -> dist/st/
 // The single-threaded bundle is optional: if its build dir is absent it is skipped.
 
-import { copyFileSync, mkdirSync, existsSync } from 'node:fs';
+import { copyFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -37,7 +37,14 @@ function copyBundle(buildDir, destDir, { required }) {
     process.exit(1);
   }
   const files = ['chdb.mjs', 'chdb.wasm'];
-  if (existsSync(join(buildDir, 'chdb.deferred.wasm'))) files.push('chdb.deferred.wasm');
+  if (existsSync(join(buildDir, 'chdb.deferred.wasm'))) {
+    files.push('chdb.deferred.wasm');
+  } else if (existsSync(join(destDir, 'chdb.deferred.wasm'))) {
+    // Don't ship a stale deferred module left over from a previous split run —
+    // it would no longer correspond to the chdb.wasm being copied.
+    rmSync(join(destDir, 'chdb.deferred.wasm'));
+    console.log(`removed stale chdb.deferred.wasm from ${destDir.replace(pkgDir + '/', '')}/`);
+  }
   for (const f of files) {
     copyFileSync(join(buildDir, f), join(destDir, f));
     console.log(`copied ${f} -> ${destDir.replace(pkgDir + '/', '')}/`);

--- a/packages/chdb-wasm/scripts/copy-artifacts.mjs
+++ b/packages/chdb-wasm/scripts/copy-artifacts.mjs
@@ -27,7 +27,18 @@ function copyBundle(buildDir, destDir, { required }) {
     return;
   }
   mkdirSync(destDir, { recursive: true });
-  for (const f of ['chdb.mjs', 'chdb.wasm']) {
+  // A dir containing chdb.wasm.orig is a -DWASM_SPLIT_MODULE=ON CMake build
+  // tree, where chdb.wasm is the profiling-INSTRUMENTED module — never ship
+  // that. Run tools/split/split-wasm.mjs and pass its --out dir here instead
+  // (it holds the split primary + chdb.deferred.wasm + patched glue).
+  if (existsSync(join(buildDir, 'chdb.wasm.orig'))) {
+    console.error(`${buildDir} is a WASM_SPLIT_MODULE build tree (chdb.wasm there is instrumented);`);
+    console.error('run tools/split/split-wasm.mjs and point copy-artifacts at its --out dir.');
+    process.exit(1);
+  }
+  const files = ['chdb.mjs', 'chdb.wasm'];
+  if (existsSync(join(buildDir, 'chdb.deferred.wasm'))) files.push('chdb.deferred.wasm');
+  for (const f of files) {
     copyFileSync(join(buildDir, f), join(destDir, f));
     console.log(`copied ${f} -> ${destDir.replace(pkgDir + '/', '')}/`);
   }

--- a/packages/chdb-wasm/test/split.test.mjs
+++ b/packages/chdb-wasm/test/split.test.mjs
@@ -1,0 +1,187 @@
+// Tests for the wasm-split bundles (tools/split/): artifact shape, hot-path
+// completeness, lazy loading of the deferred module, negative controls, and
+// the split tooling's own guard rails.
+//
+// Points at split output dirs (each holding chdb.mjs + chdb.wasm +
+// chdb.deferred.wasm, as produced by tools/split/split-wasm.mjs --out):
+//   CHDB_SPLIT_MT_DIR=/path/mt CHDB_SPLIT_ST_DIR=/path/st node test/split.test.mjs
+// Skips cleanly when neither dir is provided (split is an opt-in build mode;
+// see tools/split/README.md).
+//
+// Functional equivalence of the engine itself is NOT re-tested here — run the
+// regular suites (matrix/datalake/...) against the split bundle via
+// CHDB_WASM_MJS for that. This file tests what is SPLIT-specific.
+
+import assert from 'node:assert';
+import { readFileSync, writeFileSync, renameSync, existsSync, mkdtempSync, copyFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const bundles = [
+  ['mt', process.env.CHDB_SPLIT_MT_DIR],
+  ['st', process.env.CHDB_SPLIT_ST_DIR],
+].filter(([, dir]) => dir && existsSync(join(dir, 'chdb.deferred.wasm')));
+
+if (!bundles.length) {
+  console.log('SKIP split.test: set CHDB_SPLIT_MT_DIR / CHDB_SPLIT_ST_DIR to split output dirs');
+  process.exit(0);
+}
+
+let checks = 0;
+const ok = (label) => { checks++; console.log(`ok: ${label}`); };
+
+// Runs a probe script in a CHILD process: lazy-load state is per-instance, so
+// cold-path and no-deferred checks each need a fresh process. Returns
+// {status, stdout, stderr}; timeout guards against the historical hang modes.
+function probe(dir, body, timeoutMs = 300000) {
+  const script = `
+    import { AsyncChdb } from ${JSON.stringify(join(pkgDir, 'dist/index.js'))};
+    const db = await AsyncChdb.create({ moduleUrl: ${JSON.stringify(join(dir, 'chdb.mjs'))} });
+    const q = async (sql) => (await db.query(sql, 'CSV')).text().trim();
+    ${body}
+    await db.terminate();
+    process.exit(0);
+  `;
+  const file = join(mkdtempSync(join(tmpdir(), 'chdb-split-test-')), 'probe.mjs');
+  writeFileSync(file, script);
+  return spawnSync(process.execPath, [file], { encoding: 'utf8', timeout: timeoutMs });
+}
+const lastLine = (r) => r.stdout.trim().split('\n').pop();
+
+for (const [variant, dir] of bundles) {
+  console.log(`===== ${variant}: ${dir}`);
+
+  // ---- artifact shape ----------------------------------------------------
+  {
+    const primary = new WebAssembly.Module(readFileSync(join(dir, 'chdb.wasm')));
+    const placeholders = WebAssembly.Module.imports(primary).filter((i) => i.module.startsWith('placeholder'));
+    assert.ok(placeholders.length > 1000, `expected >1000 placeholder imports, got ${placeholders.length}`);
+    ok(`${variant}: primary has ${placeholders.length} placeholder stubs`);
+
+    const deferredHead = readFileSync(join(dir, 'chdb.deferred.wasm')).subarray(0, 4);
+    assert.deepStrictEqual([...deferredHead], [0x00, 0x61, 0x73, 0x6d], 'deferred module wasm magic');
+    ok(`${variant}: deferred module is a wasm binary`);
+
+    const glue = readFileSync(join(dir, 'chdb.mjs'), 'utf8');
+    assert.ok(glue.includes('wasmBinaryFile??=findWasmBinary()'), 'lazy-load patch: wasmBinaryFile fallback');
+    assert.ok(glue.includes('pt__'), 'lazy-load patch: placeholder-table redispatch');
+    assert.ok(!glue.includes('chdbWriteProfile'), 'shipped glue must NOT carry the profile-collect patch');
+    ok(`${variant}: glue carries lazy-load patches only`);
+  }
+
+  // ---- hot paths: engine + full SDK surface, no deferred involvement ------
+  // (asserted for real below by renaming the deferred module away)
+  {
+    const r = probe(dir, `
+      console.log(await q('SELECT sum(number), count() FROM numbers(1000)'));
+      console.log(await q('SELECT number % 3 AS g, count() FROM numbers(9) GROUP BY g ORDER BY g'));
+      console.log(await q('SELECT a.number * 10 + b.number FROM numbers(2) a JOIN numbers(2) b ON a.number = b.number ORDER BY 1'));
+      try { await q('SELECT no_such_function_xyz(1)'); console.log('NO-ERROR'); }
+      catch (e) { console.log(e.message.includes('no_such_function_xyz') ? 'ERROR-OK' : 'BAD:' + e.message.slice(0, 60)); }
+    `);
+    assert.strictEqual(r.status, 0, `hot probe failed: ${r.stderr?.slice(-300)}`);
+    const [sum, ...rest] = r.stdout.trim().split('\n');
+    assert.strictEqual(sum, '499500,1000');
+    assert.strictEqual(rest.slice(0, 3).join('|'), '0,3|1,3|2,3');
+    assert.strictEqual(rest[3], '0');
+    assert.strictEqual(rest[4], '11');
+    assert.strictEqual(rest[5], 'ERROR-OK');
+    ok(`${variant}: hot queries + error reporting exact results`);
+  }
+
+  // ---- session + streaming + putFile on the split bundle ------------------
+  {
+    const r = probe(dir, `
+      const conn = await db.connect();
+      await conn.query('CREATE TABLE t (x Int32, s String) ENGINE = Memory');
+      await conn.query("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+      console.log((await conn.query('SELECT sum(x), max(s) FROM t')).text().trim());
+      let rows = 0;
+      for await (const chunk of conn.queryStream('SELECT number FROM numbers(50000)', 'CSV'))
+        rows += chunk.text().split('\\n').filter(Boolean).length;
+      console.log('rows=' + rows);
+      await db.putFile('/split-test.csv', new TextEncoder().encode('7,x\\n8,y\\n'));
+      console.log(await q("SELECT sum(c1), max(c2) FROM file('/split-test.csv', CSV)"));
+    `);
+    assert.strictEqual(r.status, 0, `session probe failed: ${r.stderr?.slice(-300)}`);
+    const lines = r.stdout.trim().split('\n');
+    assert.strictEqual(lines[0], '6,"c"');
+    assert.strictEqual(lines[1], 'rows=50000');
+    assert.strictEqual(lines[2], '15,"y"');
+    ok(`${variant}: session DDL/DML, streaming (50k rows), putFile+file() on split bundle`);
+  }
+
+  // ---- cold path: lazy-loads the deferred module and computes correctly ---
+  {
+    // toModifiedJulianDay/fromModifiedJulianDay are deliberately NOT in
+    // profile-corpus.sql — keep it that way or this test stops testing.
+    const r = probe(dir, `console.log(await q("SELECT toModifiedJulianDay('2024-03-15'), fromModifiedJulianDay(60384)"));`);
+    assert.strictEqual(r.status, 0, `cold probe failed: ${r.stderr?.slice(-300)}`);
+    assert.strictEqual(lastLine(r), '60384,"2024-03-15"');
+    ok(`${variant}: cold function lazy-loads deferred module, exact result`);
+  }
+
+  // ---- negative controls: deferred module renamed away ---------------------
+  {
+    const deferred = join(dir, 'chdb.deferred.wasm');
+    renameSync(deferred, deferred + '.hidden');
+    try {
+      // Everything above except the cold query must STILL work: init, session,
+      // streaming, files, error reporting — proof the primary is self-contained.
+      const hot = probe(dir, `
+        console.log(await q('SELECT sum(number), count() FROM numbers(1000)'));
+        const conn = await db.connect();
+        await conn.query('CREATE TABLE t (x Int32) ENGINE = Memory');
+        await conn.query('INSERT INTO t SELECT number FROM numbers(10)');
+        console.log((await conn.query('SELECT sum(x) FROM t')).text().trim());
+        try { await q('SELECT no_such_function_xyz(1)'); } catch (e) { console.log('ERROR-OK'); }
+      `);
+      assert.strictEqual(hot.status, 0, `hot-without-deferred failed: ${hot.stderr?.slice(-300)}`);
+      assert.strictEqual(hot.stdout.trim().split('\n').join('|'), '499500,1000|45|ERROR-OK');
+      ok(`${variant}: primary fully self-contained without deferred module`);
+
+      // The cold query must fail FAST with a real error — not hang (the
+      // historical failure mode) and not succeed.
+      const cold = probe(dir, `console.log(await q("SELECT toModifiedJulianDay('2024-03-15')"));`, 120000);
+      assert.notStrictEqual(cold.status, 0, 'cold query without deferred must fail');
+      assert.notStrictEqual(cold.status, null, 'cold query without deferred must not hang until timeout');
+      ok(`${variant}: cold call without deferred fails fast (no hang)`);
+    } finally {
+      renameSync(deferred + '.hidden', deferred);
+    }
+  }
+}
+
+// ---- tooling guard rails (repo-level, bundle-independent) -------------------
+{
+  // patch-glue is idempotent on an already-patched glue…
+  const patched = join(bundles[0][1], 'chdb.mjs');
+  const tmp = join(mkdtempSync(join(tmpdir(), 'chdb-split-test-')), 'glue.mjs');
+  copyFileSync(patched, tmp);
+  const before = readFileSync(tmp, 'utf8');
+  const again = spawnSync(process.execPath, [join(pkgDir, 'tools/split/patch-glue.mjs'), tmp, '--lazy-load'], { encoding: 'utf8' });
+  assert.strictEqual(again.status, 0, again.stderr);
+  assert.ok(again.stdout.includes('already patched'));
+  assert.strictEqual(readFileSync(tmp, 'utf8'), before, 'idempotent re-patch must not change the file');
+  ok('patch-glue: idempotent on already-patched glue');
+
+  // …and fails loudly when its anchors are missing (emscripten upgrade guard).
+  writeFileSync(tmp, 'export default function notAGlue() {}');
+  const bad = spawnSync(process.execPath, [join(pkgDir, 'tools/split/patch-glue.mjs'), tmp, '--lazy-load'], { encoding: 'utf8' });
+  assert.notStrictEqual(bad.status, 0, 'patch-glue must fail on foreign input');
+  ok('patch-glue: fails loudly when anchors are missing');
+
+  // copy-artifacts refuses a WASM_SPLIT_MODULE build tree (its chdb.wasm is
+  // the profiling-instrumented module, never shippable).
+  const fakeBuild = mkdtempSync(join(tmpdir(), 'chdb-split-test-'));
+  for (const f of ['chdb.mjs', 'chdb.wasm', 'chdb.wasm.orig']) writeFileSync(join(fakeBuild, f), 'x');
+  const guard = spawnSync(process.execPath, [join(pkgDir, 'scripts/copy-artifacts.mjs'), fakeBuild], { encoding: 'utf8' });
+  assert.notStrictEqual(guard.status, 0, 'copy-artifacts must reject an instrumented build tree');
+  assert.ok((guard.stderr + guard.stdout).includes('instrumented'), 'guard message names the reason');
+  ok('copy-artifacts: refuses to ship from an instrumented build tree');
+}
+
+console.log(`PASS split.test (${checks} checks, bundles: ${bundles.map(([v]) => v).join('+')})`);

--- a/packages/chdb-wasm/test/split.test.mjs
+++ b/packages/chdb-wasm/test/split.test.mjs
@@ -13,17 +13,29 @@
 // CHDB_WASM_MJS for that. This file tests what is SPLIT-specific.
 
 import assert from 'node:assert';
-import { readFileSync, writeFileSync, renameSync, existsSync, mkdtempSync, copyFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, mkdirSync, rmSync, copyFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)));
+// An UNSET env var skips that bundle; a SET one pointing at a dir without the
+// split artifacts fails loudly — otherwise a pipeline regression that stops
+// emitting chdb.deferred.wasm would silently turn CI's run into a skip.
 const bundles = [
   ['mt', process.env.CHDB_SPLIT_MT_DIR],
   ['st', process.env.CHDB_SPLIT_ST_DIR],
-].filter(([, dir]) => dir && existsSync(join(dir, 'chdb.deferred.wasm')));
+].filter(([variant, dir]) => {
+  if (!dir) return false;
+  for (const f of ['chdb.mjs', 'chdb.wasm', 'chdb.deferred.wasm']) {
+    if (!existsSync(join(dir, f))) {
+      console.error(`FAIL split.test: CHDB_SPLIT_${variant.toUpperCase()}_DIR=${dir} is set but ${f} is missing`);
+      process.exit(1);
+    }
+  }
+  return true;
+});
 
 if (!bundles.length) {
   console.log('SKIP split.test: set CHDB_SPLIT_MT_DIR / CHDB_SPLIT_ST_DIR to split output dirs');
@@ -36,6 +48,11 @@ const ok = (label) => { checks++; console.log(`ok: ${label}`); };
 // Runs a probe script in a CHILD process: lazy-load state is per-instance, so
 // cold-path and no-deferred checks each need a fresh process. Returns
 // {status, stdout, stderr}; timeout guards against the historical hang modes.
+const tmpRoot = mkdtempSync(join(tmpdir(), 'chdb-split-test-'));
+process.on('exit', () => rmSync(tmpRoot, { recursive: true, force: true }));
+let tmpSeq = 0;
+const tmpFile = (name) => { mkdirSync(join(tmpRoot, String(++tmpSeq))); return join(tmpRoot, String(tmpSeq), name); };
+
 function probe(dir, body, timeoutMs = 300000) {
   const script = `
     import { AsyncChdb } from ${JSON.stringify(join(pkgDir, 'dist/index.js'))};
@@ -45,7 +62,7 @@ function probe(dir, body, timeoutMs = 300000) {
     await db.terminate();
     process.exit(0);
   `;
-  const file = join(mkdtempSync(join(tmpdir(), 'chdb-split-test-')), 'probe.mjs');
+  const file = tmpFile('probe.mjs');
   writeFileSync(file, script);
   return spawnSync(process.execPath, [file], { encoding: 'utf8', timeout: timeoutMs });
 }
@@ -73,7 +90,7 @@ for (const [variant, dir] of bundles) {
   }
 
   // ---- hot paths: engine + full SDK surface, no deferred involvement ------
-  // (asserted for real below by renaming the deferred module away)
+  // (asserted for real below against a copy that has no deferred module)
   {
     const r = probe(dir, `
       console.log(await q('SELECT sum(number), count() FROM numbers(1000)'));
@@ -117,41 +134,45 @@ for (const [variant, dir] of bundles) {
   // ---- cold path: lazy-loads the deferred module and computes correctly ---
   {
     // toModifiedJulianDay/fromModifiedJulianDay are deliberately NOT in
-    // profile-corpus.sql — keep it that way or this test stops testing.
+    // profile-corpus.sql; enforced here, or adding them to the corpus would
+    // silently turn the cold-path checks into hot-path ones.
+    const corpus = readFileSync(join(pkgDir, 'tools/split/profile-corpus.sql'), 'utf8');
+    assert.ok(!corpus.includes('ModifiedJulianDay'), 'profile-corpus.sql must not contain the cold-probe functions');
     const r = probe(dir, `console.log(await q("SELECT toModifiedJulianDay('2024-03-15'), fromModifiedJulianDay(60384)"));`);
     assert.strictEqual(r.status, 0, `cold probe failed: ${r.stderr?.slice(-300)}`);
     assert.strictEqual(lastLine(r), '60384,"2024-03-15"');
     ok(`${variant}: cold function lazy-loads deferred module, exact result`);
   }
 
-  // ---- negative controls: deferred module renamed away ---------------------
+  // ---- negative controls: a COPY of the bundle without the deferred module.
+  // Never mutate the real dir: a hard kill mid-test would leave it broken for
+  // whatever reads it next (in CI, the split-artifact upload).
   {
-    const deferred = join(dir, 'chdb.deferred.wasm');
-    renameSync(deferred, deferred + '.hidden');
-    try {
-      // Everything above except the cold query must STILL work: init, session,
-      // streaming, files, error reporting — proof the primary is self-contained.
-      const hot = probe(dir, `
-        console.log(await q('SELECT sum(number), count() FROM numbers(1000)'));
-        const conn = await db.connect();
-        await conn.query('CREATE TABLE t (x Int32) ENGINE = Memory');
-        await conn.query('INSERT INTO t SELECT number FROM numbers(10)');
-        console.log((await conn.query('SELECT sum(x) FROM t')).text().trim());
-        try { await q('SELECT no_such_function_xyz(1)'); } catch (e) { console.log('ERROR-OK'); }
-      `);
-      assert.strictEqual(hot.status, 0, `hot-without-deferred failed: ${hot.stderr?.slice(-300)}`);
-      assert.strictEqual(hot.stdout.trim().split('\n').join('|'), '499500,1000|45|ERROR-OK');
-      ok(`${variant}: primary fully self-contained without deferred module`);
+    const noDeferred = join(tmpRoot, `no-deferred-${variant}`);
+    mkdirSync(noDeferred);
+    copyFileSync(join(dir, 'chdb.mjs'), join(noDeferred, 'chdb.mjs'));
+    copyFileSync(join(dir, 'chdb.wasm'), join(noDeferred, 'chdb.wasm'));
 
-      // The cold query must fail FAST with a real error — not hang (the
-      // historical failure mode) and not succeed.
-      const cold = probe(dir, `console.log(await q("SELECT toModifiedJulianDay('2024-03-15')"));`, 120000);
-      assert.notStrictEqual(cold.status, 0, 'cold query without deferred must fail');
-      assert.notStrictEqual(cold.status, null, 'cold query without deferred must not hang until timeout');
-      ok(`${variant}: cold call without deferred fails fast (no hang)`);
-    } finally {
-      renameSync(deferred + '.hidden', deferred);
-    }
+    // Everything above except the cold query must STILL work: init, session,
+    // streaming, files, error reporting — proof the primary is self-contained.
+    const hot = probe(noDeferred, `
+      console.log(await q('SELECT sum(number), count() FROM numbers(1000)'));
+      const conn = await db.connect();
+      await conn.query('CREATE TABLE t (x Int32) ENGINE = Memory');
+      await conn.query('INSERT INTO t SELECT number FROM numbers(10)');
+      console.log((await conn.query('SELECT sum(x) FROM t')).text().trim());
+      try { await q('SELECT no_such_function_xyz(1)'); } catch (e) { console.log('ERROR-OK'); }
+    `);
+    assert.strictEqual(hot.status, 0, `hot-without-deferred failed: ${hot.stderr?.slice(-300)}`);
+    assert.strictEqual(hot.stdout.trim().split('\n').join('|'), '499500,1000|45|ERROR-OK');
+    ok(`${variant}: primary fully self-contained without deferred module`);
+
+    // The cold query must fail FAST with a real error — not hang (the
+    // historical failure mode) and not succeed.
+    const cold = probe(noDeferred, `console.log(await q("SELECT toModifiedJulianDay('2024-03-15')"));`, 120000);
+    assert.notStrictEqual(cold.status, 0, 'cold query without deferred must fail');
+    assert.notStrictEqual(cold.status, null, 'cold query without deferred must not hang until timeout');
+    ok(`${variant}: cold call without deferred fails fast (no hang)`);
   }
 }
 
@@ -159,7 +180,7 @@ for (const [variant, dir] of bundles) {
 {
   // patch-glue is idempotent on an already-patched glue…
   const patched = join(bundles[0][1], 'chdb.mjs');
-  const tmp = join(mkdtempSync(join(tmpdir(), 'chdb-split-test-')), 'glue.mjs');
+  const tmp = tmpFile('glue.mjs');
   copyFileSync(patched, tmp);
   const before = readFileSync(tmp, 'utf8');
   const again = spawnSync(process.execPath, [join(pkgDir, 'tools/split/patch-glue.mjs'), tmp, '--lazy-load'], { encoding: 'utf8' });
@@ -176,7 +197,8 @@ for (const [variant, dir] of bundles) {
 
   // copy-artifacts refuses a WASM_SPLIT_MODULE build tree (its chdb.wasm is
   // the profiling-instrumented module, never shippable).
-  const fakeBuild = mkdtempSync(join(tmpdir(), 'chdb-split-test-'));
+  const fakeBuild = join(tmpRoot, 'fake-build');
+  mkdirSync(fakeBuild);
   for (const f of ['chdb.mjs', 'chdb.wasm', 'chdb.wasm.orig']) writeFileSync(join(fakeBuild, f), 'x');
   const guard = spawnSync(process.execPath, [join(pkgDir, 'scripts/copy-artifacts.mjs'), fakeBuild], { encoding: 'utf8' });
   assert.notStrictEqual(guard.status, 0, 'copy-artifacts must reject an instrumented build tree');

--- a/packages/chdb-wasm/tools/split/README.md
+++ b/packages/chdb-wasm/tools/split/README.md
@@ -14,12 +14,12 @@ function granularity, driven by an execution profile recorded while running
 functions, formats, DDL/DML, error paths, Iceberg/Delta/DataLakeCatalog) against
 the instrumented build.
 
-Measured on the 26.5 build (verify-split all green, full test matrix passing):
+Measured on the 26.5 build (split.test 19/19, full test matrix passing):
 
-| bundle | before | primary (up-front) | deferred (lazy) |
-| --- | --- | --- | --- |
-| mt | 99.3MB | **40.8MB** | 64.2MB |
-| st | 99.2MB | **38.3MB** | 66.4MB |
+| bundle | before | primary (up-front) | deferred (lazy) | gzip transfer |
+| --- | --- | --- | --- | --- |
+| mt | 99.3MB | **41.7MB** | 64.1MB | 21.2MB → **9.2MB** |
+| st | 99.2MB | **39.5MB** | 66.3MB | → 8.6MB |
 
 ## Runbook
 
@@ -104,3 +104,13 @@ statements are skipped (and their code ends up in the deferred module).
   `-g` re-split and the secondary's elem section.
 - keep-funcs entries must be in wasm-split's ESCAPED name form (`\28\29` for
   parens, `\20` for spaces) — raw demangled names silently match nothing.
+- **Synthesized names don't transfer across links**: nameless lambda thunks
+  (bare-index names) and wasm-ld's signature bridges (`trampoline_X`,
+  `X_<number>`) get link-specific names, so the st hot set can't cover them on
+  mt even though hot code calls straight into them. Every cold one is
+  force-kept (~10k tiny functions, ~1MB).
+- The engine's ONE cold start per process is claimed by whichever API runs
+  first — profile both orders (main pass boots via connect, the
+  CHDB_INIT_PROBE=global pass boots via connectionless query, then both run
+  the corpus). And keep unqualified default-database DDL in the corpus:
+  clickhouse-local's DatabaseOverlay is its own code path.

--- a/packages/chdb-wasm/tools/split/README.md
+++ b/packages/chdb-wasm/tools/split/README.md
@@ -1,0 +1,87 @@
+# wasm-split pipeline
+
+Splits `chdb.wasm` into a **primary** module holding the profile-hot functions
+(downloaded up front) and a **deferred** module holding everything else
+(`chdb.deferred.wasm`). The first call into a function that lives in the
+deferred module synchronously fetches + instantiates it (once per wasm
+instance; the browser HTTP cache makes repeats cheap), patches the shared
+function table, and the original call proceeds. **No functionality is lost** —
+a query touching cold code just stalls once for the download.
+
+Mechanics: Emscripten `-sSPLIT_MODULE` + Binaryen `wasm-split`. The split is at
+function granularity, driven by an execution profile recorded while running
+`profile-corpus.sql` (SQL operators, scalar/aggregate function families, table
+functions, formats, DDL/DML, error paths, Iceberg/Delta/DataLakeCatalog) against
+the instrumented build.
+
+## Runbook
+
+```sh
+# 1. build both trees with the split link option (only relinks, cheap)
+source ~/code/emsdk/emsdk_env.sh
+cd buildwasm     && cmake -DWASM_SPLIT_MODULE=ON . && ninja chdb_wasm
+cd ../buildwasm-st && cmake -DWASM_SPLIT_MODULE=ON . && ninja chdb_wasm
+# each emits: chdb.mjs (glue with lazy-load proxy), chdb.wasm (instrumented),
+#             chdb.wasm.orig (the real artifact that gets split)
+
+# 2. single-threaded bundle FIRST — its lone instance executes the whole query
+#    pipeline inline, so its hot set is the complete corpus coverage; export it
+node tools/split/split-wasm.mjs --build ../../buildwasm-st/programs/wasm \
+    --out /tmp/chdb-split-st --emit-hot-names /tmp/chdb-split-st/hot-names.txt
+
+# 3. threaded bundle, mixing in the st hot set: mt pool workers park in
+#    Atomics.wait and cannot answer the profile-collection message, so work
+#    that ran only on worker threads is invisible to the mt profile
+node tools/split/split-wasm.mjs --build ../../buildwasm/programs/wasm \
+    --out /tmp/chdb-split-mt --extra-hot /tmp/chdb-split-st/hot-names.txt
+
+# 4. verify each split bundle (hot query / cold lazy-load / negative control)
+node tools/split/verify-split.mjs /tmp/chdb-split-mt
+node tools/split/verify-split.mjs /tmp/chdb-split-st
+
+# 5. install into dist/ (+ dist/st) and run the test suites against it
+node scripts/copy-artifacts.mjs /tmp/chdb-split-mt /tmp/chdb-split-st
+CHDB_WASM_MJS=$PWD/dist/chdb.mjs node test/smoke.test.mjs
+```
+
+Prereqs: `/tmp/node24/bin/node` (>=23), and for the data-lake corpus sections a
+venv at `ICEBERG_PY` (default `/tmp/iceberg-venv/bin/python`) with
+`pyiceberg[sql-sqlite] pyarrow moto[server] s3fs deltalake`; without it those
+statements are skipped (and their code ends up in the deferred module).
+
+## Files
+
+| file | role |
+| --- | --- |
+| `profile-corpus.sql` | defines the hot set; statements ending in failure are fine (error handling should be hot too); `/*mt-only*/` statements are skipped on st |
+| `run-profile.mjs` | executes the corpus + streaming C API against the instrumented bundle, dumps one profile per wasm instance |
+| `fixture-host.mjs` | out-of-process mocks (static HTTP for `url()`, Iceberg REST + Unity catalogs); moto runs as its own python process |
+| `patch-glue.mjs` | two glue patches with hard anchor checks: `--lazy-load` (wasmBinaryFile fallback so pthread workers can resolve `chdb.deferred.wasm`) and `--profile-collect` (worker-side `chdbWriteProfile` message) |
+| `split-wasm.mjs` | merge profiles → keep-list (thread-runtime safety regex + `--extra-hot`) → `wasm-split` → install |
+| `verify-split.mjs` | asserts hot query works, cold query lazy-loads, and the cold query FAILS when `chdb.deferred.wasm` is hidden (negative control) |
+
+## Gotchas learned the hard way
+
+- **Per-instance profiles**: wasm-split's instrumentation counters are wasm
+  globals — every pthread worker instance has its own. The main instance's
+  `__write_profile` sees only main-thread execution. Binaryen's shared-memory
+  instrumentation modes (`--in-memory`, `--in-secondary-memory`) emit invalid
+  code for Memory64 (i32 addressing), so they're not usable here — hence the
+  st-hot-names transfer plus the thread-runtime safety keep-list.
+- **Parked workers**: idle ClickHouse pool threads sit in `Atomics.wait`; their
+  workers never service `postMessage`, so per-worker collection mostly times
+  out on mt. Harmless (5s timeout each), but it's why `--extra-hot` exists.
+- **pthread instantiation**: the split primary's placeholder imports are read
+  during `new WebAssembly.Instance` in each worker, where the stock glue never
+  set `wasmBinaryFile` — without the `--lazy-load` patch the pool hangs at
+  startup.
+- **Names**: `-sSPLIT_MODULE` keeps the name section in `chdb.wasm.orig`
+  (needed for keep-funcs matching); wasm-split strips it from both outputs by
+  default. Export names are minified, so reach `malloc` via `Module._malloc`,
+  not `wasmExports.malloc`; binaryen-added `__write_profile` is unminified and
+  raw (BigInt i64 pointer arg, Number i32 length).
+- **print-profile output exceeds V8's string limit** (~140k functions with huge
+  mangled names) — always stream it.
+- The corpus runner must never host HTTP fixtures in-process: queries block the
+  main thread synchronously while the wasm HTTP bridge waits on a child
+  process fetch, deadlocking any same-process server.

--- a/packages/chdb-wasm/tools/split/README.md
+++ b/packages/chdb-wasm/tools/split/README.md
@@ -14,6 +14,13 @@ function granularity, driven by an execution profile recorded while running
 functions, formats, DDL/DML, error paths, Iceberg/Delta/DataLakeCatalog) against
 the instrumented build.
 
+Measured on the 26.5 build (verify-split all green, full test matrix passing):
+
+| bundle | before | primary (up-front) | deferred (lazy) |
+| --- | --- | --- | --- |
+| mt | 99.3MB | **40.8MB** | 64.2MB |
+| st | 99.2MB | **38.3MB** | 66.4MB |
+
 ## Runbook
 
 ```sh
@@ -85,3 +92,15 @@ statements are skipped (and their code ends up in the deferred module).
 - The corpus runner must never host HTTP fixtures in-process: queries block the
   main thread synchronously while the wasm HTTP bridge waits on a child
   process fetch, deadlocking any same-process server.
+- **Worker-path blind spot**: code that runs ONLY on mt worker instances is
+  invisible to every profile pass (per-instance globals + parked workers) and
+  often absent from the st hot set too (st takes synchronous implementations —
+  LazyOutputFormat, ParallelFormattingOutputFormat, the thread-entry
+  trampolines). Covered by SAFETY/SAFETY_SUBSTR patterns and
+  keep-worker-path.txt. If a new one appears, the symptom is a hang or
+  "worker sent an error" on a bundle whose chdb.deferred.wasm is unreachable;
+  find it by logging `base` in the glue's placeholder trampoline (workers
+  can't console.log — append to a file), then map the ordinal to a name via a
+  `-g` re-split and the secondary's elem section.
+- keep-funcs entries must be in wasm-split's ESCAPED name form (`\28\29` for
+  parens, `\20` for spaces) — raw demangled names silently match nothing.

--- a/packages/chdb-wasm/tools/split/fixture-host.mjs
+++ b/packages/chdb-wasm/tools/split/fixture-host.mjs
@@ -13,20 +13,28 @@
 //   fixture-host.mjs --http-port N --static-dir DIR
 //       [--catalog-port N --iceberg-descriptor FILE]
 //       [--unity-port N --unity-descriptor FILE]
-// Prints "READY" on stdout once everything listens; exits with the parent.
+// Prints "READY" on stdout once everything listens; exits when the parent
+// dies (watchdog on the piped stdin — survives even a SIGKILL'd parent).
 
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
-import { join, normalize } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, join, normalize } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const args = {};
 for (let i = 2; i < process.argv.length; i += 2) args[process.argv[i].replace(/^--/, '')] = process.argv[i + 1];
 
 const testDir = join(dirname(fileURLToPath(import.meta.url)), '../../test');
-const { startMockCatalog } = await import(join(testDir, 'datalake/mock-rest-catalog.mjs'));
-const { startMockUnityCatalog } = await import(join(testDir, 'datalake/mock-unity-catalog.mjs'));
+// pathToFileURL: a raw filesystem path is not a valid ESM specifier on Windows.
+const { startMockCatalog } = await import(pathToFileURL(join(testDir, 'datalake/mock-rest-catalog.mjs')).href);
+const { startMockUnityCatalog } = await import(pathToFileURL(join(testDir, 'datalake/mock-unity-catalog.mjs')).href);
+
+// Parent-liveness watchdog: the runner spawns us with a piped stdin; when the
+// parent dies for ANY reason (including SIGKILL, where its cleanup handlers
+// never run), the pipe closes and we exit instead of orphaning the ports.
+process.stdin.resume();
+process.stdin.on('close', () => process.exit(0));
+process.stdin.on('end', () => process.exit(0));
 
 function listenOrReject(server, port) {
   return new Promise((resolve, reject) => {

--- a/packages/chdb-wasm/tools/split/fixture-host.mjs
+++ b/packages/chdb-wasm/tools/split/fixture-host.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Fixture services for the profiling run, hosted in a SEPARATE process: the
+// profiling runner executes queries synchronously on its main thread, so any
+// HTTP service living in the runner's event loop would deadlock the moment a
+// query fetches from it (the wasm HTTP bridge blocks the thread that would
+// serve the response). moto (python) is already its own process; this hosts
+// the pure-Node pieces:
+//   * a static file server for url() statements ({HTTP})
+//   * the mock Iceberg REST catalog ({CATALOG}, reused from test/datalake/)
+//   * the mock Unity catalog ({UNITY})
+//
+// Usage:
+//   fixture-host.mjs --http-port N --static-dir DIR
+//       [--catalog-port N --iceberg-descriptor FILE]
+//       [--unity-port N --unity-descriptor FILE]
+// Prints "READY" on stdout once everything listens; exits with the parent.
+
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const args = {};
+for (let i = 2; i < process.argv.length; i += 2) args[process.argv[i].replace(/^--/, '')] = process.argv[i + 1];
+
+const testDir = join(dirname(fileURLToPath(import.meta.url)), '../../test');
+const { startMockCatalog } = await import(join(testDir, 'datalake/mock-rest-catalog.mjs'));
+const { startMockUnityCatalog } = await import(join(testDir, 'datalake/mock-unity-catalog.mjs'));
+
+function listenOrReject(server, port) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve(server);
+    });
+  });
+}
+
+const jobs = [];
+
+if (args['http-port']) {
+  const dir = args['static-dir'];
+  const server = createServer((req, res) => {
+    try {
+      const rel = normalize(decodeURIComponent((req.url || '/').split('?')[0])).replace(/^([/\\]|\.\.[/\\])+/, '');
+      const body = readFileSync(join(dir, rel));
+      res.setHeader('Content-Length', body.length);
+      res.end(body);
+    } catch {
+      res.statusCode = 404;
+      res.end('not found');
+    }
+  });
+  jobs.push(listenOrReject(server, Number(args['http-port'])));
+}
+
+if (args['catalog-port']) {
+  const descriptor = JSON.parse(readFileSync(args['iceberg-descriptor'], 'utf8'));
+  jobs.push(startMockCatalog({ port: Number(args['catalog-port']), descriptor }));
+}
+
+if (args['unity-port']) {
+  const descriptor = JSON.parse(readFileSync(args['unity-descriptor'], 'utf8'));
+  jobs.push(startMockUnityCatalog({ port: Number(args['unity-port']), descriptor }));
+}
+
+await Promise.all(jobs);
+console.log('READY');

--- a/packages/chdb-wasm/tools/split/keep-worker-path.txt
+++ b/packages/chdb-wasm/tools/split/keep-worker-path.txt
@@ -1,0 +1,8 @@
+# Worker-path functions that must stay in the split primary, found by probing
+# a deferred-less mt bundle to convergence (see README "Gotchas"). Escaped
+# wasm-name form, exactly as wasm-split prints them. Family-wide patterns
+# live in split-wasm.mjs (SAFETY/SAFETY_SUBSTR); this file holds the
+# leftovers that are single concrete functions.
+DB::HashTablesStatistics<DB::AggregationEntry>&\20DB::getHashTablesStatistics<DB::AggregationEntry>\28\29
+Poco::EventImpl::resetImpl\28\29
+Poco::EventImpl::setImpl\28\29

--- a/packages/chdb-wasm/tools/split/patch-glue.mjs
+++ b/packages/chdb-wasm/tools/split/patch-glue.mjs
@@ -55,7 +55,21 @@ if (doLazy) {
     // Both branches of the proxy (old `placeholder` and new `placeholder.N`
     // module-name formats) compute the secondary file name this way.
     replaceCounted('lazy-load', 'wasmBinaryFile.slice(0,-5)', '(wasmBinaryFile??=findWasmBinary()).slice(0,-5)', 2);
-    console.log('lazy-load: patched (2 sites)');
+
+    // binaryen's wasm-split puts placeholders in a SECOND table (the import
+    // name is a sequential ordinal into it), and the secondary module's elem
+    // repairs THAT table — but the glue trampoline re-dispatches through the
+    // MAIN function table (wasmTable), reaching an unrelated function. Pick
+    // the placeholder table out of the raw exports (the split step exports it
+    // via --export-prefix); it is 32-bit even when the main table is table64,
+    // so index with whichever type its length reports.
+    replaceCounted(
+      'lazy-load(redispatch)',
+      'return wasmTable.get(BigInt(base))(...args)}',
+      'var pt__=Object.values(wasmRawExports).find((v)=>v instanceof WebAssembly.Table&&v!==wasmTable)||wasmTable;'
+        + 'return pt__.get(typeof pt__.length==="bigint"?BigInt(base):Number(base))(...args)}',
+      1);
+    console.log('lazy-load: patched (2 sites + placeholder-table redispatch)');
   }
 }
 

--- a/packages/chdb-wasm/tools/split/patch-glue.mjs
+++ b/packages/chdb-wasm/tools/split/patch-glue.mjs
@@ -40,6 +40,7 @@ if (!file || (!doLazy && !doProfile)) {
 }
 
 let src = readFileSync(file, 'utf8');
+const srcBefore = src;
 
 function replaceCounted(what, anchor, replacement, expected) {
   const n = src.split(anchor).length - 1;
@@ -66,7 +67,9 @@ if (doLazy) {
     replaceCounted(
       'lazy-load(redispatch)',
       'return wasmTable.get(BigInt(base))(...args)}',
-      'var pt__=Object.values(wasmRawExports).find((v)=>v instanceof WebAssembly.Table&&v!==wasmTable)||wasmTable;'
+      'var pts__=Object.values(wasmRawExports).filter((v)=>v instanceof WebAssembly.Table&&v!==wasmTable);'
+        + 'if(pts__.length!==1)throw new Error("chdb split: expected exactly one placeholder table, found "+pts__.length);'
+        + 'var pt__=pts__[0];'
         + 'return pt__.get(typeof pt__.length==="bigint"?BigInt(base):Number(base))(...args)}',
       1);
     console.log('lazy-load: patched (2 sites + placeholder-table redispatch)');
@@ -87,14 +90,20 @@ if (doProfile) {
     // parentPort in Node). Memory64: the pointer parameter is a raw i64 ->
     // BigInt; the byte-count parameter is i32 -> Number.
     const anchor = 'else if(msgData.target==="setimmediate"){}';
+    // try/catch so ANY failure still posts a reply — otherwise the runner
+    // burns its per-worker timeout with no indication of the real cause.
     const branch =
       'else if(cmd==="chdbWriteProfile"){' +
-      'var wp__=wasmExports["__write_profile"];' +
-      'var n__=wp__?Number(wp__(BigInt(msgData.ptr),msgData.cap)):-1;' +
+      'var n__=-1;' +
+      'try{var wp__=wasmExports["__write_profile"];' +
+      'if(wp__)n__=Number(wp__(BigInt(msgData.ptr),msgData.cap))}' +
+      'catch(e__){n__=-1}' +
       'postMessage({cmd:"callHandler",handler:"__chdbProfileWritten",args:[msgData.tag,n__]})}';
     replaceCounted('profile-collect', anchor, branch + anchor, 1);
     console.log('profile-collect: patched');
   }
 }
 
-writeFileSync(file, src);
+// Don't dirty the mtime when every branch was a no-op (already patched /
+// single-threaded skip) — that can trigger spurious downstream rebuilds.
+if (src !== srcBefore) writeFileSync(file, src);

--- a/packages/chdb-wasm/tools/split/patch-glue.mjs
+++ b/packages/chdb-wasm/tools/split/patch-glue.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Post-link patches for the -sSPLIT_MODULE Emscripten glue (chdb.mjs).
+//
+// Two independent patches, selected by flags; each asserts its anchor text so
+// an emsdk upgrade that changes the glue fails LOUDLY here instead of hanging
+// at runtime:
+//
+// --lazy-load (shipped split bundle AND instrumented bundle):
+//   The placeholder-import proxy derives the deferred file name from
+//   `wasmBinaryFile`, but pthread workers instantiate the module from the
+//   postMessage'd WebAssembly.Module without ever assigning wasmBinaryFile
+//   (preamble sets it only on the main-instance path), so the first cold call
+//   on a worker — or plain instantiation of the split primary, whose
+//   placeholder imports are read during `new WebAssembly.Instance` — throws.
+//   Fix: fall back to findWasmBinary() at the use site.
+//
+// --profile-collect (instrumented mt bundle only):
+//   wasm-split's instrumentation counters live in module GLOBALS, which are
+//   per-instance — and every pthread worker is its own instance. The main
+//   instance's __write_profile therefore misses everything that only ran on
+//   workers (thread entry points, futex/proxying, IO-pool reads, parallel
+//   parsing...). This patch adds a `chdbWriteProfile` command to the worker
+//   message dispatch: the worker calls ITS OWN instance's __write_profile,
+//   writing into a caller-provided buffer in the SHARED linear memory, and
+//   replies through the existing `callHandler` main-thread dispatch
+//   (Module.__chdbProfileWritten(tag, len)). The profiling runner collects one
+//   profile per worker plus the main instance and wasm-split --merge-profiles
+//   unions them.
+//
+// Usage: patch-glue.mjs <chdb.mjs> [--lazy-load] [--profile-collect]
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const file = process.argv[2];
+const doLazy = process.argv.includes('--lazy-load');
+const doProfile = process.argv.includes('--profile-collect');
+if (!file || (!doLazy && !doProfile)) {
+  console.error('usage: patch-glue.mjs <chdb.mjs> [--lazy-load] [--profile-collect]');
+  process.exit(2);
+}
+
+let src = readFileSync(file, 'utf8');
+
+function replaceCounted(what, anchor, replacement, expected) {
+  const n = src.split(anchor).length - 1;
+  if (n !== expected)
+    throw new Error(`${what}: expected ${expected} occurrence(s) of anchor, found ${n} — emscripten glue changed, re-verify the patch`);
+  src = src.split(anchor).join(replacement);
+}
+
+if (doLazy) {
+  if (src.includes('wasmBinaryFile??=findWasmBinary()).slice(0,-5)')) {
+    console.log('lazy-load: already patched');
+  } else {
+    // Both branches of the proxy (old `placeholder` and new `placeholder.N`
+    // module-name formats) compute the secondary file name this way.
+    replaceCounted('lazy-load', 'wasmBinaryFile.slice(0,-5)', '(wasmBinaryFile??=findWasmBinary()).slice(0,-5)', 2);
+    console.log('lazy-load: patched (2 sites)');
+  }
+}
+
+if (doProfile) {
+  if (src.includes('chdbWriteProfile')) {
+    console.log('profile-collect: already patched');
+  } else if (!src.includes('unusedWorkers')) {
+    // Single-threaded glue: no pthread workers, nothing to collect from — the
+    // main instance's __write_profile already sees everything.
+    console.log('profile-collect: single-threaded glue, skipped');
+  } else {
+    // Insert before the worker-side setimmediate no-op branch. In scope here:
+    // msgData (the message), wasmExports (THIS worker instance's raw exports,
+    // where binaryen's __write_profile lives), postMessage (bridged to
+    // parentPort in Node). Memory64: the pointer parameter is a raw i64 ->
+    // BigInt; the byte-count parameter is i32 -> Number.
+    const anchor = 'else if(msgData.target==="setimmediate"){}';
+    const branch =
+      'else if(cmd==="chdbWriteProfile"){' +
+      'var wp__=wasmExports["__write_profile"];' +
+      'var n__=wp__?Number(wp__(BigInt(msgData.ptr),msgData.cap)):-1;' +
+      'postMessage({cmd:"callHandler",handler:"__chdbProfileWritten",args:[msgData.tag,n__]})}';
+    replaceCounted('profile-collect', anchor, branch + anchor, 1);
+    console.log('profile-collect: patched');
+  }
+}
+
+writeFileSync(file, src);

--- a/packages/chdb-wasm/tools/split/profile-corpus.sql
+++ b/packages/chdb-wasm/tools/split/profile-corpus.sql
@@ -272,6 +272,16 @@ SELECT sleepEachRow(0.001) FROM numbers(2);
 -- ============================================================================
 -- 16. DDL + DML: Memory / MergeTree family / views / mutations
 -- ============================================================================
+-- Tables in the DEFAULT database go through clickhouse-local's DatabaseOverlay
+-- — a different lookup/DDL path than the qualified corpus.* names below, and
+-- the most common shape users type. Keep both hot.
+CREATE TABLE overlay_tbl (x Int32, s String) ENGINE = Memory;
+INSERT INTO overlay_tbl VALUES (1, 'a'), (2, 'b'), (3, 'c');
+SELECT sum(x), max(s) FROM overlay_tbl;
+SHOW TABLES;
+DESCRIBE overlay_tbl;
+EXISTS TABLE overlay_tbl;
+DROP TABLE overlay_tbl;
 -- Atomic (the default engine) is mt-only: on the single-threaded build CREATE
 -- DATABASE aborts the wasm instance (pre-existing st limitation, not split
 -- related); the Memory-engine fallback keeps this section running there.

--- a/packages/chdb-wasm/tools/split/profile-corpus.sql
+++ b/packages/chdb-wasm/tools/split/profile-corpus.sql
@@ -97,7 +97,7 @@ SELECT x.number FROM numbers(4) AS x JOIN numbers(4) AS y USING (number) ORDER B
 SELECT count() FROM numbers(100) AS a JOIN numbers(100) AS b ON a.number = b.number JOIN numbers(100) AS c ON b.number = c.number;
 SET join_algorithm = 'partial_merge';
 SELECT count() FROM numbers(1000) AS a JOIN numbers(1000) AS b ON a.number = b.number;
-SET join_algorithm = 'hash';
+SET join_algorithm = DEFAULT;
 
 -- ============================================================================
 -- 6. Window functions
@@ -123,18 +123,9 @@ SELECT uniq(number % 100), uniqExact(number % 100), uniqCombined(number % 100), 
 SELECT quantile(0.5)(number), quantiles(0.25, 0.5, 0.75)(number), quantileExact(0.9)(number), quantileTiming(0.5)(number % 1000), quantileBFloat16(0.5)(number), median(number) FROM numbers(10000);
 SELECT topK(3)(number % 10), topKWeighted(3)(number % 10, number % 4 + 1) FROM numbers(10000);
 SELECT groupArray(number), groupUniqArray(number % 3), groupArraySample(3)(number) FROM numbers(10);
-SELECT groupArrayMovingSum(3)(number), groupArrayMovingAvg(3)(number) FROM numbers(10);
-SELECT groupBitAnd(number), groupBitOr(number), groupBitXor(number) FROM numbers(1, 100);
-SELECT groupBitmap(toUInt32(number % 50)), bitmapCardinality(groupBitmapState(toUInt32(number % 50))) FROM numbers(1000);
 SELECT corr(toFloat64(number), number * 2.0), covarPop(toFloat64(number), number + 1.0), covarSamp(toFloat64(number), number + 1.0) FROM numbers(100);
 SELECT stddevPop(number), stddevSamp(number), varPop(number), varSamp(number), skewPop(number), skewSamp(number), kurtPop(number), kurtSamp(number) FROM numbers(1000);
 SELECT deltaSum(number), sumCount(number) FROM numbers(100);
-SELECT histogram(5)(toFloat64(number % 100)) FROM numbers(1000);
-SELECT simpleLinearRegression(toFloat64(number), toFloat64(2 * number + 1)) FROM numbers(100);
-SELECT mannWhitneyUTest(toFloat64(number % 17), number % 2) FROM numbers(200);
-SELECT studentTTest(toFloat64(number % 13), number % 2), welchTTest(toFloat64(number % 13), number % 2) FROM numbers(200);
-SELECT rankCorr(toFloat64(number % 7), toFloat64(number % 11)) FROM numbers(200);
-SELECT cramersV(number % 3, number % 5), theilsU(number % 3, number % 5) FROM numbers(1000);
 SELECT sumMap(map(number % 4, number)) FROM numbers(100);
 SELECT sumArray([number, number + 1]), avgArray([number, number * 2]) FROM numbers(100);
 SELECT countMerge(s) FROM (SELECT countState() AS s FROM numbers(100));
@@ -143,10 +134,7 @@ SELECT finalizeAggregation(initializeAggregation('uniqState', 42)), finalizeAggr
 SELECT sumForEach([number, number + 1]) FROM numbers(10);
 SELECT countResample(0, 10, 2)(number) FROM numbers(10);
 SELECT sumDistinct(number % 5), avgOrNull(number), maxOrDefault(number) FROM numbers(100);
-SELECT sequenceMatch('(?1)(?2)')(toDateTime(number), number % 3 = 0, number % 3 = 1) FROM numbers(100);
 SELECT windowFunnel(10)(toDateTime(number), number % 5 = 0, number % 5 = 1, number % 5 = 2) FROM numbers(100);
-SELECT retention(number % 7 = 0, number % 7 = 1, number % 7 = 2) FROM numbers(49);
-SELECT exponentialMovingAverage(5)(toFloat64(number), number) FROM numbers(50);
 SELECT number % 3 AS g, groupArrayIf(number, number % 2 = 0) FROM numbers(20) GROUP BY g ORDER BY g;
 
 -- ============================================================================
@@ -216,7 +204,6 @@ SELECT arrayReduce('sum', range(10)), arrayReduce('uniq', [1, 1, 2]), arrayReduc
 SELECT arrayJoin([1, 2, 3]) AS x, x * 10 FROM system.one;
 SELECT number, arr FROM numbers(3) ARRAY JOIN [10, 20] AS arr ORDER BY number, arr;
 SELECT number, arr FROM numbers(2) LEFT ARRAY JOIN emptyArrayInt32() AS arr;
-SELECT arrayAUC([0.1, 0.4, 0.35, 0.8], [0, 0, 1, 1]);
 
 -- ============================================================================
 -- 12. Tuple / Map functions
@@ -372,7 +359,7 @@ SELECT * FROM file('/corpus/people_names.csv', CSVWithNames) ORDER BY id;
 SELECT * FROM file('/corpus/people.tsv', TSV, 'id UInt32, name String, score Float64') ORDER BY id;
 SELECT * FROM file('/corpus/people.jsonl', JSONEachRow) ORDER BY id;
 DESCRIBE file('/corpus/people_names.csv');
-SELECT count() FROM file('/corpus/people*.csv', CSVWithNames);
+SELECT count() FROM file('/corpus/people{2,_names}.csv', CSVWithNames);
 INSERT INTO FUNCTION file('/corpus/out.parquet', Parquet) SELECT number AS id, toString(number) AS s, number / 3 AS f FROM numbers(1000);
 SELECT count(), sum(id), max(f) FROM file('/corpus/out.parquet', Parquet);
 SELECT id, s FROM file('/corpus/out.parquet') WHERE id % 100 = 0 ORDER BY id;
@@ -436,6 +423,8 @@ SELECT * FROM system.one;
 SELECT number FROM system.numbers LIMIT 5;
 SET max_threads = 2;
 SELECT sum(number) FROM numbers(100000);
+-- back to 1, the wasm product default (chdb_wasm.cpp caps max_threads at connect;
+-- plain DEFAULT would jump to 'auto' and diverge from shipped behavior).
 SET max_threads = 1;
 
 -- ============================================================================
@@ -506,8 +495,10 @@ SELECT histogram(5)(toFloat64(number % 100)) FROM numbers(1000);
 SELECT simpleLinearRegression(toFloat64(number), toFloat64(2 * number + 1)) FROM numbers(100);
 SELECT mannWhitneyUTest(toFloat64(number % 17), number % 2) FROM numbers(200);
 SELECT studentTTest(toFloat64(number % 13), number % 2) FROM numbers(200);
+SELECT welchTTest(toFloat64(number % 13), number % 2) FROM numbers(200);
 SELECT rankCorr(toFloat64(number % 7), toFloat64(number % 11)) FROM numbers(200);
 SELECT cramersV(number % 3, number % 5) FROM numbers(1000);
+SELECT theilsU(number % 3, number % 5) FROM numbers(1000);
 SELECT sequenceMatch('(?1)(?2)')(toDateTime(number), number % 3 = 0, number % 3 = 1) FROM numbers(100);
 SELECT retention(number % 7 = 0, number % 7 = 1) FROM numbers(49);
 SELECT exponentialMovingAverage(5)(toFloat64(number), number) FROM numbers(50);

--- a/packages/chdb-wasm/tools/split/profile-corpus.sql
+++ b/packages/chdb-wasm/tools/split/profile-corpus.sql
@@ -396,7 +396,9 @@ SELECT number FROM numbers(3) FORMAT SQLInsert;
 SELECT number FROM numbers(3) FORMAT XML;
 SELECT number FROM numbers(3) FORMAT RowBinary;
 SELECT number FROM numbers(3) FORMAT Parquet;
-SELECT number FROM numbers(3) FORMAT Arrow;
+-- mt-only: on st the parallel Arrow output format fails thread creation (clean
+-- error on the plain build, but a busy-spin hang on the instrumented one).
+SELECT number FROM numbers(3) FORMAT Arrow /*mt-only*/;
 SELECT number FROM numbers(3) FORMAT Native;
 SELECT number FROM numbers(1000) FORMAT Null;
 

--- a/packages/chdb-wasm/tools/split/profile-corpus.sql
+++ b/packages/chdb-wasm/tools/split/profile-corpus.sql
@@ -1,0 +1,527 @@
+-- Profiling corpus for wasm-split: every statement here marks the functions it
+-- executes as "hot", keeping them in the primary chdb.wasm. Anything not
+-- exercised is split into chdb.deferred.wasm and lazy-loaded on first use, so
+-- this file should cover what typical users run: SQL operators and clauses,
+-- the common scalar-function families, aggregate functions (+ combinators),
+-- table functions, input/output formats, DDL/DML, and error handling.
+--
+-- Runner: tools/split/run-profile.mjs. Rules:
+--   * statements end with `;` at end of line (no semicolons inside strings)
+--   * `--` lines are comments
+--   * {HTTP} {S3} {CATALOG} {UNITY} are substituted by the runner when the
+--     corresponding fixture service is up; statements with an unsubstituted
+--     placeholder are skipped
+--   * failures are recorded, not fatal: a few statements fail on purpose to
+--     keep the error-formatting machinery hot
+--
+-- Keep statements small (row counts in the thousands): coverage is what
+-- matters, not volume.
+
+-- ============================================================================
+-- 1. Literals, types, casts
+-- ============================================================================
+SELECT 1, -2, 3.5, -0.25, 1e10, 0x1F, 'hello', NULL;
+SELECT toTypeName(42), toTypeName(4.2), toTypeName('s'), toTypeName(NULL), toTypeName([1, 2]), toTypeName((1, 'a')), toTypeName(map('k', 1));
+SELECT toInt8(1), toInt16(2), toInt32(3), toInt64(4);
+SELECT toUInt8(1), toUInt16(2), toUInt32(3), toUInt64(4);
+SELECT toFloat32(1.5), toFloat64(2.5), toDecimal32(1.2345, 3), toDecimal64(1.23456, 5);
+SELECT toInt32OrZero('bad'), toInt32OrNull('bad'), toUInt64OrDefault('x', toUInt64(7)), toFloat64OrZero('nan-ish');
+SELECT toString(123), toFixedString('ab', 4), toLowCardinality('tag'), toNullable(5), assumeNotNull(toNullable(6));
+SELECT CAST(42 AS String), CAST('2024-01-02' AS Date), 42::Float64, '[1,2,3]'::Array(Int32), accurateCast(300, 'Int16'), accurateCastOrNull(300, 'Int8');
+SELECT toDate('2024-03-15'), toDate32('1950-06-01'), toDateTime('2024-03-15 12:34:56'), toDateTime64('2024-03-15 12:34:56.789', 3);
+SELECT toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), generateUUIDv4() != generateUUIDv4();
+SELECT toIPv4('1.2.3.4'), toIPv6('::ffff:1.2.3.4'), toBool(1), toBool('true');
+SELECT CAST('a' AS Enum('a' = 1, 'b' = 2)), CAST(2 AS Enum('a' = 1, 'b' = 2));
+SELECT toIntervalSecond(30), toIntervalDay(2), INTERVAL 3 MONTH;
+SELECT reinterpretAsUInt32(reinterpretAsString(305419896)), reinterpret(-1, 'UInt8');
+
+-- ============================================================================
+-- 2. Operators and expressions
+-- ============================================================================
+SELECT 7 + 3, 7 - 3, 7 * 3, 7 / 3, 7 % 3, intDiv(7, 3), moduloOrZero(7, 0), -abs(-5);
+SELECT 1 < 2, 2 <= 2, 3 > 2, 3 >= 4, 1 = 1, 1 != 2, 'a' < 'b';
+SELECT 1 AND 0, 1 OR 0, NOT 1, xor(1, 0);
+SELECT 5 BETWEEN 1 AND 10, 3 IN (1, 2, 3), 4 NOT IN (1, 2, 3), (1, 'a') = (1, 'a');
+SELECT number IN (SELECT number FROM numbers(5) WHERE number % 2 = 0) FROM numbers(6);
+SELECT 'foobar' LIKE 'foo%', 'foobar' ILIKE 'FOO%', 'foobar' NOT LIKE 'baz%', match('foobar', '^fo+bar$');
+SELECT NULL IS NULL, 1 IS NOT NULL, ifNull(NULL, 'fallback'), coalesce(NULL, NULL, 3), nullIf(5, 5);
+SELECT 'a' || 'b' || 'c', [1, 2][1], map('x', 10)['x'], (1, 'two').2;
+SELECT bitAnd(12, 10), bitOr(12, 10), bitXor(12, 10), bitNot(0), bitCount(255), bitTest(5, 0), byteSwap(3735928559);
+SELECT if(1 = 1, 'yes', 'no'), multiIf(0, 'a', 1, 'b', 'c'), CASE WHEN 2 > 1 THEN 'gt' ELSE 'le' END, CASE 2 WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'many' END;
+SELECT greatest(1, 2, 3), least(1, 2, 3), greatest('a', 'b'), max2(1.5, 2.5), min2(1.5, 2.5);
+
+-- ============================================================================
+-- 3. Core clauses: WHERE / GROUP BY / HAVING / ORDER BY / LIMIT / DISTINCT
+-- ============================================================================
+SELECT count() FROM numbers(10000) WHERE number % 7 = 3;
+SELECT number % 5 AS k, count(), sum(number), avg(number), min(number), max(number) FROM numbers(10000) GROUP BY k ORDER BY k;
+SELECT number % 5 AS k, count() AS c FROM numbers(10000) GROUP BY k HAVING c > 1500 ORDER BY c DESC, k;
+SELECT number % 3 AS a, number % 4 AS b, count() FROM numbers(1000) GROUP BY a, b WITH ROLLUP ORDER BY a, b;
+SELECT number % 3 AS a, number % 4 AS b, count() FROM numbers(1000) GROUP BY a, b WITH CUBE ORDER BY a, b;
+SELECT number % 3 AS a, count() FROM numbers(1000) GROUP BY a WITH TOTALS ORDER BY a;
+SELECT number % 3 AS a, number % 2 AS b, count() FROM numbers(1000) GROUP BY GROUPING SETS ((a), (b), (a, b)) ORDER BY a, b;
+SELECT DISTINCT number % 4 FROM numbers(100) ORDER BY 1;
+SELECT DISTINCT ON (number % 3) number, number % 3 FROM numbers(30) ORDER BY number % 3, number;
+SELECT number FROM numbers(100) ORDER BY number DESC LIMIT 5;
+SELECT number FROM numbers(100) ORDER BY number LIMIT 5 OFFSET 20;
+SELECT number % 3 AS g, number FROM numbers(30) ORDER BY g, number LIMIT 2 BY g;
+SELECT toNullable(if(number % 3 = 0, NULL, number)) AS v FROM numbers(9) ORDER BY v ASC NULLS FIRST;
+SELECT number FROM numbers(3) ORDER BY number WITH FILL FROM 0 TO 10 STEP 2;
+SELECT intDiv(number, 100) AS bucket, count() FROM numbers(100000) GROUP BY bucket ORDER BY bucket LIMIT 10;
+
+-- ============================================================================
+-- 4. Subqueries, CTEs, set operations
+-- ============================================================================
+SELECT (SELECT max(number) FROM numbers(100)) + 1;
+SELECT number FROM (SELECT number * 2 AS number FROM numbers(10)) WHERE number > 10 ORDER BY number;
+WITH 10 AS lim SELECT count() FROM numbers(100) WHERE number < lim;
+WITH evens AS (SELECT number FROM numbers(20) WHERE number % 2 = 0) SELECT count(), sum(number) FROM evens;
+WITH RECURSIVE fib AS (SELECT 0 AS a, 1 AS b, 1 AS i UNION ALL SELECT b, a + b, i + 1 FROM fib WHERE i < 12) SELECT max(b) FROM fib;
+SELECT number FROM numbers(3) UNION ALL SELECT number + 10 FROM numbers(3) ORDER BY number;
+SELECT number % 3 FROM numbers(10) UNION DISTINCT SELECT number % 4 FROM numbers(10) ORDER BY 1;
+SELECT number FROM numbers(10) INTERSECT SELECT number FROM numbers(5, 10) ORDER BY number;
+SELECT number FROM numbers(10) EXCEPT SELECT number FROM numbers(5, 10) ORDER BY number;
+
+-- ============================================================================
+-- 5. JOINs
+-- ============================================================================
+SELECT a.number, b.number FROM numbers(5) AS a INNER JOIN (SELECT number FROM numbers(3, 5)) AS b ON a.number = b.number ORDER BY a.number;
+SELECT a.number, b.n FROM numbers(5) AS a LEFT JOIN (SELECT number AS number, number * 10 AS n FROM numbers(3)) AS b ON a.number = b.number ORDER BY a.number;
+SELECT a.number, b.number FROM (SELECT number FROM numbers(3)) AS a RIGHT JOIN numbers(5) AS b ON a.number = b.number ORDER BY b.number;
+SELECT a.number, b.number FROM (SELECT number FROM numbers(4)) AS a FULL OUTER JOIN (SELECT number + 2 AS number FROM numbers(4)) AS b ON a.number = b.number ORDER BY a.number, b.number;
+SELECT count() FROM numbers(10) AS a CROSS JOIN numbers(10) AS b;
+SELECT a.number FROM numbers(6) AS a SEMI LEFT JOIN (SELECT number FROM numbers(3)) AS b ON a.number = b.number ORDER BY a.number;
+SELECT a.number FROM numbers(6) AS a ANTI LEFT JOIN (SELECT number FROM numbers(3)) AS b ON a.number = b.number ORDER BY a.number;
+SELECT a.k, a.t, b.t FROM (SELECT 1 AS k, number * 10 AS t FROM numbers(5)) AS a ASOF JOIN (SELECT 1 AS k, number * 15 AS t FROM numbers(5)) AS b ON a.k = b.k AND a.t >= b.t ORDER BY a.t;
+SELECT x.number FROM numbers(4) AS x JOIN numbers(4) AS y USING (number) ORDER BY x.number;
+SELECT count() FROM numbers(100) AS a JOIN numbers(100) AS b ON a.number = b.number JOIN numbers(100) AS c ON b.number = c.number;
+SET join_algorithm = 'partial_merge';
+SELECT count() FROM numbers(1000) AS a JOIN numbers(1000) AS b ON a.number = b.number;
+SET join_algorithm = 'hash';
+
+-- ============================================================================
+-- 6. Window functions
+-- ============================================================================
+SELECT number, row_number() OVER (ORDER BY number DESC) AS rn FROM numbers(10) ORDER BY number;
+SELECT number % 3 AS g, number, rank() OVER (PARTITION BY number % 3 ORDER BY number) AS r, dense_rank() OVER (PARTITION BY number % 3 ORDER BY number) AS dr FROM numbers(12) ORDER BY g, number;
+SELECT number, sum(number) OVER (ORDER BY number ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running FROM numbers(10);
+SELECT number, avg(number) OVER (ORDER BY number ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS centered FROM numbers(10);
+SELECT number, lagInFrame(number, 1) OVER w AS prev, leadInFrame(number, 1) OVER w AS next FROM numbers(8) WINDOW w AS (ORDER BY number ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING);
+SELECT number, first_value(number) OVER w AS f, last_value(number) OVER w AS l FROM numbers(8) WINDOW w AS (PARTITION BY number % 2 ORDER BY number ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) ORDER BY number;
+SELECT number, ntile(3) OVER (ORDER BY number) AS bucket FROM numbers(9);
+SELECT number % 4 AS g, max(number) OVER (PARTITION BY g) FROM numbers(16) QUALIFY number = max(number) OVER (PARTITION BY g) ORDER BY g;
+SELECT number, count() OVER (ORDER BY number RANGE BETWEEN 3 PRECEDING AND CURRENT ROW) FROM numbers(10);
+
+-- ============================================================================
+-- 7. Aggregate functions and combinators
+-- ============================================================================
+SELECT count(), count(DISTINCT number % 10), countIf(number % 2 = 0) FROM numbers(1000);
+SELECT sum(number), sumIf(number, number % 2 = 1), avg(number), avgIf(number, number > 500) FROM numbers(1000);
+SELECT min(number), max(number), minIf(number, number > 10), maxIf(number, number < 990), any(number), anyLast(number) FROM numbers(1000);
+SELECT argMin(number, number % 7), argMax(number, number % 7) FROM numbers(1000);
+SELECT uniq(number % 100), uniqExact(number % 100), uniqCombined(number % 100), uniqCombined64(number % 100), uniqHLL12(number % 100) FROM numbers(10000);
+SELECT quantile(0.5)(number), quantiles(0.25, 0.5, 0.75)(number), quantileExact(0.9)(number), quantileTiming(0.5)(number % 1000), quantileBFloat16(0.5)(number), median(number) FROM numbers(10000);
+SELECT topK(3)(number % 10), topKWeighted(3)(number % 10, number % 4 + 1) FROM numbers(10000);
+SELECT groupArray(number), groupUniqArray(number % 3), groupArraySample(3)(number) FROM numbers(10);
+SELECT groupArrayMovingSum(3)(number), groupArrayMovingAvg(3)(number) FROM numbers(10);
+SELECT groupBitAnd(number), groupBitOr(number), groupBitXor(number) FROM numbers(1, 100);
+SELECT groupBitmap(toUInt32(number % 50)), bitmapCardinality(groupBitmapState(toUInt32(number % 50))) FROM numbers(1000);
+SELECT corr(toFloat64(number), number * 2.0), covarPop(toFloat64(number), number + 1.0), covarSamp(toFloat64(number), number + 1.0) FROM numbers(100);
+SELECT stddevPop(number), stddevSamp(number), varPop(number), varSamp(number), skewPop(number), skewSamp(number), kurtPop(number), kurtSamp(number) FROM numbers(1000);
+SELECT deltaSum(number), sumCount(number) FROM numbers(100);
+SELECT histogram(5)(toFloat64(number % 100)) FROM numbers(1000);
+SELECT simpleLinearRegression(toFloat64(number), toFloat64(2 * number + 1)) FROM numbers(100);
+SELECT mannWhitneyUTest(toFloat64(number % 17), number % 2) FROM numbers(200);
+SELECT studentTTest(toFloat64(number % 13), number % 2), welchTTest(toFloat64(number % 13), number % 2) FROM numbers(200);
+SELECT rankCorr(toFloat64(number % 7), toFloat64(number % 11)) FROM numbers(200);
+SELECT cramersV(number % 3, number % 5), theilsU(number % 3, number % 5) FROM numbers(1000);
+SELECT sumMap(map(number % 4, number)) FROM numbers(100);
+SELECT sumArray([number, number + 1]), avgArray([number, number * 2]) FROM numbers(100);
+SELECT countMerge(s) FROM (SELECT countState() AS s FROM numbers(100));
+SELECT avgMerge(s) FROM (SELECT avgState(number) AS s FROM numbers(100) GROUP BY number % 10);
+SELECT finalizeAggregation(initializeAggregation('uniqState', 42)), finalizeAggregation(sumStateOrDefault) FROM (SELECT sumState(number) AS sumStateOrDefault FROM numbers(10));
+SELECT sumForEach([number, number + 1]) FROM numbers(10);
+SELECT countResample(0, 10, 2)(number) FROM numbers(10);
+SELECT sumDistinct(number % 5), avgOrNull(number), maxOrDefault(number) FROM numbers(100);
+SELECT sequenceMatch('(?1)(?2)')(toDateTime(number), number % 3 = 0, number % 3 = 1) FROM numbers(100);
+SELECT windowFunnel(10)(toDateTime(number), number % 5 = 0, number % 5 = 1, number % 5 = 2) FROM numbers(100);
+SELECT retention(number % 7 = 0, number % 7 = 1, number % 7 = 2) FROM numbers(49);
+SELECT exponentialMovingAverage(5)(toFloat64(number), number) FROM numbers(50);
+SELECT number % 3 AS g, groupArrayIf(number, number % 2 = 0) FROM numbers(20) GROUP BY g ORDER BY g;
+
+-- ============================================================================
+-- 8. String functions
+-- ============================================================================
+SELECT length('hello'), lengthUTF8('héllo'), empty(''), notEmpty('x'), byteSize('abc'), char(72, 105);
+SELECT lower('MiXeD'), upper('MiXeD'), initcap('hello world');
+SELECT reverse('abc'), reverseUTF8('héllo'), repeat('ab', 3), space(4) || '|';
+SELECT substring('clickhouse', 6), substring('clickhouse', 1, 5), substringUTF8('héllo', 2, 3), left('clickhouse', 5), right('clickhouse', 5);
+SELECT trim('  pad  '), trimLeft('  pad'), trimRight('pad  '), trim(BOTH 'x' FROM 'xxpadxx'), leftPad('7', 4, '0'), rightPad('7', 4, '.');
+SELECT concat('a', 'b', 'c'), concatWithSeparator('-', 'x', 'y', 'z'), format('{} scored {}', 'alice', 95);
+SELECT startsWith('clickhouse', 'click'), endsWith('clickhouse', 'house'), position('clickhouse', 'house'), positionCaseInsensitive('ClickHouse', 'HOUSE'), locate('house', 'clickhouse');
+SELECT replaceOne('aaa', 'a', 'b'), replaceAll('aaa', 'a', 'b'), replaceRegexpOne('2024-03-15', '(\d+)-(\d+)-(\d+)', '\3/\2/\1'), replaceRegexpAll('a1b2c3', '\d', '#'), translate('abc', 'abc', 'xyz');
+SELECT splitByChar(',', 'a,b,c'), splitByString(', ', 'a, b, c'), splitByRegexp('\d+', 'a1bb22ccc'), arrayStringConcat(['x', 'y', 'z'], '|');
+SELECT extract('key=val', 'key=(\w+)'), extractAll('a1b22c333', '\d+'), extractGroups('alice:95', '(\w+):(\d+)'), extractAllGroupsVertical('a:1,b:2', '(\w):(\d)');
+SELECT match('hello123', '^[a-z]+\d+$'), countMatches('a1b2c3', '\d'), countSubstrings('banana', 'an'), regexpExtract('foo123bar', '([0-9]+)', 1);
+SELECT multiSearchAny('clickhouse', ['house', 'click']), multiSearchFirstIndex('clickhouse', ['x', 'house']), multiSearchAllPositions('clickhouse', ['click', 'house']);
+SELECT levenshteinDistance('kitten', 'sitting'), jaroSimilarity('martha', 'marhta'), stringJaccardIndex('abc', 'abd'), ngramDistance('clickhouse', 'clckhouse');
+SELECT isValidUTF8('ok'), toValidUTF8('ok');
+SELECT formatReadableSize(123456789), formatReadableTimeDelta(361);
+SELECT hex('AB'), unhex('4142'), bin('a'), unbin('01100001');
+
+-- ============================================================================
+-- 9. Date/time functions
+-- ============================================================================
+SELECT now() > toDateTime('2020-01-01'), now64(3) > toDateTime64('2020-01-01 00:00:00', 3), today() >= yesterday();
+SELECT toYear(d), toQuarter(d), toMonth(d), toDayOfMonth(d), toDayOfWeek(d), toDayOfYear(d), toISOWeek(d), toISOYear(d) FROM (SELECT toDate('2024-03-15') AS d);
+SELECT toHour(t), toMinute(t), toSecond(t), toUnixTimestamp(t) FROM (SELECT toDateTime('2024-03-15 12:34:56') AS t);
+SELECT toStartOfYear(t), toStartOfQuarter(t), toStartOfMonth(t), toMonday(t), toStartOfWeek(t), toLastDayOfMonth(t) FROM (SELECT toDate('2024-03-15') AS t);
+SELECT toStartOfDay(t), toStartOfHour(t), toStartOfMinute(t), toStartOfFifteenMinutes(t), toStartOfFiveMinutes(t), toStartOfSecond(toDateTime64('2024-03-15 12:34:56.789', 3)) FROM (SELECT toDateTime('2024-03-15 12:34:56') AS t);
+SELECT toYYYYMM(toDate('2024-03-15')), toYYYYMMDD(toDate('2024-03-15')), toYYYYMMDDhhmmss(toDateTime('2024-03-15 12:34:56'));
+SELECT addYears(d, 1), addMonths(d, 2), addWeeks(d, 3), addDays(d, 4), subtractDays(d, 5), addHours(toDateTime(d), 6), subtractMinutes(toDateTime(d), 7) FROM (SELECT toDate('2024-03-15') AS d);
+SELECT dateDiff('day', toDate('2024-01-01'), toDate('2024-03-15')), dateDiff('hour', toDateTime('2024-03-15 00:00:00'), toDateTime('2024-03-15 12:00:00')), age('year', toDate('2000-06-15'), toDate('2024-03-15'));
+SELECT date_add(DAY, 3, toDate('2024-03-15')), date_sub(MONTH, 1, toDate('2024-03-15')), timestamp_diff(MINUTE, toDateTime('2024-03-15 12:00:00'), toDateTime('2024-03-15 12:45:00'));
+SELECT toDate('2024-03-15') + INTERVAL 10 DAY, now() - INTERVAL 1 HOUR > toDateTime('2020-01-01');
+SELECT formatDateTime(toDateTime('2024-03-15 12:34:56'), '%Y/%m/%d %H:%M:%S'), formatDateTime(toDate('2024-03-15'), '%W %j');
+SELECT parseDateTime('2024*03*15', '%Y*%m*%d'), parseDateTimeBestEffort('15 Mar 2024 12:34:56');
+SELECT makeDate(2024, 3, 15), makeDateTime(2024, 3, 15, 12, 34, 56), YYYYMMDDToDate(20240315), fromUnixTimestamp(1700000000);
+SELECT monthName(toDate('2024-03-15')), toRelativeDayNum(toDate('2024-03-15')) > 0, timeSlot(toDateTime('2024-03-15 12:34:56'));
+SELECT toTimeZone(toDateTime('2024-03-15 12:00:00', 'UTC'), 'Asia/Shanghai'), timeZoneOf(toDateTime('2024-03-15 12:00:00', 'UTC')), toDateTime('2024-03-15 12:00:00', 'America/New_York');
+SELECT toStartOfInterval(toDateTime('2024-03-15 12:34:56'), INTERVAL 10 MINUTE), date_trunc('week', toDateTime('2024-03-15 12:34:56'));
+
+-- ============================================================================
+-- 10. Math functions
+-- ============================================================================
+SELECT abs(-3), sign(-2.5), exp(1), log(e()), log2(8), log10(1000), exp2(10), exp10(3), sqrt(2), cbrt(27), pow(2, 10), intExp2(8), intExp10(4);
+SELECT sin(pi() / 2), cos(0), tan(pi() / 4), asin(1), acos(0), atan(1), atan2(1, 1), sinh(1), cosh(1), tanh(1);
+SELECT degrees(pi()), radians(180), erf(1), erfc(1), lgamma(10), tgamma(5), factorial(10), hypot(3, 4);
+SELECT round(2.567), round(2.567, 2), roundBankers(2.5), floor(2.9), ceil(2.1), trunc(-2.9), round(1234, -2), roundToExp2(100), roundDuration(95), roundAge(35);
+SELECT isFinite(1.0), isInfinite(1 / 0.0), isNaN(0 / 0.0), ifNotFinite(1 / 0.0, -1), log1p(0.5);
+SELECT e(), pi(), plus(2, 3), minus(5, 2), multiply(4, 6), divide(10, 4), negate(7);
+
+-- ============================================================================
+-- 11. Array functions
+-- ============================================================================
+SELECT [1, 2, 3], array(4, 5), range(5), range(2, 10, 2), arrayWithConstant(3, 'x'), emptyArrayInt32();
+SELECT length([1, 2, 3]), empty([]), notEmpty([1]), arrayElement([10, 20, 30], 2), [10, 20, 30][-1];
+SELECT arrayMap(x -> x * 2, [1, 2, 3]), arrayMap((x, y) -> x + y, [1, 2], [10, 20]), arrayFilter(x -> x % 2 = 0, range(10));
+SELECT arrayExists(x -> x > 2, [1, 2, 3]), arrayAll(x -> x > 0, [1, 2, 3]), arrayCount(x -> x % 3 = 0, range(20)), arrayFirst(x -> x > 5, range(10)), arrayLast(x -> x < 5, range(10)), arrayFirstIndex(x -> x = 3, range(10));
+SELECT arraySum([1, 2, 3]), arrayProduct([1.0, 2, 3]), arrayMin([3, 1, 2]), arrayMax([3, 1, 2]), arrayAvg([1, 2, 3]), arrayDifference([10, 13, 17]);
+SELECT arraySort([3, 1, 2]), arrayReverseSort([1, 3, 2]), arraySort(x -> -x, [1, 3, 2]), arrayReverse([1, 2, 3]);
+SELECT arrayDistinct([1, 2, 2, 3, 1]), arrayUniq([1, 2, 2, 3]), arrayCompact([1, 1, 2, 2, 1]), arrayEnumerate([9, 8, 7]), arrayEnumerateUniq([1, 1, 2, 1]);
+SELECT has([1, 2, 3], 2), hasAll([1, 2, 3, 4], [2, 4]), hasAny([1, 2], [9, 2]), hasSubstr([1, 2, 3, 4], [2, 3]), indexOf([7, 8, 9], 9), countEqual([1, 2, 2, 3], 2);
+SELECT arrayConcat([1, 2], [3], [4, 5]), arraySlice([1, 2, 3, 4, 5], 2, 3), arrayResize([1, 2], 4, 0), arrayPushBack([1, 2], 3), arrayPushFront([2, 3], 1), arrayPopBack([1, 2, 3]), arrayPopFront([1, 2, 3]);
+SELECT arrayFlatten([[1, 2], [3]]), arrayZip([1, 2], ['a', 'b']), arrayIntersect([1, 2, 3], [2, 3, 4]);
+SELECT arrayReduce('sum', range(10)), arrayReduce('uniq', [1, 1, 2]), arrayReduceInRanges('sum', [(1, 3), (2, 2)], [10, 20, 30, 40]);
+SELECT arrayJoin([1, 2, 3]) AS x, x * 10 FROM system.one;
+SELECT number, arr FROM numbers(3) ARRAY JOIN [10, 20] AS arr ORDER BY number, arr;
+SELECT number, arr FROM numbers(2) LEFT ARRAY JOIN emptyArrayInt32() AS arr;
+SELECT arrayAUC([0.1, 0.4, 0.35, 0.8], [0, 0, 1, 1]);
+
+-- ============================================================================
+-- 12. Tuple / Map functions
+-- ============================================================================
+SELECT tuple(1, 'a', 3.5) AS t, tupleElement(t, 1), t.3, untuple((7, 8));
+SELECT map('a', 1, 'b', 2) AS m, mapKeys(m), mapValues(m), mapContains(m, 'a'), length(m);
+SELECT mapFromArrays(['x', 'y'], [10, 20]), mapFilter((k, v) -> v > 1, map('a', 1, 'b', 2));
+SELECT CAST(([1, 2], ['one', 'two']), 'Map(Int32, String)'), CAST(map(1, 'one'), 'Array(Tuple(Int32, String))');
+SELECT tupleHammingDistance((1, 2, 3), (1, 9, 3));
+
+-- ============================================================================
+-- 13. JSON functions (+ JSON type)
+-- ============================================================================
+SELECT JSONExtractInt('{"a": 42}', 'a'), JSONExtractFloat('{"a": 4.2}', 'a'), JSONExtractBool('{"a": true}', 'a'), JSONExtractString('{"a": "hi"}', 'a');
+SELECT JSONExtractRaw('{"a": {"b": 1}}', 'a'), JSONExtractArrayRaw('{"a": [1, 2]}', 'a'), JSONExtractKeysAndValues('{"a": 1, "b": 2}', 'Int32');
+SELECT JSONHas('{"a": 1}', 'a'), JSONLength('{"a": [1, 2, 3]}', 'a'), JSONType('{"a": [1]}', 'a'), JSONArrayLength('[1, 2, 3]'), isValidJSON('{"ok": 1}'), isValidJSON('nope{');
+SELECT JSONExtract('{"a": [1, 2]}', 'a', 'Array(Int64)'), JSONExtract('{"x": {"y": 5}}', 'x', 'y', 'Int64');
+SELECT JSON_VALUE('{"a": {"b": "v"}}', '$.a.b'), JSON_QUERY('{"a": [1, 2]}', '$.a'), JSON_EXISTS('{"a": 1}', '$.a');
+SELECT simpleJSONExtractInt('{"k": 7}', 'k'), simpleJSONExtractString('{"k": "s"}', 'k'), simpleJSONHas('{"k": 1}', 'k');
+SELECT toJSONString(map('a', [1, 2])), toJSONString((1, 'two', [3]));
+SET allow_experimental_json_type = 1;
+SELECT '{"user": {"name": "alice", "score": 9.5}, "tags": ["x", "y"]}'::JSON AS j, j.user.name, j.tags, JSONAllPaths(j);
+
+-- ============================================================================
+-- 14. URL / IP / UUID / hash / random / encoding functions
+-- ============================================================================
+SELECT protocol(u), domain(u), domainWithoutWWW(u), topLevelDomain(u), port(u), netloc(u) FROM (SELECT 'https://www.example.co.uk:8443/a/b?q=1&r=2#frag' AS u);
+SELECT path(u), pathFull(u), queryString(u), fragment(u), queryStringAndFragment(u) FROM (SELECT 'https://example.com/a/b?q=1&r=2#frag' AS u);
+SELECT extractURLParameter(u, 'r'), extractURLParameters(u), extractURLParameterNames(u), cutQueryString(u) FROM (SELECT 'https://example.com/p?q=1&r=2' AS u);
+SELECT URLHierarchy('https://example.com/a/b/c'), URLPathHierarchy('https://example.com/a/b/c'), encodeURLComponent('a b&c'), decodeURLComponent('a%20b%26c');
+SELECT IPv4NumToString(16909060), IPv4StringToNum('1.2.3.4'), IPv6NumToString(IPv6StringToNum('2001:db8::1')), IPv4ToIPv6(toIPv4('1.2.3.4'));
+SELECT isIPv4String('1.2.3.4'), isIPv6String('::1'), isIPAddressInRange('192.168.1.7', '192.168.0.0/16'), IPv4CIDRToRange(toIPv4('10.0.0.1'), 8);
+SELECT hex(MD5('chdb')), hex(SHA1('chdb')), hex(SHA224('chdb')), hex(SHA256('chdb')), hex(SHA512('chdb')), halfMD5('chdb');
+SELECT sipHash64('chdb'), cityHash64('chdb'), farmHash64('chdb'), metroHash64('chdb'), wyHash64('chdb');
+SELECT xxHash64('chdb'), xxh3('chdb'), CRC32('chdb'), CRC64('chdb'), gccMurmurHash('chdb');
+SELECT javaHash('chdb'), hiveHash('chdb');
+SELECT rand() >= 0, rand64() >= 0, randCanonical() BETWEEN 0 AND 1, randConstant() >= 0, randUniform(0, 10) BETWEEN 0 AND 10;
+SELECT randNormal(0, 1) IS NOT NULL, randExponential(1) >= 0, length(randomString(16)), length(randomPrintableASCII(8));
+SELECT UUIDStringToNum('61f0c404-5cb3-11e7-907b-a6006ad3dba0') AS n, UUIDNumToString(n), toString(generateUUIDv7()) != '';
+
+-- ============================================================================
+-- 15. Conditional / misc / introspection functions
+-- ============================================================================
+SELECT transform(2, [1, 2, 3], ['one', 'two', 'three'], 'other'), transform('b', ['a', 'b'], [1, 2], 0);
+SELECT bar(5, 0, 10, 10), materialize(42), identity('x'), ignore(1, 2, 3), isConstant(3), rowNumberInAllBlocks() FROM numbers(2);
+SELECT version() != '', currentDatabase(), currentUser() != '', hostName() != '', uptime() >= 0, timezone() != '';
+SELECT blockSize() > 0, blockNumber() >= 0 FROM numbers(5);
+SELECT defaultValueOfArgumentType(CAST(1 AS Nullable(Int32))), defaultValueOfTypeName('String'), toColumnTypeName(now());
+SELECT greatCircleDistance(-73.98, 40.75, 116.39, 39.91), geoDistance(-73.98, 40.75, 116.39, 39.91), greatCircleAngle(0, 0, 10, 10);
+SELECT geohashEncode(-5.60302734375, 42.593994140625), geohashDecode('ezs42');
+SELECT sleepEachRow(0.001) FROM numbers(2);
+
+-- ============================================================================
+-- 16. DDL + DML: Memory / MergeTree family / views / mutations
+-- ============================================================================
+-- Atomic (the default engine) is mt-only: on the single-threaded build CREATE
+-- DATABASE aborts the wasm instance (pre-existing st limitation, not split
+-- related); the Memory-engine fallback keeps this section running there.
+CREATE DATABASE IF NOT EXISTS corpus /*mt-only*/;
+CREATE DATABASE IF NOT EXISTS corpus ENGINE = Memory;
+CREATE TABLE corpus.mem (id UInt32, name String, score Float64, tags Array(String), created DateTime) ENGINE = Memory;
+INSERT INTO corpus.mem VALUES (1, 'alice', 9.5, ['a', 'b'], '2024-01-01 10:00:00'), (2, 'bob', 7.25, ['b'], '2024-01-02 11:30:00'), (3, 'carol', 8.0, [], '2024-01-03 09:15:00');
+INSERT INTO corpus.mem SELECT number + 10, concat('user', toString(number)), number * 1.5, [toString(number % 3)], toDateTime('2024-02-01 00:00:00') + number * 3600 FROM numbers(50);
+SELECT count(), avg(score), uniqExact(name) FROM corpus.mem;
+SELECT name, score FROM corpus.mem WHERE has(tags, 'b') ORDER BY score DESC;
+CREATE TABLE corpus.mt (id UInt64, ts DateTime, kind LowCardinality(String), val Nullable(Float64), payload String) ENGINE = MergeTree ORDER BY (kind, id) PARTITION BY toYYYYMM(ts) SETTINGS index_granularity = 256;
+INSERT INTO corpus.mt SELECT number, toDateTime('2024-01-01 00:00:00') + number * 900, ['clicks', 'views', 'buys'][number % 3 + 1], if(number % 11 = 0, NULL, number / 7), concat('p-', toString(cityHash64(number))) FROM numbers(5000);
+SELECT kind, count(), round(avg(val), 3), min(ts), max(ts) FROM corpus.mt GROUP BY kind ORDER BY kind;
+SELECT count() FROM corpus.mt PREWHERE kind = 'clicks' WHERE val > 100;
+SELECT id, kind, val FROM corpus.mt WHERE id BETWEEN 100 AND 120 ORDER BY id LIMIT 10;
+SELECT partition, rows FROM system.parts WHERE database = 'corpus' AND table = 'mt' AND active ORDER BY partition;
+ALTER TABLE corpus.mt ADD COLUMN extra UInt8 DEFAULT 0;
+ALTER TABLE corpus.mt UPDATE extra = 1 WHERE id < 100 SETTINGS mutations_sync = 1;
+SELECT countIf(extra = 1) FROM corpus.mt;
+ALTER TABLE corpus.mt DROP COLUMN extra;
+DELETE FROM corpus.mt WHERE id % 100 = 7;
+SELECT count() FROM corpus.mt;
+OPTIMIZE TABLE corpus.mt FINAL;
+CREATE TABLE corpus.repl (k UInt32, v String, ver UInt32) ENGINE = ReplacingMergeTree(ver) ORDER BY k;
+INSERT INTO corpus.repl VALUES (1, 'old', 1), (1, 'new', 2), (2, 'only', 1);
+SELECT k, v FROM corpus.repl FINAL ORDER BY k;
+CREATE TABLE corpus.summing (k UInt32, s UInt64) ENGINE = SummingMergeTree ORDER BY k;
+INSERT INTO corpus.summing SELECT number % 5, number FROM numbers(100);
+OPTIMIZE TABLE corpus.summing FINAL;
+SELECT k, s FROM corpus.summing ORDER BY k;
+CREATE TABLE corpus.agg (k UInt8, st AggregateFunction(avg, Float64)) ENGINE = AggregatingMergeTree ORDER BY k;
+INSERT INTO corpus.agg SELECT number % 3, avgState(toFloat64(number)) FROM numbers(1000) GROUP BY number % 3;
+SELECT k, avgMerge(st) FROM corpus.agg GROUP BY k ORDER BY k;
+CREATE VIEW corpus.v AS SELECT kind, count() AS c FROM corpus.mt GROUP BY kind;
+SELECT * FROM corpus.v ORDER BY kind;
+CREATE MATERIALIZED VIEW corpus.mv ENGINE = SummingMergeTree ORDER BY kind AS SELECT kind, count() AS c FROM corpus.mt GROUP BY kind;
+INSERT INTO corpus.mt (id, ts, kind, val, payload) SELECT number + 100000, now(), 'views', 1.0, 'x' FROM numbers(100);
+SELECT kind, sum(c) FROM corpus.mv GROUP BY kind ORDER BY kind;
+CREATE TABLE corpus.nullsink (x UInt64) ENGINE = Null;
+INSERT INTO corpus.nullsink SELECT number FROM numbers(1000);
+CREATE TEMPORARY TABLE tmp_corpus (a Int32);
+INSERT INTO tmp_corpus VALUES (1), (2);
+SELECT sum(a) FROM tmp_corpus;
+CREATE FUNCTION corpus_add2 AS (a, b) -> a + b * 2;
+SELECT corpus_add2(3, 4);
+DROP FUNCTION corpus_add2;
+TRUNCATE TABLE corpus.mem;
+SELECT count() FROM corpus.mem;
+RENAME TABLE corpus.repl TO corpus.repl2;
+EXISTS TABLE corpus.repl2;
+DROP TABLE corpus.repl2;
+SHOW TABLES FROM corpus;
+SHOW CREATE TABLE corpus.mt;
+DESCRIBE TABLE corpus.mt;
+
+-- ============================================================================
+-- 17. Spill-to-disk + heavier pipelines (external sort/aggregation paths)
+-- ============================================================================
+SET max_bytes_before_external_group_by = 262144;
+SELECT number % 10000 AS k, count(), sum(number) FROM numbers(200000) GROUP BY k FORMAT Null;
+SET max_bytes_before_external_group_by = 0;
+SET max_bytes_before_external_sort = 262144;
+SELECT number FROM numbers(200000) ORDER BY cityHash64(number) LIMIT 5;
+SET max_bytes_before_external_sort = 0;
+SELECT uniqExact(number) FROM numbers(300000);
+SELECT sum(cityHash64(number)) FROM numbers(500000);
+
+-- ============================================================================
+-- 18. Table functions: numbers / generateRandom / values / format / view / merge
+-- ============================================================================
+SELECT count() FROM numbers(1000);
+SELECT count() FROM numbers(100, 900);
+SELECT sum(zero) FROM zeros(1000);
+SELECT count(), uniqExact(i % 10) FROM (SELECT i FROM generateRandom('i UInt64, s String, a Array(Int8)', 42) LIMIT 500);
+SELECT * FROM values('a Int32, b String', (1, 'x'), (2, 'y')) ORDER BY a;
+SELECT * FROM format(JSONEachRow, '{"n": 1, "s": "one"}\n{"n": 2, "s": "two"}') ORDER BY n;
+SELECT * FROM format(CSVWithNames, 'id,name\n1,alpha\n2,beta') ORDER BY id;
+SELECT count() FROM view(SELECT number FROM numbers(10) WHERE number > 4);
+SELECT count() FROM merge('corpus', '^m');
+SELECT * FROM null('x Int32') LIMIT 0;
+SELECT number FROM numbers(5) SETTINGS max_block_size = 2;
+
+-- ============================================================================
+-- 19. file() over MEMFS in many formats (runner pre-writes /corpus/*)
+-- ============================================================================
+SELECT * FROM file('/corpus/people.csv', CSV, 'id UInt32, name String, score Float64') ORDER BY id;
+SELECT * FROM file('/corpus/people_names.csv', CSVWithNames) ORDER BY id;
+SELECT * FROM file('/corpus/people.tsv', TSV, 'id UInt32, name String, score Float64') ORDER BY id;
+SELECT * FROM file('/corpus/people.jsonl', JSONEachRow) ORDER BY id;
+DESCRIBE file('/corpus/people_names.csv');
+SELECT count() FROM file('/corpus/people*.csv', CSVWithNames);
+INSERT INTO FUNCTION file('/corpus/out.parquet', Parquet) SELECT number AS id, toString(number) AS s, number / 3 AS f FROM numbers(1000);
+SELECT count(), sum(id), max(f) FROM file('/corpus/out.parquet', Parquet);
+SELECT id, s FROM file('/corpus/out.parquet') WHERE id % 100 = 0 ORDER BY id;
+INSERT INTO FUNCTION file('/corpus/out.arrow', Arrow) SELECT number AS id, concat('r', toString(number)) AS s FROM numbers(500);
+SELECT count(), any(s) FROM file('/corpus/out.arrow', Arrow);
+INSERT INTO FUNCTION file('/corpus/out.native', Native) SELECT number AS n, map('k', number) AS m FROM numbers(100);
+SELECT sum(n), any(m['k']) FROM file('/corpus/out.native', Native);
+INSERT INTO FUNCTION file('/corpus/out.csv.gz', CSV) SELECT number, randomPrintableASCII(10) FROM numbers(200);
+SELECT count() FROM file('/corpus/out.csv.gz', CSV, 'a UInt64, b String');
+CREATE TABLE corpus.from_file ENGINE = Memory AS SELECT * FROM file('/corpus/people_names.csv');
+SELECT count() FROM corpus.from_file;
+
+-- ============================================================================
+-- 20. Output formats (FORMAT clause exercises each serializer)
+-- ============================================================================
+SELECT number, toString(number) AS s, number / 2.0 AS f FROM numbers(5) FORMAT CSV;
+SELECT number, toString(number) AS s FROM numbers(5) FORMAT CSVWithNames;
+SELECT number, toString(number) AS s FROM numbers(5) FORMAT TSV;
+SELECT number, toString(number) AS s FROM numbers(5) FORMAT TabSeparatedWithNamesAndTypes;
+SELECT number, [number, number + 1] AS arr FROM numbers(3) FORMAT JSON;
+SELECT number, map('k', number) AS m FROM numbers(3) FORMAT JSONEachRow;
+SELECT number FROM numbers(3) FORMAT JSONCompact;
+SELECT number FROM numbers(3) FORMAT JSONColumns;
+SELECT number, toString(number) AS s FROM numbers(5) FORMAT Pretty;
+SELECT number, toString(number) AS s FROM numbers(5) FORMAT PrettyCompact;
+SELECT number, toString(number) AS s FROM numbers(5) FORMAT PrettySpace;
+SELECT number, toString(number) AS s FROM numbers(2) FORMAT Vertical;
+SELECT number FROM numbers(3) FORMAT Values;
+SELECT number, toString(number) AS s FROM numbers(3) FORMAT Markdown;
+SELECT number FROM numbers(3) FORMAT SQLInsert;
+SELECT number FROM numbers(3) FORMAT XML;
+SELECT number FROM numbers(3) FORMAT RowBinary;
+SELECT number FROM numbers(3) FORMAT Parquet;
+SELECT number FROM numbers(3) FORMAT Arrow;
+SELECT number FROM numbers(3) FORMAT Native;
+SELECT number FROM numbers(1000) FORMAT Null;
+
+-- ============================================================================
+-- 21. EXPLAIN / SHOW / system tables / settings
+-- ============================================================================
+EXPLAIN AST SELECT number FROM numbers(10) WHERE number > 5;
+EXPLAIN SYNTAX SELECT number FROM numbers(10) WHERE number > 5 ORDER BY number;
+EXPLAIN PLAN SELECT number % 3 AS k, count() FROM numbers(100) GROUP BY k;
+EXPLAIN PIPELINE SELECT number % 3 AS k, count() FROM numbers(100) GROUP BY k;
+EXPLAIN QUERY TREE SELECT sum(number) FROM numbers(10);
+EXPLAIN ESTIMATE SELECT count() FROM corpus.mt;
+SHOW DATABASES;
+SHOW PROCESSLIST;
+SELECT name, engine FROM system.tables WHERE database = 'corpus' ORDER BY name;
+SELECT name, type FROM system.columns WHERE database = 'corpus' AND table = 'mt' ORDER BY position;
+SELECT count() FROM system.functions;
+SELECT count() FROM system.table_functions;
+SELECT count() FROM system.table_engines;
+SELECT count() FROM system.formats;
+SELECT count() FROM system.data_type_families;
+SELECT name, value FROM system.settings WHERE changed ORDER BY name LIMIT 20;
+SELECT name, value FROM system.build_options WHERE name IN ('VERSION_FULL', 'SYSTEM') ORDER BY name;
+SELECT * FROM system.one;
+SELECT number FROM system.numbers LIMIT 5;
+SET max_threads = 2;
+SELECT sum(number) FROM numbers(100000);
+SET max_threads = 1;
+
+-- ============================================================================
+-- 22. Deliberate error paths (keeps exception formatting/reporting hot)
+-- ============================================================================
+SELECT * FROM this_table_does_not_exist;
+SELECT no_such_function(42);
+SELECT toInt32('definitely not a number');
+SELECT intDiv(1, 0);
+SELECT arrayMap(x -> y, [1]);
+SELECT FROM WHERE;
+SELECT count() FROM file('/corpus/missing_file.csv', CSV, 'a Int32');
+CREATE TABLE corpus.mem (id UInt32) ENGINE = Memory;
+SELECT [1, 2] + 3;
+
+-- ============================================================================
+-- 23. url() via local fixture HTTP server (WasmHTTPBridge path)
+-- ============================================================================
+SELECT * FROM url('{HTTP}/people_names.csv', CSVWithNames) ORDER BY id;
+SELECT count() FROM url('{HTTP}/people.jsonl', JSONEachRow);
+DESCRIBE url('{HTTP}/people_names.csv');
+
+-- ============================================================================
+-- 24. Data lake: DataLakeCatalog + icebergS3 + deltaLake + Unity
+--     (runner brings up moto S3, pyiceberg/delta-rs fixtures, mock catalogs)
+-- ============================================================================
+CREATE DATABASE lake ENGINE = DataLakeCatalog('{CATALOG}/v1', 'testing', 'testing') SETTINGS catalog_type = 'rest', warehouse = 'warehouse', storage_endpoint = '{S3}', vended_credentials = false;
+SHOW TABLES FROM lake;
+DESCRIBE TABLE lake.`lakehouse.events`;
+SELECT * FROM lake.`lakehouse.events` ORDER BY id;
+SELECT count(), sum(id), round(avg(score), 2) FROM lake.`lakehouse.events`;
+SELECT city, count(), sum(amount) FROM lake.`lakehouse.city_events` GROUP BY city ORDER BY city;
+SELECT * FROM lake.`lakehouse.deleted_events` ORDER BY id;
+SELECT name, score FROM lake.`lakehouse.events` WHERE id > 3 ORDER BY score DESC LIMIT 3;
+DROP DATABASE lake;
+DESCRIBE icebergS3('{S3}/lakebucket/warehouse/lakehouse/events', 'testing', 'testing');
+SELECT count(), max(id) FROM icebergS3('{S3}/lakebucket/warehouse/lakehouse/events', 'testing', 'testing');
+SELECT id, name FROM icebergS3('{S3}/lakebucket/warehouse/lakehouse/events', 'testing', 'testing') WHERE score > 3 ORDER BY id;
+CREATE DATABASE unity ENGINE = DataLakeCatalog('{UNITY}', 'testing', 'testing') SETTINGS catalog_type = 'unity', warehouse = 'unity', storage_endpoint = '{S3}', vended_credentials = false;
+SHOW TABLES FROM unity;
+SELECT id, item, price FROM unity.`lakeschema.sales` ORDER BY id;
+SELECT count(), max(price) FROM unity.`lakeschema.sales`;
+DROP DATABASE unity;
+DESCRIBE deltaLake('{S3}/deltabucket/unity/sales', 'testing', 'testing');
+SELECT count(), round(sum(price), 2) FROM deltaLake('{S3}/deltabucket/unity/sales', 'testing', 'testing');
+SELECT id, item FROM deltaLake('{S3}/deltabucket/unity/sales', 'testing', 'testing') WHERE price > 10 ORDER BY id;
+
+-- ============================================================================
+-- 26. Probes for functions NOT registered in the wasm build (each fails alone,
+--     keeping UNKNOWN_FUNCTION handling hot without poisoning other lines).
+--     If a future build adds one, it graduates into the sections above.
+-- ============================================================================
+SELECT toInt128(5), toInt256(6);
+SELECT toUInt128(5), toUInt256(6);
+SELECT toDecimal128(9.87, 2);
+SELECT intDivOrZero(7, 0);
+SELECT bitShiftLeft(1, 4), bitShiftRight(256, 4), bitRotateLeft(1, 33);
+SELECT avgWeighted(number, number % 3 + 1) FROM numbers(100);
+SELECT anyHeavy(number % 5) FROM numbers(100);
+SELECT uniqUpTo(5)(number % 100) FROM numbers(1000);
+SELECT quantileTDigest(0.95)(number) FROM numbers(1000);
+SELECT groupArraySorted(5)(10 - number) FROM numbers(10);
+SELECT groupArrayMovingSum(3)(number), groupArrayMovingAvg(3)(number) FROM numbers(10);
+SELECT groupBitAnd(number), groupBitOr(number), groupBitXor(number) FROM numbers(1, 100);
+SELECT groupBitmap(toUInt32(number % 50)) FROM numbers(1000);
+SELECT entropy(number % 10) FROM numbers(100);
+SELECT histogram(5)(toFloat64(number % 100)) FROM numbers(1000);
+SELECT simpleLinearRegression(toFloat64(number), toFloat64(2 * number + 1)) FROM numbers(100);
+SELECT mannWhitneyUTest(toFloat64(number % 17), number % 2) FROM numbers(200);
+SELECT studentTTest(toFloat64(number % 13), number % 2) FROM numbers(200);
+SELECT rankCorr(toFloat64(number % 7), toFloat64(number % 11)) FROM numbers(200);
+SELECT cramersV(number % 3, number % 5) FROM numbers(1000);
+SELECT sequenceMatch('(?1)(?2)')(toDateTime(number), number % 3 = 0, number % 3 = 1) FROM numbers(100);
+SELECT retention(number % 7 = 0, number % 7 = 1) FROM numbers(49);
+SELECT exponentialMovingAverage(5)(toFloat64(number), number) FROM numbers(50);
+SELECT ascii('A');
+SELECT lowerUTF8('ÄÖÜ'), upperUTF8('äöü');
+SELECT soundex('Robert');
+SELECT formatReadableQuantity(123456789), formatReadableDecimalSize(123456789);
+SELECT base64Encode('chdb'), base64Decode('Y2hkYg==');
+SELECT parseDateTimeBestEffortOrNull('garbage');
+SELECT gcd(12, 18), lcm(4, 6);
+SELECT expm1(0.5);
+SELECT arrayCumSum([1, 2, 3]);
+SELECT arrayShuffle([1, 2, 3]);
+SELECT arrayRotateLeft([1, 2, 3, 4], 1), arrayShiftRight([1, 2, 3, 4], 1, 0);
+SELECT arrayFold((acc, x) -> acc + x, [1, 2, 3], toInt64(0));
+SELECT arrayAUC([0.1, 0.4, 0.35, 0.8], [0, 0, 1, 1]);
+SELECT mapApply((k, v) -> (upper(k), v * 2), map('a', 1));
+SELECT JSONExtractKeys('{"a": 1, "b": 2}');
+SELECT hex(sipHash128('chdb')), hex(murmurHash3_128('chdb'));
+SELECT xxHash32('chdb');
+SELECT murmurHash2_64('chdb'), murmurHash3_32('chdb');
+SELECT pointInPolygon((1.5, 1.5), [(0, 0), (3, 0), (3, 3), (0, 3)]);
+SELECT tupleToNameValuePairs(CAST((42, 3.5), 'Tuple(i Int32, f Float64)'));
+
+-- ============================================================================
+-- 25. Session/stream API coverage happens in the runner itself (streaming
+--     fetch, cancel, progress) — no SQL needed here.
+-- ============================================================================
+SELECT 'corpus done';

--- a/packages/chdb-wasm/tools/split/run-profile.mjs
+++ b/packages/chdb-wasm/tools/split/run-profile.mjs
@@ -110,6 +110,9 @@ const cleanup = () => {
   if (moto) moto.kill('SIGKILL');
 };
 process.on('exit', cleanup);
+// 'exit' doesn't fire on signals; without these a killed runner orphans moto
+// and fixture-host, and the next run fails on EADDRINUSE.
+for (const sig of ['SIGTERM', 'SIGINT']) process.on(sig, () => { cleanup(); process.exit(143); });
 
 // --- load the instrumented module --------------------------------------------
 const factory = (await import(pathToFileURL(join(bundleDir, 'chdb.mjs')).href)).default;

--- a/packages/chdb-wasm/tools/split/run-profile.mjs
+++ b/packages/chdb-wasm/tools/split/run-profile.mjs
@@ -68,8 +68,23 @@ writeFileSync(join(staticDir, 'people.jsonl'), PEOPLE_JSONL);
 
 // --- fixture services (all out-of-process) -----------------------------------
 const children = [];
-const substitutions = { '{HTTP}': `http://127.0.0.1:${HTTP_PORT}` };
+// {HTTP} only when the fixture host will actually run: in the INIT_PROBE pass
+// it does not, and an unconditional substitution would aim the url()
+// statements at a dead endpoint (recorded as failures) instead of skipping.
+const substitutions = {};
+if (!INIT_PROBE) substitutions['{HTTP}'] = `http://127.0.0.1:${HTTP_PORT}`;
 let moto = null;
+
+// Registered BEFORE startLake(): moto is spawned inside it, and a failure in a
+// later startup step (bucket PUT, table fixtures) must not orphan it on its
+// port. 'exit' doesn't fire on signals; without those handlers a killed runner
+// orphans moto and fixture-host, and the next run fails on EADDRINUSE.
+const cleanup = () => {
+  for (const c of children) c.kill('SIGKILL');
+  if (moto) moto.kill('SIGKILL');
+};
+process.on('exit', cleanup);
+for (const sig of ['SIGTERM', 'SIGINT']) process.on(sig, () => { cleanup(); process.exit(143); });
 
 async function startLake() {
   if (process.env.CHDB_SKIP_LAKE === '1' || !existsSync(PY)) return false;
@@ -107,7 +122,9 @@ if (!INIT_PROBE) {
       '--catalog-port', String(CATALOG_PORT), '--iceberg-descriptor', join(staticDir, 'iceberg-descriptor.json'),
       '--unity-port', String(UNITY_PORT), '--unity-descriptor', join(staticDir, 'unity-descriptor.json'));
   }
-  const host = spawn(process.execPath, [join(here, 'fixture-host.mjs'), ...hostArgs], { stdio: ['ignore', 'pipe', 'inherit'] });
+  // stdin 'pipe' (not 'ignore'): fixture-host watches it to detect parent
+  // death even when our cleanup handlers never run (SIGKILL).
+  const host = spawn(process.execPath, [join(here, 'fixture-host.mjs'), ...hostArgs], { stdio: ['pipe', 'pipe', 'inherit'] });
   children.push(host);
   await new Promise((resolve, reject) => {
     const t = setTimeout(() => reject(new Error('fixture-host did not become ready')), 15000);
@@ -116,15 +133,6 @@ if (!INIT_PROBE) {
   });
   console.log(`fixtures ready (lake: ${lake ? 'on' : 'OFF — data-lake statements will be skipped'})`);
 }
-
-const cleanup = () => {
-  for (const c of children) c.kill('SIGKILL');
-  if (moto) moto.kill('SIGKILL');
-};
-process.on('exit', cleanup);
-// 'exit' doesn't fire on signals; without these a killed runner orphans moto
-// and fixture-host, and the next run fails on EADDRINUSE.
-for (const sig of ['SIGTERM', 'SIGINT']) process.on(sig, () => { cleanup(); process.exit(143); });
 
 // --- load the instrumented module --------------------------------------------
 const factory = (await import(pathToFileURL(join(bundleDir, 'chdb.mjs')).href)).default;
@@ -259,9 +267,14 @@ mod.ccall('chdb_wasm_close_conn', null, ['number'], [conn]);
 const wp = mod.wasmExports?.__write_profile;
 if (!wp) throw new Error('__write_profile export missing — is this the instrumented bundle?');
 const profLen = Number(rawCall(wp, 0n, 0));
+
+const workers = mod.PThread ? [...mod.PThread.runningWorkers, ...mod.PThread.unusedWorkers] : [];
 // wasm export names are minified at this link level, so malloc must be reached
-// through the glue's Module._malloc alias (raw, unwrapped on Memory64).
-const bufPtr = num(rawCall(mod._malloc, profLen));
+// through the glue's Module._malloc alias (raw, unwrapped on Memory64). One
+// SLOT PER INSTANCE: a worker that answers after its collection timed out
+// still writes into its own slot, never into one being read for another.
+const bufPtr = num(rawCall(mod._malloc, profLen * (workers.length + 1)));
+if (!bufPtr) throw new Error(`_malloc(${profLen * (workers.length + 1)}) failed for the profile buffers`);
 
 const profiles = [];
 {
@@ -270,22 +283,23 @@ const profiles = [];
   console.log(`profile main: ${n} bytes`);
 }
 
-const PThread = mod.PThread;
-if (PThread) {
-  const workers = [...PThread.runningWorkers, ...PThread.unusedWorkers];
+if (workers.length) {
   let collected = 0, timedOut = 0;
   for (let i = 0; i < workers.length; i++) {
+    const slot = bufPtr + profLen * (1 + i);
     const n = await new Promise((resolve) => {
       // A worker parked in a blocking wait (Atomics.wait) can't service
       // messages; skip it after a short timeout rather than hanging. Its
       // coverage is lost, which at worst means an unnecessary lazy load at
       // runtime — never a failure (see patch-glue.mjs --lazy-load).
       const t = setTimeout(() => resolve(-2), 5000);
-      mod.__chdbProfileWritten = (tag, len) => { clearTimeout(t); resolve(len); };
-      workers[i].postMessage({ cmd: 'chdbWriteProfile', ptr: bufPtr, cap: profLen, tag: i });
+      // Tag check: a worker that answers AFTER its timeout must not resolve a
+      // later worker's promise with the wrong length.
+      mod.__chdbProfileWritten = (tag, len) => { if (tag !== i) return; clearTimeout(t); resolve(len); };
+      workers[i].postMessage({ cmd: 'chdbWriteProfile', ptr: slot, cap: profLen, tag: i });
     });
     if (n > 0) {
-      profiles.push(Uint8Array.from(mod.HEAPU8.slice(bufPtr, bufPtr + n)));
+      profiles.push(Uint8Array.from(mod.HEAPU8.slice(slot, slot + n)));
       collected++;
     } else if (n === -2) timedOut++;
   }

--- a/packages/chdb-wasm/tools/split/run-profile.mjs
+++ b/packages/chdb-wasm/tools/split/run-profile.mjs
@@ -34,6 +34,15 @@ mkdirSync(outDir, { recursive: true });
 const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
 const S3_PORT = 8151, CATALOG_PORT = 8152, UNITY_PORT = 8153, HTTP_PORT = 8154;
 
+// CHDB_INIT_PROBE=global: a light second pass whose FIRST engine call is the
+// connectionless chdb_wasm_query — its cold-start of the process-global
+// connection takes a different init path than chdb_wasm_connect, and whichever
+// runs first in a process claims the one cold start. The main corpus pass
+// starts with connect(), so this pass covers the other order (the SDK's
+// AsyncChdb.query without an explicit Connection). No fixtures, no corpus.
+const INIT_PROBE = process.env.CHDB_INIT_PROBE === 'global';
+const PROFILE_PREFIX = process.env.CHDB_PROFILE_PREFIX || 'profile';
+
 const num = (x) => (typeof x === 'bigint' ? Number(x) : x);
 // Memory64: binaryen-added exports (__write_profile) keep raw i64 -> BigInt
 // pointer params while emscripten-known exports are signature-converted to
@@ -89,21 +98,23 @@ async function startLake() {
   return true;
 }
 
-const lake = await startLake();
-const hostArgs = ['--http-port', String(HTTP_PORT), '--static-dir', staticDir];
-if (lake) {
-  hostArgs.push(
-    '--catalog-port', String(CATALOG_PORT), '--iceberg-descriptor', join(staticDir, 'iceberg-descriptor.json'),
-    '--unity-port', String(UNITY_PORT), '--unity-descriptor', join(staticDir, 'unity-descriptor.json'));
+const lake = INIT_PROBE ? false : await startLake();
+if (!INIT_PROBE) {
+  const hostArgs = ['--http-port', String(HTTP_PORT), '--static-dir', staticDir];
+  if (lake) {
+    hostArgs.push(
+      '--catalog-port', String(CATALOG_PORT), '--iceberg-descriptor', join(staticDir, 'iceberg-descriptor.json'),
+      '--unity-port', String(UNITY_PORT), '--unity-descriptor', join(staticDir, 'unity-descriptor.json'));
+  }
+  const host = spawn(process.execPath, [join(here, 'fixture-host.mjs'), ...hostArgs], { stdio: ['ignore', 'pipe', 'inherit'] });
+  children.push(host);
+  await new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('fixture-host did not become ready')), 15000);
+    host.stdout.on('data', (d) => { if (String(d).includes('READY')) { clearTimeout(t); resolve(); } });
+    host.on('exit', (c) => reject(new Error(`fixture-host exited early (${c})`)));
+  });
+  console.log(`fixtures ready (lake: ${lake ? 'on' : 'OFF — data-lake statements will be skipped'})`);
 }
-const host = spawn(process.execPath, [join(here, 'fixture-host.mjs'), ...hostArgs], { stdio: ['ignore', 'pipe', 'inherit'] });
-children.push(host);
-await new Promise((resolve, reject) => {
-  const t = setTimeout(() => reject(new Error('fixture-host did not become ready')), 15000);
-  host.stdout.on('data', (d) => { if (String(d).includes('READY')) { clearTimeout(t); resolve(); } });
-  host.on('exit', (c) => reject(new Error(`fixture-host exited early (${c})`)));
-});
-console.log(`fixtures ready (lake: ${lake ? 'on' : 'OFF — data-lake statements will be skipped'})`);
 
 const cleanup = () => {
   for (const c of children) c.kill('SIGKILL');
@@ -127,17 +138,42 @@ mod.FS.writeFile('/corpus/people_names.csv', PEOPLE_NAMES_CSV);
 mod.FS.writeFile('/corpus/people.tsv', PEOPLE_TSV);
 mod.FS.writeFile('/corpus/people.jsonl', PEOPLE_JSONL);
 
-// Handles (conn, result, stream pointers) are BigInt on Memory64 and must be
-// passed back into ccall UNconverted (the raw exports take i64); num() is only
-// for heap offsets consumed from JS. Mirrors src/bindings.ts.
-const conn = mod.ccall('chdb_wasm_connect', 'number', ['string'], ['']);
-if (!num(conn)) throw new Error('chdb_wasm_connect failed');
-
 // The SDK calls these during init (worker.ts shares the cancel/progress
 // offsets with the page) — they must be hot or a split bundle can't even
 // initialize without the deferred module.
 mod.ccall('chdb_wasm_cancel_flag_addr', 'number', [], []);
 mod.ccall('chdb_wasm_progress_addr', 'number', [], []);
+
+// Connectionless queries: AsyncChdb.query goes through chdb_wasm_query, whose
+// FIRST call cold-starts the process-global connection.
+function globalQueries() {
+  for (const [sql, fmt] of [
+    ['SELECT number, toString(number) FROM numbers(100)', 'CSV'],
+    ['SELECT 1 AS one FORMAT JSON', 'CSV'],
+    ['SELECT broken syntax here', 'CSV'],
+  ]) {
+    const r = mod.ccall('chdb_wasm_query', 'number', ['string', 'string'], [sql, fmt]);
+    if (num(r)) {
+      mod.ccall('chdb_wasm_result_error', 'number', ['number'], [r]);
+      mod.ccall('chdb_wasm_result_buffer', 'number', ['number'], [r]);
+      mod.ccall('chdb_wasm_result_length', 'number', ['number'], [r]);
+      mod.ccall('chdb_wasm_free_result', null, ['number'], [r]);
+    }
+  }
+}
+
+// The init-probe pass makes the GLOBAL connection the process's cold start;
+// the main pass gives that honor to chdb_wasm_connect below.
+if (INIT_PROBE) {
+  globalQueries();
+  console.log('init-probe: global-connection cold start exercised');
+}
+
+// Handles (conn, result, stream pointers) are BigInt on Memory64 and must be
+// passed back into ccall UNconverted (the raw exports take i64); num() is only
+// for heap offsets consumed from JS. Mirrors src/bindings.ts.
+const conn = INIT_PROBE ? null : mod.ccall('chdb_wasm_connect', 'number', ['string'], ['']);
+if (!INIT_PROBE && !num(conn)) throw new Error('chdb_wasm_connect failed');
 
 // Consume results the way src/bindings.ts does — buffer/length/stats getters
 // are on every user's path and must land in the primary module.
@@ -174,7 +210,7 @@ let ok = 0, skipped = 0;
 const failures = [];
 const t0 = Date.now();
 const isMt = !!mod.PThread;
-for (let sql of statements) {
+if (!INIT_PROBE) for (let sql of statements) {
   for (const [k, v] of Object.entries(substitutions)) sql = sql.replaceAll(k, v);
   if (/\{[A-Z0-9]+\}/.test(sql)) { skipped++; continue; }
   if (!isMt && sql.includes('/*mt-only*/')) { skipped++; continue; }
@@ -190,25 +226,12 @@ for (let sql of statements) {
     throw e;
   }
 }
-console.log(`corpus: ${ok} ok, ${failures.length} failed, ${skipped} skipped, ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+if (!INIT_PROBE) console.log(`corpus: ${ok} ok, ${failures.length} failed, ${skipped} skipped, ${((Date.now() - t0) / 1000).toFixed(1)}s`);
 
-// --- connectionless query API (AsyncChdb.query goes through chdb_wasm_query) -----
-for (const [sql, fmt] of [
-  ['SELECT number, toString(number) FROM numbers(100)', 'CSV'],
-  ['SELECT 1 AS one FORMAT JSON', 'CSV'],
-  ['SELECT broken syntax here', 'CSV'],
-]) {
-  const r = mod.ccall('chdb_wasm_query', 'number', ['string', 'string'], [sql, fmt]);
-  if (num(r)) {
-    mod.ccall('chdb_wasm_result_error', 'number', ['number'], [r]);
-    mod.ccall('chdb_wasm_result_buffer', 'number', ['number'], [r]);
-    mod.ccall('chdb_wasm_result_length', 'number', ['number'], [r]);
-    mod.ccall('chdb_wasm_free_result', null, ['number'], [r]);
-  }
-}
+if (!INIT_PROBE) globalQueries();
 
 // --- streaming C-API surface ----------------------------------------------------
-{
+if (!INIT_PROBE) {
   const s = mod.ccall('chdb_wasm_stream_start', 'number', ['number', 'string', 'string'], [conn, 'SELECT number, toString(number) FROM numbers(100000)', 'CSV']);
   let chunks = 0;
   for (;;) {
@@ -229,7 +252,7 @@ for (const [sql, fmt] of [
 // Close the session before collecting: exercises shutdown paths and lets
 // query/background threads exit, so their pool workers return to the idle
 // (message-processing) state where they can answer chdbWriteProfile.
-mod.ccall('chdb_wasm_close_conn', null, ['number'], [conn]);
+if (!INIT_PROBE) mod.ccall('chdb_wasm_close_conn', null, ['number'], [conn]);
 
 // --- profile collection ---------------------------------------------------------
 const wp = mod.wasmExports?.__write_profile;
@@ -268,11 +291,13 @@ if (PThread) {
   console.log(`profile workers: ${collected} collected, ${timedOut} unresponsive of ${workers.length}`);
 }
 
-profiles.forEach((p, i) => writeFileSync(join(outDir, `profile-${i}.data`), p));
-writeFileSync(join(outDir, 'summary.json'), JSON.stringify({
-  statements: statements.length, ok, failed: failures.length, skipped, lake, profiles: profiles.length, failures,
-}, null, 2));
-console.log(`wrote ${profiles.length} profiles + summary.json to ${outDir}`);
+profiles.forEach((p, i) => writeFileSync(join(outDir, `${PROFILE_PREFIX}-${i}.data`), p));
+if (!INIT_PROBE) {
+  writeFileSync(join(outDir, 'summary.json'), JSON.stringify({
+    statements: statements.length, ok, failed: failures.length, skipped, lake, profiles: profiles.length, failures,
+  }, null, 2));
+}
+console.log(`wrote ${profiles.length} ${PROFILE_PREFIX}-*.data profiles to ${outDir}`);
 
 cleanup();
 process.exit(0);

--- a/packages/chdb-wasm/tools/split/run-profile.mjs
+++ b/packages/chdb-wasm/tools/split/run-profile.mjs
@@ -133,11 +133,29 @@ mod.FS.writeFile('/corpus/people.jsonl', PEOPLE_JSONL);
 const conn = mod.ccall('chdb_wasm_connect', 'number', ['string'], ['']);
 if (!num(conn)) throw new Error('chdb_wasm_connect failed');
 
+// The SDK calls these during init (worker.ts shares the cancel/progress
+// offsets with the page) — they must be hot or a split bundle can't even
+// initialize without the deferred module.
+mod.ccall('chdb_wasm_cancel_flag_addr', 'number', [], []);
+mod.ccall('chdb_wasm_progress_addr', 'number', [], []);
+
+// Consume results the way src/bindings.ts does — buffer/length/stats getters
+// are on every user's path and must land in the primary module.
 function runStatement(sql, format = 'CSV') {
   const r = mod.ccall('chdb_wasm_query_conn', 'number', ['number', 'string', 'string'], [conn, sql, format]);
   if (!num(r)) return 'null result';
   const errPtr = num(mod.ccall('chdb_wasm_result_error', 'number', ['number'], [r]));
   const err = errPtr ? mod.UTF8ToString(errPtr) : null;
+  if (!err) {
+    const buf = num(mod.ccall('chdb_wasm_result_buffer', 'number', ['number'], [r]));
+    const len = num(mod.ccall('chdb_wasm_result_length', 'number', ['number'], [r]));
+    if (buf && len) mod.HEAPU8[buf]; // touch the data
+    mod.ccall('chdb_wasm_result_elapsed', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_result_rows_read', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_result_bytes_read', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_result_scanned_rows', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_result_scanned_bytes', 'number', ['number'], [r]);
+  }
   mod.ccall('chdb_wasm_free_result', null, ['number'], [r]);
   return err;
 }
@@ -173,6 +191,21 @@ for (let sql of statements) {
   }
 }
 console.log(`corpus: ${ok} ok, ${failures.length} failed, ${skipped} skipped, ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+// --- connectionless query API (AsyncChdb.query goes through chdb_wasm_query) -----
+for (const [sql, fmt] of [
+  ['SELECT number, toString(number) FROM numbers(100)', 'CSV'],
+  ['SELECT 1 AS one FORMAT JSON', 'CSV'],
+  ['SELECT broken syntax here', 'CSV'],
+]) {
+  const r = mod.ccall('chdb_wasm_query', 'number', ['string', 'string'], [sql, fmt]);
+  if (num(r)) {
+    mod.ccall('chdb_wasm_result_error', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_result_buffer', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_result_length', 'number', ['number'], [r]);
+    mod.ccall('chdb_wasm_free_result', null, ['number'], [r]);
+  }
+}
 
 // --- streaming C-API surface ----------------------------------------------------
 {

--- a/packages/chdb-wasm/tools/split/run-profile.mjs
+++ b/packages/chdb-wasm/tools/split/run-profile.mjs
@@ -34,12 +34,13 @@ mkdirSync(outDir, { recursive: true });
 const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
 const S3_PORT = 8151, CATALOG_PORT = 8152, UNITY_PORT = 8153, HTTP_PORT = 8154;
 
-// CHDB_INIT_PROBE=global: a light second pass whose FIRST engine call is the
-// connectionless chdb_wasm_query — its cold-start of the process-global
-// connection takes a different init path than chdb_wasm_connect, and whichever
-// runs first in a process claims the one cold start. The main corpus pass
-// starts with connect(), so this pass covers the other order (the SDK's
-// AsyncChdb.query without an explicit Connection). No fixtures, no corpus.
+// CHDB_INIT_PROBE=global: an ORDER-REVERSED second pass. A process gets one
+// engine cold start, and which API claims it changes which init paths run:
+// the main pass boots via chdb_wasm_connect then runs the corpus; this pass
+// boots via connectionless chdb_wasm_query FIRST (the SDK's AsyncChdb.query
+// shape) and THEN connects and runs the corpus, so session-after-global init
+// paths get profiled too. Data-lake fixtures are skipped (those statements
+// auto-skip); everything else runs in both orders.
 const INIT_PROBE = process.env.CHDB_INIT_PROBE === 'global';
 const PROFILE_PREFIX = process.env.CHDB_PROFILE_PREFIX || 'profile';
 
@@ -172,8 +173,8 @@ if (INIT_PROBE) {
 // Handles (conn, result, stream pointers) are BigInt on Memory64 and must be
 // passed back into ccall UNconverted (the raw exports take i64); num() is only
 // for heap offsets consumed from JS. Mirrors src/bindings.ts.
-const conn = INIT_PROBE ? null : mod.ccall('chdb_wasm_connect', 'number', ['string'], ['']);
-if (!INIT_PROBE && !num(conn)) throw new Error('chdb_wasm_connect failed');
+const conn = mod.ccall('chdb_wasm_connect', 'number', ['string'], ['']);
+if (!num(conn)) throw new Error('chdb_wasm_connect failed');
 
 // Consume results the way src/bindings.ts does — buffer/length/stats getters
 // are on every user's path and must land in the primary module.
@@ -210,7 +211,7 @@ let ok = 0, skipped = 0;
 const failures = [];
 const t0 = Date.now();
 const isMt = !!mod.PThread;
-if (!INIT_PROBE) for (let sql of statements) {
+for (let sql of statements) {
   for (const [k, v] of Object.entries(substitutions)) sql = sql.replaceAll(k, v);
   if (/\{[A-Z0-9]+\}/.test(sql)) { skipped++; continue; }
   if (!isMt && sql.includes('/*mt-only*/')) { skipped++; continue; }
@@ -226,12 +227,12 @@ if (!INIT_PROBE) for (let sql of statements) {
     throw e;
   }
 }
-if (!INIT_PROBE) console.log(`corpus: ${ok} ok, ${failures.length} failed, ${skipped} skipped, ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+console.log(`corpus: ${ok} ok, ${failures.length} failed, ${skipped} skipped, ${((Date.now() - t0) / 1000).toFixed(1)}s`);
 
 if (!INIT_PROBE) globalQueries();
 
 // --- streaming C-API surface ----------------------------------------------------
-if (!INIT_PROBE) {
+{
   const s = mod.ccall('chdb_wasm_stream_start', 'number', ['number', 'string', 'string'], [conn, 'SELECT number, toString(number) FROM numbers(100000)', 'CSV']);
   let chunks = 0;
   for (;;) {
@@ -252,7 +253,7 @@ if (!INIT_PROBE) {
 // Close the session before collecting: exercises shutdown paths and lets
 // query/background threads exit, so their pool workers return to the idle
 // (message-processing) state where they can answer chdbWriteProfile.
-if (!INIT_PROBE) mod.ccall('chdb_wasm_close_conn', null, ['number'], [conn]);
+mod.ccall('chdb_wasm_close_conn', null, ['number'], [conn]);
 
 // --- profile collection ---------------------------------------------------------
 const wp = mod.wasmExports?.__write_profile;

--- a/packages/chdb-wasm/tools/split/run-profile.mjs
+++ b/packages/chdb-wasm/tools/split/run-profile.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+// Profiling runner for wasm-split: loads the INSTRUMENTED chdb bundle, executes
+// profile-corpus.sql against it (plus the streaming C-API surface), then dumps
+// one execution profile per wasm instance — the main instance and, on the
+// threaded build, every pthread pool worker (each is its own instance with its
+// own instrumentation globals; see patch-glue.mjs --profile-collect). The
+// profiles are unioned later by `wasm-split --merge-profiles`.
+//
+// Queries run synchronously on THIS thread, so every HTTP fixture lives in
+// another process: moto (python S3) is spawned directly, the Node mocks run in
+// fixture-host.mjs. Data-lake statements are skipped when the pyiceberg venv
+// (ICEBERG_PY, default /tmp/iceberg-venv/bin/python) is missing.
+//
+// Env: CHDB_BUNDLE_DIR  dir with the instrumented+patched chdb.mjs/chdb.wasm (required)
+//      CHDB_PROFILE_OUT output dir for profile-*.data + summary.json (required)
+//      ICEBERG_PY       python with pyiceberg+moto+deltalake (optional)
+//      CHDB_SKIP_LAKE   set to 1 to force-skip the data-lake section
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, mkdtempSync } from 'node:fs';
+import { spawn, execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundleDir = process.env.CHDB_BUNDLE_DIR;
+const outDir = process.env.CHDB_PROFILE_OUT;
+if (!bundleDir || !outDir) {
+  console.error('CHDB_BUNDLE_DIR and CHDB_PROFILE_OUT are required');
+  process.exit(2);
+}
+mkdirSync(outDir, { recursive: true });
+
+const PY = process.env.ICEBERG_PY || '/tmp/iceberg-venv/bin/python';
+const S3_PORT = 8151, CATALOG_PORT = 8152, UNITY_PORT = 8153, HTTP_PORT = 8154;
+
+const num = (x) => (typeof x === 'bigint' ? Number(x) : x);
+// Memory64: binaryen-added exports (__write_profile) keep raw i64 -> BigInt
+// pointer params while emscripten-known exports are signature-converted to
+// Number; probe rather than hardcode.
+const rawCall = (fn, ...args) => {
+  for (const conv of [(a) => a, (a) => a.map((x) => (typeof x === 'bigint' ? Number(x) : BigInt(x)))]) {
+    try { return fn(...conv(args)); } catch (e) { if (!(e instanceof TypeError) || !/BigInt/.test(e.message)) throw e; }
+  }
+  throw new Error('no BigInt/Number combination accepted');
+};
+
+// --- fixture data ------------------------------------------------------------
+const PEOPLE_CSV = '1,alice,9.5\n2,bob,7.25\n3,carol,8.0\n4,dave,6.5\n';
+const PEOPLE_NAMES_CSV = 'id,name,score\n' + PEOPLE_CSV;
+const PEOPLE_TSV = PEOPLE_CSV.replaceAll(',', '\t');
+const PEOPLE_JSONL =
+  '{"id": 1, "name": "alice", "score": 9.5}\n{"id": 2, "name": "bob", "score": 7.25}\n{"id": 3, "name": "carol", "score": 8.0}\n';
+
+const staticDir = mkdtempSync(join(tmpdir(), 'chdb-profile-static-'));
+writeFileSync(join(staticDir, 'people_names.csv'), PEOPLE_NAMES_CSV);
+writeFileSync(join(staticDir, 'people.jsonl'), PEOPLE_JSONL);
+
+// --- fixture services (all out-of-process) -----------------------------------
+const children = [];
+const substitutions = { '{HTTP}': `http://127.0.0.1:${HTTP_PORT}` };
+let moto = null;
+
+async function startLake() {
+  if (process.env.CHDB_SKIP_LAKE === '1' || !existsSync(PY)) return false;
+  const testDir = join(here, '../../test');
+  moto = spawn(PY, ['-m', 'moto.server', '-p', String(S3_PORT)], { stdio: ['ignore', 'ignore', 'pipe'] });
+  let motoStderr = '';
+  moto.stderr.on('data', (d) => { motoStderr += d; });
+  const deadline = Date.now() + 30000;
+  for (;;) {
+    if (moto.exitCode !== null) { console.error('moto exited early:\n' + motoStderr); return false; }
+    try { await fetch(`http://127.0.0.1:${S3_PORT}`); break; }
+    catch {
+      if (Date.now() > deadline) { console.error('moto did not come up'); moto.kill('SIGKILL'); moto = null; return false; }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  const endpoint = `http://127.0.0.1:${S3_PORT}`;
+  await fetch(`${endpoint}/lakebucket`, { method: 'PUT' });
+  await fetch(`${endpoint}/deltabucket`, { method: 'PUT' });
+  const iceberg = execFileSync(PY, [join(testDir, 'datalake/make_iceberg_table.py'), endpoint, 'lakebucket'], { encoding: 'utf8' }).trim();
+  const delta = execFileSync(PY, [join(testDir, 'datalake/make_delta_table.py'), endpoint, 'deltabucket'], { encoding: 'utf8' }).trim();
+  writeFileSync(join(staticDir, 'iceberg-descriptor.json'), iceberg);
+  writeFileSync(join(staticDir, 'unity-descriptor.json'), delta);
+  substitutions['{S3}'] = endpoint;
+  substitutions['{CATALOG}'] = `http://127.0.0.1:${CATALOG_PORT}`;
+  substitutions['{UNITY}'] = `http://127.0.0.1:${UNITY_PORT}/api/2.1/unity-catalog`;
+  return true;
+}
+
+const lake = await startLake();
+const hostArgs = ['--http-port', String(HTTP_PORT), '--static-dir', staticDir];
+if (lake) {
+  hostArgs.push(
+    '--catalog-port', String(CATALOG_PORT), '--iceberg-descriptor', join(staticDir, 'iceberg-descriptor.json'),
+    '--unity-port', String(UNITY_PORT), '--unity-descriptor', join(staticDir, 'unity-descriptor.json'));
+}
+const host = spawn(process.execPath, [join(here, 'fixture-host.mjs'), ...hostArgs], { stdio: ['ignore', 'pipe', 'inherit'] });
+children.push(host);
+await new Promise((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error('fixture-host did not become ready')), 15000);
+  host.stdout.on('data', (d) => { if (String(d).includes('READY')) { clearTimeout(t); resolve(); } });
+  host.on('exit', (c) => reject(new Error(`fixture-host exited early (${c})`)));
+});
+console.log(`fixtures ready (lake: ${lake ? 'on' : 'OFF — data-lake statements will be skipped'})`);
+
+const cleanup = () => {
+  for (const c of children) c.kill('SIGKILL');
+  if (moto) moto.kill('SIGKILL');
+};
+process.on('exit', cleanup);
+
+// --- load the instrumented module --------------------------------------------
+const factory = (await import(pathToFileURL(join(bundleDir, 'chdb.mjs')).href)).default;
+const mod = await factory();
+console.log('instrumented module ready');
+
+// MEMFS fixtures for file() statements.
+mod.FS.mkdir('/corpus');
+mod.FS.writeFile('/corpus/people.csv', PEOPLE_CSV);
+mod.FS.writeFile('/corpus/people2.csv', PEOPLE_NAMES_CSV); // glob partner
+mod.FS.writeFile('/corpus/people_names.csv', PEOPLE_NAMES_CSV);
+mod.FS.writeFile('/corpus/people.tsv', PEOPLE_TSV);
+mod.FS.writeFile('/corpus/people.jsonl', PEOPLE_JSONL);
+
+// Handles (conn, result, stream pointers) are BigInt on Memory64 and must be
+// passed back into ccall UNconverted (the raw exports take i64); num() is only
+// for heap offsets consumed from JS. Mirrors src/bindings.ts.
+const conn = mod.ccall('chdb_wasm_connect', 'number', ['string'], ['']);
+if (!num(conn)) throw new Error('chdb_wasm_connect failed');
+
+function runStatement(sql, format = 'CSV') {
+  const r = mod.ccall('chdb_wasm_query_conn', 'number', ['number', 'string', 'string'], [conn, sql, format]);
+  if (!num(r)) return 'null result';
+  const errPtr = num(mod.ccall('chdb_wasm_result_error', 'number', ['number'], [r]));
+  const err = errPtr ? mod.UTF8ToString(errPtr) : null;
+  mod.ccall('chdb_wasm_free_result', null, ['number'], [r]);
+  return err;
+}
+
+// --- execute the corpus -------------------------------------------------------
+const corpus = readFileSync(join(here, 'profile-corpus.sql'), 'utf8');
+const statements = [];
+let buf = [];
+for (const line of corpus.split('\n')) {
+  if (/^\s*--/.test(line) || (!buf.length && !line.trim())) continue;
+  buf.push(line);
+  if (/;\s*$/.test(line)) { statements.push(buf.join('\n')); buf = []; }
+}
+
+let ok = 0, skipped = 0;
+const failures = [];
+const t0 = Date.now();
+const isMt = !!mod.PThread;
+for (let sql of statements) {
+  for (const [k, v] of Object.entries(substitutions)) sql = sql.replaceAll(k, v);
+  if (/\{[A-Z0-9]+\}/.test(sql)) { skipped++; continue; }
+  if (!isMt && sql.includes('/*mt-only*/')) { skipped++; continue; }
+  if (process.env.CHDB_TRACE === '1') console.log(`>>> ${sql.replace(/\n/g, ' ').slice(0, 100)}`);
+  try {
+    const err = runStatement(sql);
+    if (err) failures.push({ sql: sql.slice(0, 120), error: err.slice(0, 200) });
+    else ok++;
+  } catch (e) {
+    // A wasm trap (RuntimeError) means the instance aborted — nothing further
+    // can run; surface WHICH statement did it and give up.
+    console.error(`FATAL wasm trap on statement: ${sql.replace(/\n/g, ' ').slice(0, 200)}`);
+    throw e;
+  }
+}
+console.log(`corpus: ${ok} ok, ${failures.length} failed, ${skipped} skipped, ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+// --- streaming C-API surface ----------------------------------------------------
+{
+  const s = mod.ccall('chdb_wasm_stream_start', 'number', ['number', 'string', 'string'], [conn, 'SELECT number, toString(number) FROM numbers(100000)', 'CSV']);
+  let chunks = 0;
+  for (;;) {
+    const c = mod.ccall('chdb_wasm_stream_fetch', 'number', ['number', 'number'], [conn, s]);
+    if (!num(c)) break;
+    const len = num(mod.ccall('chdb_wasm_result_length', 'number', ['number'], [c]));
+    mod.ccall('chdb_wasm_free_result', null, ['number'], [c]);
+    chunks++;
+    if (!len) break;
+  }
+  mod.ccall('chdb_wasm_free_result', null, ['number'], [s]);
+  const s2 = mod.ccall('chdb_wasm_stream_start', 'number', ['number', 'string', 'string'], [conn, 'SELECT number FROM numbers(1000000)', 'CSV']);
+  mod.ccall('chdb_wasm_stream_cancel', null, ['number', 'number'], [conn, s2]);
+  mod.ccall('chdb_wasm_free_result', null, ['number'], [s2]);
+  console.log(`streaming: ${chunks} chunks + cancel`);
+}
+
+// Close the session before collecting: exercises shutdown paths and lets
+// query/background threads exit, so their pool workers return to the idle
+// (message-processing) state where they can answer chdbWriteProfile.
+mod.ccall('chdb_wasm_close_conn', null, ['number'], [conn]);
+
+// --- profile collection ---------------------------------------------------------
+const wp = mod.wasmExports?.__write_profile;
+if (!wp) throw new Error('__write_profile export missing — is this the instrumented bundle?');
+const profLen = Number(rawCall(wp, 0n, 0));
+// wasm export names are minified at this link level, so malloc must be reached
+// through the glue's Module._malloc alias (raw, unwrapped on Memory64).
+const bufPtr = num(rawCall(mod._malloc, profLen));
+
+const profiles = [];
+{
+  const n = Number(rawCall(wp, BigInt(bufPtr), profLen));
+  profiles.push(Uint8Array.from(mod.HEAPU8.slice(bufPtr, bufPtr + n)));
+  console.log(`profile main: ${n} bytes`);
+}
+
+const PThread = mod.PThread;
+if (PThread) {
+  const workers = [...PThread.runningWorkers, ...PThread.unusedWorkers];
+  let collected = 0, timedOut = 0;
+  for (let i = 0; i < workers.length; i++) {
+    const n = await new Promise((resolve) => {
+      // A worker parked in a blocking wait (Atomics.wait) can't service
+      // messages; skip it after a short timeout rather than hanging. Its
+      // coverage is lost, which at worst means an unnecessary lazy load at
+      // runtime — never a failure (see patch-glue.mjs --lazy-load).
+      const t = setTimeout(() => resolve(-2), 5000);
+      mod.__chdbProfileWritten = (tag, len) => { clearTimeout(t); resolve(len); };
+      workers[i].postMessage({ cmd: 'chdbWriteProfile', ptr: bufPtr, cap: profLen, tag: i });
+    });
+    if (n > 0) {
+      profiles.push(Uint8Array.from(mod.HEAPU8.slice(bufPtr, bufPtr + n)));
+      collected++;
+    } else if (n === -2) timedOut++;
+  }
+  console.log(`profile workers: ${collected} collected, ${timedOut} unresponsive of ${workers.length}`);
+}
+
+profiles.forEach((p, i) => writeFileSync(join(outDir, `profile-${i}.data`), p));
+writeFileSync(join(outDir, 'summary.json'), JSON.stringify({
+  statements: statements.length, ok, failed: failures.length, skipped, lake, profiles: profiles.length, failures,
+}, null, 2));
+console.log(`wrote ${profiles.length} profiles + summary.json to ${outDir}`);
+
+cleanup();
+process.exit(0);

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -118,7 +118,15 @@ run(wasmSplit, ['--merge-profiles', ...profiles, '-o', merged]);
 // executes ONLY on worker instances (invisible to the main profile) and does
 // not exist in the st build, so no profile can ever see it. Same class of
 // blind spot for the rest of the thread-entry runtime here.
-const SAFETY = /^(_*pthread_|__futex|futex_|emscripten_futex_|_*emscripten_stack_|emscripten_wasm_worker_|_emscripten_thread_|_emscripten_tls_|__wasm_init_tls|_emscripten_check_mailbox|emscripten_proxy_|em_proxying_|do_proxy|_emscripten_yield|emscripten_exit_with_live_runtime|__cxa_thread_|thrd_|call_once|__wait|__timedwait|__private_cond_signal|init_mparams)/;
+const SAFETY = /^(_*pthread_|__futex|futex_|emscripten_futex_|_*emscripten_stack_|emscripten_wasm_worker_|_emscripten_thread_|_emscripten_tls_|__wasm_init_tls|_emscripten_check_mailbox|emscripten_proxy_|em_proxying_|do_proxy|_emscripten_yield|emscripten_exit_with_live_runtime|__cxa_thread_|thrd_|call_once|__wait|__timedwait|__private_cond_signal|init_mparams|abort$)/;
+// Same blind spot one layer up, in C++: thread ENTRY code — std::thread /
+// Poco / ThreadFromGlobalPool trampolines, the per-task lambda wrapper
+// template instances they dispatch to, thread-local init routines, the
+// terminate/abort chain, and the logging-channel threads. All of it runs only
+// on worker instances of the mt build, so no profile pass can record it
+// (found empirically by probing a deferred-less bundle; matching by substring
+// catches the endless per-task template variants).
+const SAFETY_SUBSTR = /ThreadFromGlobalPool|ThreadPoolImpl<|__thread_proxy|__thread_struct|__thread_local_data|JobWithPriority|thread-local\\20initialization|runnableEntry|OwnRunnableForChannel|OwnAsyncSplitChannel|AsyncLogMessageQueue|demangling_terminate|std::terminate|std::__terminate|GrantedAllocation|TracingContextHolder|arrow::Unreachable|DiskEncryptedTransaction::undo/;
 const extraHotFile = opt('extra-hot');
 const extraHot = extraHotFile ? new Set(readFileSync(extraHotFile, 'utf8').split('\n').filter(Boolean)) : null;
 const emitHotFile = opt('emit-hot-names');
@@ -140,7 +148,7 @@ const keepStream = createWriteStream(keepFile);
       const name = line.slice(2);
       cold++;
       if (/^\d+$/.test(name)) numericNames++;
-      if (SAFETY.test(name)) { keepStream.write(name + '\n'); keptSafety++; }
+      if (SAFETY.test(name) || SAFETY_SUBSTR.test(name)) { keepStream.write(name + '\n'); keptSafety++; }
       else if (extraHot?.has(name)) { keepStream.write(name + '\n'); keptExtra++; }
     }
   }

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -110,7 +110,7 @@ const keepFile = join(outDir, 'keep-funcs.txt');
 const keepStream = createWriteStream(keepFile);
 {
   console.log(`$ ${wasmSplit} --print-profile=${merged} ${orig}  (streamed)`);
-  const p = spawn(wasmSplit, [`--print-profile=${merged}`, orig], { stdio: ['ignore', 'pipe', 'inherit'] });
+  const p = spawn(wasmSplit, [`--print-profile=${merged}`, orig, '--all-features'], { stdio: ['ignore', 'pipe', 'inherit'] });
   const rl = createInterface({ input: p.stdout, crlfDelay: Infinity });
   for await (const line of rl) {
     if (line.startsWith('+ ')) {

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -114,7 +114,11 @@ run(wasmSplit, ['--merge-profiles', ...profiles, '-o', merged]);
 //     as the existence check (wasm-split ignores names, it can't match).
 // print-profile output exceeds V8's string limit (~140k functions with huge
 // mangled names), so it is streamed line by line.
-const SAFETY = /^(_*pthread_|__futex|futex_|emscripten_futex_|_emscripten_thread_|_emscripten_tls_|__wasm_init_tls|_emscripten_check_mailbox|emscripten_proxy_|em_proxying_|do_proxy|_emscripten_yield|emscripten_exit_with_live_runtime|__cxa_thread_|thrd_|call_once|__wait|__timedwait|__private_cond_signal|init_mparams)/;
+// emscripten_stack_* runs at every pthread's entry (stack-bounds setup) — it
+// executes ONLY on worker instances (invisible to the main profile) and does
+// not exist in the st build, so no profile can ever see it. Same class of
+// blind spot for the rest of the thread-entry runtime here.
+const SAFETY = /^(_*pthread_|__futex|futex_|emscripten_futex_|_*emscripten_stack_|emscripten_wasm_worker_|_emscripten_thread_|_emscripten_tls_|__wasm_init_tls|_emscripten_check_mailbox|emscripten_proxy_|em_proxying_|do_proxy|_emscripten_yield|emscripten_exit_with_live_runtime|__cxa_thread_|thrd_|call_once|__wait|__timedwait|__private_cond_signal|init_mparams)/;
 const extraHotFile = opt('extra-hot');
 const extraHot = extraHotFile ? new Set(readFileSync(extraHotFile, 'utf8').split('\n').filter(Boolean)) : null;
 const emitHotFile = opt('emit-hot-names');

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -115,7 +115,7 @@ const extraHot = extraHotFile ? new Set(readFileSync(extraHotFile, 'utf8').split
 const emitHotFile = opt('emit-hot-names');
 const emitHot = emitHotFile ? createWriteStream(emitHotFile) : null;
 
-let hot = 0, cold = 0, keptSafety = 0, keptExtra = 0;
+let hot = 0, cold = 0, keptSafety = 0, keptExtra = 0, numericNames = 0;
 const keepFile = join(outDir, 'keep-funcs.txt');
 const keepStream = createWriteStream(keepFile);
 {
@@ -125,10 +125,12 @@ const keepStream = createWriteStream(keepFile);
   for await (const line of rl) {
     if (line.startsWith('+ ')) {
       hot++;
+      if (/^\d+$/.test(line.slice(2))) numericNames++;
       emitHot?.write(line.slice(2) + '\n');
     } else if (line.startsWith('- ')) {
       const name = line.slice(2);
       cold++;
+      if (/^\d+$/.test(name)) numericNames++;
       if (SAFETY.test(name)) { keepStream.write(name + '\n'); keptSafety++; }
       else if (extraHot?.has(name)) { keepStream.write(name + '\n'); keptExtra++; }
     }
@@ -136,6 +138,11 @@ const keepStream = createWriteStream(keepFile);
   await new Promise((res, rej) => p.on('exit', (c) => (c === 0 ? res() : rej(new Error(`print-profile exited with ${c}`)))));
   await Promise.all([keepStream, emitHot].filter(Boolean).map((s) => new Promise((r) => s.end(r))));
 }
+// Without a name section print-profile emits bare function INDICES; the
+// keep-lists and the st->mt hot-set transfer silently degrade to noise
+// (indices from different links never correspond). Guard against it.
+if (numericNames > (hot + cold) * 0.9)
+  throw new Error('profile names are bare indices — the build lost its name section; link with WASM_SPLIT_MODULE=ON (adds --profiling-funcs)');
 console.log(`profile: ${hot} hot / ${cold} cold; force-keeping ${keptSafety} thread-runtime + ${keptExtra} extra-hot functions`);
 
 // --- 5. split ---------------------------------------------------------------------

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -58,6 +58,16 @@ if (!existsSync(orig)) {
   process.exit(2);
 }
 
+// The .orig carries no usable target_features section, so binaryen needs the
+// build's feature set spelled out. NOT --all-features: that lets the writer
+// use experimental encodings (e.g. shared-everything) that V8 rejects with
+// "unknown import kind".
+const FEATURES = [
+  '--enable-mutable-globals', '--enable-sign-ext', '--enable-nontrapping-float-to-int',
+  '--enable-bulk-memory', '--enable-memory64', '--enable-exception-handling',
+  '--enable-reference-types', '--enable-multivalue', '--enable-threads',
+];
+
 const run = (cmd, args) => {
   console.log(`$ ${cmd} ${args.join(' ')}`);
   const r = spawnSync(cmd, args, { stdio: 'inherit' });
@@ -110,7 +120,7 @@ const keepFile = join(outDir, 'keep-funcs.txt');
 const keepStream = createWriteStream(keepFile);
 {
   console.log(`$ ${wasmSplit} --print-profile=${merged} ${orig}  (streamed)`);
-  const p = spawn(wasmSplit, [`--print-profile=${merged}`, orig, '--all-features'], { stdio: ['ignore', 'pipe', 'inherit'] });
+  const p = spawn(wasmSplit, [`--print-profile=${merged}`, orig, ...FEATURES], { stdio: ['ignore', 'pipe', 'inherit'] });
   const rl = createInterface({ input: p.stdout, crlfDelay: Infinity });
   for await (const line of rl) {
     if (line.startsWith('+ ')) {
@@ -135,7 +145,7 @@ run(wasmSplit, [
   '--export-prefix=%', orig,
   '-o1', primary, '-o2', deferred,
   `--profile=${merged}`, `--keep-funcs=@${keepFile}`,
-  '--all-features',
+  ...FEATURES,
 ]);
 
 // --- 6. install glue ----------------------------------------------------------------

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// End-to-end wasm-split pipeline for a chdb bundle built with
+// -DWASM_SPLIT_MODULE=ON (which emits chdb.mjs + chdb.wasm [instrumented] +
+// chdb.wasm.orig [the real artifact]):
+//
+//   1. stage the instrumented bundle, patch its glue for lazy-load correctness
+//      and per-worker profile collection
+//   2. run the profiling corpus against it (run-profile.mjs, separate process)
+//   3. union the per-instance profiles (wasm-split --merge-profiles)
+//   4. add a safety keep-list: cold thread-runtime primitives whose only
+//      executions happen on workers that were parked in Atomics.wait during
+//      collection (they can't answer, so their coverage can be lost)
+//   5. split chdb.wasm.orig into primary + deferred guided by the profile
+//   6. install primary as chdb.wasm, the deferred module as
+//      chdb.deferred.wasm, and the lazy-load-patched glue as chdb.mjs
+//
+// Usage: split-wasm.mjs --build <dir> --out <dir> [--wasm-split <bin>] [--skip-profile-run]
+//   --build           dir containing chdb.mjs / chdb.wasm / chdb.wasm.orig
+//   --out             output dir (also holds staging/ and profiles/)
+//   --wasm-split      wasm-split binary (default: $WASM_SPLIT or emsdk's)
+//   --skip-profile-run reuse existing profiles in <out>/profiles
+//   --emit-hot-names F write the profile's hot function names to F (one per
+//                     line). Run the SINGLE-THREADED bundle with this: its one
+//                     instance sees the whole pipeline execute inline, so its
+//                     hot set is the complete corpus coverage.
+//   --extra-hot F     force-keep these function names too (F from a prior
+//                     --emit-hot-names run). Needed for the THREADED bundle:
+//                     its pool workers park in Atomics.wait and cannot answer
+//                     the profile-collection message, so everything that only
+//                     ran on worker threads (IO pool reads, parallel parsing,
+//                     format output threads...) is missing from its own
+//                     profile. C++ mangled names are identical across the two
+//                     links, so the st hot set fills exactly that gap.
+
+import { readFileSync, writeFileSync, mkdirSync, copyFileSync, readdirSync, statSync, existsSync, createWriteStream } from 'node:fs';
+import { spawnSync, spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const argv = process.argv.slice(2);
+const opt = (name, dflt) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : dflt;
+};
+const buildDir = opt('build');
+const outDir = opt('out');
+const wasmSplit = opt('wasm-split', process.env.WASM_SPLIT || join(homedir(), 'code/emsdk/upstream/bin/wasm-split'));
+if (!buildDir || !outDir) {
+  console.error('usage: split-wasm.mjs --build <dir> --out <dir> [--wasm-split <bin>] [--skip-profile-run]');
+  process.exit(2);
+}
+const orig = join(buildDir, 'chdb.wasm.orig');
+if (!existsSync(orig)) {
+  console.error(`${orig} not found — build with -DWASM_SPLIT_MODULE=ON first`);
+  process.exit(2);
+}
+
+const run = (cmd, args) => {
+  console.log(`$ ${cmd} ${args.join(' ')}`);
+  const r = spawnSync(cmd, args, { stdio: 'inherit' });
+  if (r.status !== 0) throw new Error(`${cmd} exited with ${r.status}`);
+};
+const mb = (p) => `${(statSync(p).size / 1048576).toFixed(1)}MB`;
+
+// --- 1. stage instrumented bundle ---------------------------------------------
+const staging = join(outDir, 'staging');
+const profilesDir = join(outDir, 'profiles');
+mkdirSync(staging, { recursive: true });
+copyFileSync(join(buildDir, 'chdb.wasm'), join(staging, 'chdb.wasm'));
+copyFileSync(join(buildDir, 'chdb.mjs'), join(staging, 'chdb.mjs'));
+run(process.execPath, [join(here, 'patch-glue.mjs'), join(staging, 'chdb.mjs'), '--lazy-load', '--profile-collect']);
+
+// --- 2. profiling run -----------------------------------------------------------
+if (!argv.includes('--skip-profile-run')) {
+  const r = spawnSync(process.execPath, [join(here, 'run-profile.mjs')], {
+    stdio: 'inherit',
+    env: { ...process.env, CHDB_BUNDLE_DIR: staging, CHDB_PROFILE_OUT: profilesDir },
+  });
+  if (r.status !== 0) throw new Error(`run-profile.mjs exited with ${r.status}`);
+}
+const profiles = readdirSync(profilesDir).filter((f) => f.endsWith('.data')).map((f) => join(profilesDir, f));
+if (!profiles.length) throw new Error(`no profiles in ${profilesDir}`);
+console.log(`${profiles.length} instance profiles`);
+
+// --- 3. merge -------------------------------------------------------------------
+const merged = join(outDir, 'merged.profile');
+run(wasmSplit, ['--merge-profiles', ...profiles, '-o', merged]);
+
+// --- 4. keep-list -----------------------------------------------------------------
+// (a) Thread/proxying runtime primitives must never be placeholder-stubbed: some
+//     run during worker instantiation (before the lazy loader could even fire)
+//     and their only profile source is a worker that may have been unresponsive
+//     at collection time. Match by name against the cold set and force-keep.
+// (b) --extra-hot names (typically the st bundle's hot set) that are cold in
+//     THIS profile get force-kept too; taking them from the cold list doubles
+//     as the existence check (wasm-split ignores names, it can't match).
+// print-profile output exceeds V8's string limit (~140k functions with huge
+// mangled names), so it is streamed line by line.
+const SAFETY = /^(_*pthread_|__futex|futex_|emscripten_futex_|_emscripten_thread_|_emscripten_tls_|__wasm_init_tls|_emscripten_check_mailbox|emscripten_proxy_|em_proxying_|do_proxy|_emscripten_yield|emscripten_exit_with_live_runtime|__cxa_thread_|thrd_|call_once|__wait|__timedwait|__private_cond_signal|init_mparams)/;
+const extraHotFile = opt('extra-hot');
+const extraHot = extraHotFile ? new Set(readFileSync(extraHotFile, 'utf8').split('\n').filter(Boolean)) : null;
+const emitHotFile = opt('emit-hot-names');
+const emitHot = emitHotFile ? createWriteStream(emitHotFile) : null;
+
+let hot = 0, cold = 0, keptSafety = 0, keptExtra = 0;
+const keepFile = join(outDir, 'keep-funcs.txt');
+const keepStream = createWriteStream(keepFile);
+{
+  console.log(`$ ${wasmSplit} --print-profile=${merged} ${orig}  (streamed)`);
+  const p = spawn(wasmSplit, [`--print-profile=${merged}`, orig], { stdio: ['ignore', 'pipe', 'inherit'] });
+  const rl = createInterface({ input: p.stdout, crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (line.startsWith('+ ')) {
+      hot++;
+      emitHot?.write(line.slice(2) + '\n');
+    } else if (line.startsWith('- ')) {
+      const name = line.slice(2);
+      cold++;
+      if (SAFETY.test(name)) { keepStream.write(name + '\n'); keptSafety++; }
+      else if (extraHot?.has(name)) { keepStream.write(name + '\n'); keptExtra++; }
+    }
+  }
+  await new Promise((res, rej) => p.on('exit', (c) => (c === 0 ? res() : rej(new Error(`print-profile exited with ${c}`)))));
+  await Promise.all([keepStream, emitHot].filter(Boolean).map((s) => new Promise((r) => s.end(r))));
+}
+console.log(`profile: ${hot} hot / ${cold} cold; force-keeping ${keptSafety} thread-runtime + ${keptExtra} extra-hot functions`);
+
+// --- 5. split ---------------------------------------------------------------------
+const primary = join(outDir, 'chdb.wasm');
+const deferred = join(outDir, 'chdb.deferred.wasm');
+run(wasmSplit, [
+  '--export-prefix=%', orig,
+  '-o1', primary, '-o2', deferred,
+  `--profile=${merged}`, `--keep-funcs=@${keepFile}`,
+  '--all-features',
+]);
+
+// --- 6. install glue ----------------------------------------------------------------
+const glue = join(outDir, 'chdb.mjs');
+copyFileSync(join(buildDir, 'chdb.mjs'), glue);
+run(process.execPath, [join(here, 'patch-glue.mjs'), glue, '--lazy-load']);
+
+// Sanity: the primary must import its stubs from `placeholder*` modules — that's
+// what the glue's proxy intercepts.
+const mod = new WebAssembly.Module(readFileSync(primary));
+const placeholders = WebAssembly.Module.imports(mod).filter((i) => i.module.startsWith('placeholder')).length;
+if (!placeholders) throw new Error('primary has no placeholder imports — split produced a non-lazy module?');
+
+console.log(`
+done:
+  primary   ${primary}  ${mb(primary)}  (${placeholders} placeholder stubs)
+  deferred  ${deferred}  ${mb(deferred)}
+  glue      ${glue}
+original    ${orig}  ${mb(orig)}`);

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -83,13 +83,18 @@ copyFileSync(join(buildDir, 'chdb.wasm'), join(staging, 'chdb.wasm'));
 copyFileSync(join(buildDir, 'chdb.mjs'), join(staging, 'chdb.mjs'));
 run(process.execPath, [join(here, 'patch-glue.mjs'), join(staging, 'chdb.mjs'), '--lazy-load', '--profile-collect']);
 
-// --- 2. profiling run -----------------------------------------------------------
+// --- 2. profiling runs ------------------------------------------------------------
+// Two passes, because a process has exactly ONE engine cold start and the SDK
+// reaches it two ways: the main corpus pass boots via chdb_wasm_connect, the
+// light init-probe pass boots via connectionless chdb_wasm_query.
 if (!argv.includes('--skip-profile-run')) {
-  const r = spawnSync(process.execPath, [join(here, 'run-profile.mjs')], {
-    stdio: 'inherit',
-    env: { ...process.env, CHDB_BUNDLE_DIR: staging, CHDB_PROFILE_OUT: profilesDir },
-  });
-  if (r.status !== 0) throw new Error(`run-profile.mjs exited with ${r.status}`);
+  for (const extraEnv of [{}, { CHDB_INIT_PROBE: 'global', CHDB_PROFILE_PREFIX: 'initprobe' }]) {
+    const r = spawnSync(process.execPath, [join(here, 'run-profile.mjs')], {
+      stdio: 'inherit',
+      env: { ...process.env, CHDB_BUNDLE_DIR: staging, CHDB_PROFILE_OUT: profilesDir, ...extraEnv },
+    });
+    if (r.status !== 0) throw new Error(`run-profile.mjs exited with ${r.status}`);
+  }
 }
 const profiles = readdirSync(profilesDir).filter((f) => f.endsWith('.data')).map((f) => join(profilesDir, f));
 if (!profiles.length) throw new Error(`no profiles in ${profilesDir}`);

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -126,9 +126,16 @@ const SAFETY = /^(_*pthread_|__futex|futex_|emscripten_futex_|_*emscripten_stack
 // on worker instances of the mt build, so no profile pass can record it
 // (found empirically by probing a deferred-less bundle; matching by substring
 // catches the endless per-task template variants).
-const SAFETY_SUBSTR = /ThreadFromGlobalPool|ThreadPoolImpl<|__thread_proxy|__thread_struct|__thread_local_data|JobWithPriority|thread-local\\20initialization|runnableEntry|OwnRunnableForChannel|OwnAsyncSplitChannel|AsyncLogMessageQueue|demangling_terminate|std::terminate|std::__terminate|GrantedAllocation|TracingContextHolder|arrow::Unreachable|DiskEncryptedTransaction::undo/;
+// The last five entries are mt-only IMPLEMENTATIONS of the query result path
+// (the st build takes the synchronous variants, so its hot set can't supply
+// them): LazyOutputFormat + PullingAsyncPipelineExecutor feed results across
+// threads, ParallelFormattingOutputFormat renders them.
+const SAFETY_SUBSTR = /ThreadFromGlobalPool|ThreadPoolImpl<|__thread_proxy|__thread_struct|__thread_local_data|JobWithPriority|thread-local\\20initialization|runnableEntry|OwnRunnableForChannel|OwnAsyncSplitChannel|AsyncLogMessageQueue|demangling_terminate|std::terminate|std::__terminate|GrantedAllocation|TracingContextHolder|arrow::Unreachable|DiskEncryptedTransaction::undo|LazyOutputFormat|ParallelFormattingOutputFormat|PullingAsyncPipelineExecutor|ThreadFramePointers|BufferWithOutsideMemory/;
 const extraHotFile = opt('extra-hot');
 const extraHot = extraHotFile ? new Set(readFileSync(extraHotFile, 'utf8').split('\n').filter(Boolean)) : null;
+// Checked-in list of single worker-path functions (see keep-worker-path.txt).
+const workerPath = new Set(
+  readFileSync(join(here, 'keep-worker-path.txt'), 'utf8').split('\n').filter((l) => l && !l.startsWith('#')));
 const emitHotFile = opt('emit-hot-names');
 const emitHot = emitHotFile ? createWriteStream(emitHotFile) : null;
 
@@ -148,7 +155,7 @@ const keepStream = createWriteStream(keepFile);
       const name = line.slice(2);
       cold++;
       if (/^\d+$/.test(name)) numericNames++;
-      if (SAFETY.test(name) || SAFETY_SUBSTR.test(name)) { keepStream.write(name + '\n'); keptSafety++; }
+      if (SAFETY.test(name) || SAFETY_SUBSTR.test(name) || workerPath.has(name)) { keepStream.write(name + '\n'); keptSafety++; }
       else if (extraHot?.has(name)) { keepStream.write(name + '\n'); keptExtra++; }
     }
   }

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -139,7 +139,7 @@ const workerPath = new Set(
 const emitHotFile = opt('emit-hot-names');
 const emitHot = emitHotFile ? createWriteStream(emitHotFile) : null;
 
-let hot = 0, cold = 0, keptSafety = 0, keptExtra = 0, numericNames = 0;
+let hot = 0, cold = 0, keptSafety = 0, keptExtra = 0, keptNameless = 0, numericNames = 0;
 const keepFile = join(outDir, 'keep-funcs.txt');
 const keepStream = createWriteStream(keepFile);
 {
@@ -154,8 +154,18 @@ const keepStream = createWriteStream(keepFile);
     } else if (line.startsWith('- ')) {
       const name = line.slice(2);
       cold++;
-      if (/^\d+$/.test(name)) numericNames++;
-      if (SAFETY.test(name) || SAFETY_SUBSTR.test(name) || workerPath.has(name)) { keepStream.write(name + '\n'); keptSafety++; }
+      if (/^\d+$/.test(name) || /^trampoline_/.test(name) || /_\d{4,}$/.test(name)) {
+        // Linker/compiler-SYNTHESIZED names never correspond across links, so
+        // the st->mt hot-set transfer is blind to them even though hot code
+        // calls into them: bare-index names on nameless std::function/lambda
+        // thunks, and wasm-ld's signature-mismatch bridges named
+        // trampoline_X / X_<link-specific-number> (found the hard way under
+        // CountingTransform and ~DeduplicationInfo in the INSERT pipeline).
+        // All tiny; keep every cold one (~10k functions, low-MB cost).
+        if (/^\d+$/.test(name)) numericNames++;
+        keepStream.write(name + '\n');
+        keptNameless++;
+      } else if (SAFETY.test(name) || SAFETY_SUBSTR.test(name) || workerPath.has(name)) { keepStream.write(name + '\n'); keptSafety++; }
       else if (extraHot?.has(name)) { keepStream.write(name + '\n'); keptExtra++; }
     }
   }
@@ -167,7 +177,7 @@ const keepStream = createWriteStream(keepFile);
 // (indices from different links never correspond). Guard against it.
 if (numericNames > (hot + cold) * 0.9)
   throw new Error('profile names are bare indices — the build lost its name section; link with WASM_SPLIT_MODULE=ON (adds --profiling-funcs)');
-console.log(`profile: ${hot} hot / ${cold} cold; force-keeping ${keptSafety} thread-runtime + ${keptExtra} extra-hot functions`);
+console.log(`profile: ${hot} hot / ${cold} cold; force-keeping ${keptSafety} thread-runtime + ${keptExtra} extra-hot + ${keptNameless} nameless-thunk functions`);
 
 // --- 5. split ---------------------------------------------------------------------
 const primary = join(outDir, 'chdb.wasm');

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -145,6 +145,14 @@ const keepStream = createWriteStream(keepFile);
 {
   console.log(`$ ${wasmSplit} --print-profile=${merged} ${orig}  (streamed)`);
   const p = spawn(wasmSplit, [`--print-profile=${merged}`, orig, ...FEATURES], { stdio: ['ignore', 'pipe', 'inherit'] });
+  // Attach BEFORE draining stdout: 'exit' can fire while buffered output is
+  // still being consumed, and a one-shot listener added afterwards never
+  // settles. 'close' fires after the stdio streams end; 'error' covers spawn
+  // failure (e.g. missing wasm-split binary).
+  const exited = new Promise((res, rej) => {
+    p.on('error', rej);
+    p.on('close', (c) => (c === 0 ? res() : rej(new Error(`print-profile exited with ${c}`))));
+  });
   const rl = createInterface({ input: p.stdout, crlfDelay: Infinity });
   for await (const line of rl) {
     if (line.startsWith('+ ')) {
@@ -169,7 +177,7 @@ const keepStream = createWriteStream(keepFile);
       else if (extraHot?.has(name)) { keepStream.write(name + '\n'); keptExtra++; }
     }
   }
-  await new Promise((res, rej) => p.on('exit', (c) => (c === 0 ? res() : rej(new Error(`print-profile exited with ${c}`)))));
+  await exited;
   await Promise.all([keepStream, emitHot].filter(Boolean).map((s) => new Promise((r) => s.end(r))));
 }
 // Without a name section print-profile emits bare function INDICES; the

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -37,7 +37,6 @@ import { spawnSync, spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { homedir } from 'node:os';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const argv = process.argv.slice(2);
@@ -47,9 +46,14 @@ const opt = (name, dflt) => {
 };
 const buildDir = opt('build');
 const outDir = opt('out');
-const wasmSplit = opt('wasm-split', process.env.WASM_SPLIT || join(homedir(), 'code/emsdk/upstream/bin/wasm-split'));
+const wasmSplit = opt('wasm-split', process.env.WASM_SPLIT
+  || (process.env.EMSDK && join(process.env.EMSDK, 'upstream/bin/wasm-split')));
 if (!buildDir || !outDir) {
   console.error('usage: split-wasm.mjs --build <dir> --out <dir> [--wasm-split <bin>] [--skip-profile-run]');
+  process.exit(2);
+}
+if (!wasmSplit || !existsSync(wasmSplit)) {
+  console.error(`wasm-split not found${wasmSplit ? ` at ${wasmSplit}` : ''} — pass --wasm-split, or set WASM_SPLIT / EMSDK (source emsdk_env.sh)`);
   process.exit(2);
 }
 const orig = join(buildDir, 'chdb.wasm.orig');
@@ -71,6 +75,8 @@ const FEATURES = [
 const run = (cmd, args) => {
   console.log(`$ ${cmd} ${args.join(' ')}`);
   const r = spawnSync(cmd, args, { stdio: 'inherit' });
+  // spawnSync doesn't throw on spawn failure: status stays null, the cause is in r.error.
+  if (r.error) throw new Error(`failed to run ${cmd}: ${r.error.message}`);
   if (r.status !== 0) throw new Error(`${cmd} exited with ${r.status}`);
 };
 const mb = (p) => `${(statSync(p).size / 1048576).toFixed(1)}MB`;
@@ -96,8 +102,10 @@ if (!argv.includes('--skip-profile-run')) {
     if (r.status !== 0) throw new Error(`run-profile.mjs exited with ${r.status}`);
   }
 }
-const profiles = readdirSync(profilesDir).filter((f) => f.endsWith('.data')).map((f) => join(profilesDir, f));
-if (!profiles.length) throw new Error(`no profiles in ${profilesDir}`);
+const profiles = existsSync(profilesDir)
+  ? readdirSync(profilesDir).filter((f) => f.endsWith('.data')).map((f) => join(profilesDir, f))
+  : [];
+if (!profiles.length) throw new Error(`no profiles in ${profilesDir} — run without --skip-profile-run first`);
 console.log(`${profiles.length} instance profiles`);
 
 // --- 3. merge -------------------------------------------------------------------

--- a/packages/chdb-wasm/tools/split/split-wasm.mjs
+++ b/packages/chdb-wasm/tools/split/split-wasm.mjs
@@ -32,7 +32,7 @@
 //                     profile. C++ mangled names are identical across the two
 //                     links, so the st hot set fills exactly that gap.
 
-import { readFileSync, writeFileSync, mkdirSync, copyFileSync, readdirSync, statSync, existsSync, createWriteStream } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, copyFileSync, readdirSync, statSync, existsSync, rmSync, createWriteStream } from 'node:fs';
 import { spawnSync, spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { join, dirname } from 'node:path';
@@ -94,6 +94,11 @@ run(process.execPath, [join(here, 'patch-glue.mjs'), join(staging, 'chdb.mjs'), 
 // reaches it two ways: the main corpus pass boots via chdb_wasm_connect, the
 // light init-probe pass boots via connectionless chdb_wasm_query.
 if (!argv.includes('--skip-profile-run')) {
+  // A fresh profiling run must not inherit .data files from a previous run in
+  // a reused --out dir: run-profile only overwrites what it produces, and
+  // leftovers (possibly from a DIFFERENT build) would be merged in below.
+  if (existsSync(profilesDir))
+    for (const f of readdirSync(profilesDir)) if (f.endsWith('.data')) rmSync(join(profilesDir, f));
   for (const extraEnv of [{}, { CHDB_INIT_PROBE: 'global', CHDB_PROFILE_PREFIX: 'initprobe' }]) {
     const r = spawnSync(process.execPath, [join(here, 'run-profile.mjs')], {
       stdio: 'inherit',

--- a/packages/chdb-wasm/tools/split/verify-split.mjs
+++ b/packages/chdb-wasm/tools/split/verify-split.mjs
@@ -34,8 +34,8 @@ const probe = (label, sql, expectOk) => {
     import { AsyncChdb } from ${JSON.stringify(join(pkgDir, 'dist/index.js'))};
     const db = await AsyncChdb.create({ moduleUrl: ${JSON.stringify(join(dir, 'chdb.mjs'))} });
     const r = await db.query(${JSON.stringify(sql)}, 'CSV');
-    console.log(r.data.trim());
-    await db.close();
+    console.log(r.text().trim());
+    await db.terminate();
     process.exit(0);
   `;
   const scriptFile = join(mkdtempSync(join(tmpdir(), 'chdb-verify-')), 'probe.mjs');

--- a/packages/chdb-wasm/tools/split/verify-split.mjs
+++ b/packages/chdb-wasm/tools/split/verify-split.mjs
@@ -43,12 +43,16 @@ const probe = (label, sql, expectOk) => {
   const r = spawnSync(process.execPath, [scriptFile], { encoding: 'utf8', timeout: 300000 });
   const ok = r.status === 0;
   if (ok !== expectOk) {
+    // No process.exit here: it would skip the caller's finally and leave
+    // chdb.deferred.wasm renamed away.
     console.error(`FAIL ${label}: expected ${expectOk ? 'success' : 'failure'}, got ${ok ? 'success' : `failure (${(r.stderr || '').split('\n').filter((l) => /Error|error/.test(l))[0] || r.status})`}`);
     if (ok) console.error(`  output: ${r.stdout.trim().slice(0, 200)}`);
-    process.exit(1);
+    failed = true;
+    return;
   }
   console.log(`ok: ${label}${ok ? ` -> ${r.stdout.trim().split('\n').pop().slice(0, 80)}` : ' (failed as expected)'}`);
 };
+let failed = false;
 
 probe('hot query on split bundle', HOT_SQL, true);
 probe('cold query lazy-loads deferred module', COLD_SQL, true);
@@ -61,4 +65,5 @@ try {
 } finally {
   renameSync(deferred + '.hidden', deferred);
 }
+if (failed) process.exit(1);
 console.log('verify-split: PASS');

--- a/packages/chdb-wasm/tools/split/verify-split.mjs
+++ b/packages/chdb-wasm/tools/split/verify-split.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Verifies a split bundle end to end:
+//   1. hot path: a corpus-covered query runs without touching the deferred module
+//   2. cold path: a query using functions ABSENT from the corpus succeeds — which
+//      is only possible if the placeholder stub lazy-loaded chdb.deferred.wasm
+//   3. negative control: with chdb.deferred.wasm renamed away, the same cold
+//      query must fail while the hot query still works — proving (2) really
+//      exercised the lazy loader rather than the primary having the code
+//
+// Steps 1+2 and step 3 run in separate child processes (a failed deferred load
+// can take the wasm instance down with it).
+//
+// Usage: verify-split.mjs <dir with chdb.mjs + chdb.wasm + chdb.deferred.wasm>
+
+import { spawnSync } from 'node:child_process';
+import { renameSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = process.argv[2];
+if (!dir || !existsSync(join(dir, 'chdb.deferred.wasm'))) {
+  console.error('usage: verify-split.mjs <dir with chdb.mjs/chdb.wasm/chdb.deferred.wasm>');
+  process.exit(2);
+}
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../..');
+
+// Deliberately NOT in profile-corpus.sql — keep it that way.
+const COLD_SQL = 'SELECT toModifiedJulianDay(\'2024-03-15\'), fromModifiedJulianDay(60384)';
+const HOT_SQL = 'SELECT sum(number), count() FROM numbers(1000)';
+
+const probe = (label, sql, expectOk) => {
+  const script = `
+    import { AsyncChdb } from ${JSON.stringify(join(pkgDir, 'dist/index.js'))};
+    const db = await AsyncChdb.create({ moduleUrl: ${JSON.stringify(join(dir, 'chdb.mjs'))} });
+    const r = await db.query(${JSON.stringify(sql)}, 'CSV');
+    console.log(r.data.trim());
+    await db.close();
+    process.exit(0);
+  `;
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8', timeout: 300000 });
+  const ok = r.status === 0;
+  if (ok !== expectOk) {
+    console.error(`FAIL ${label}: expected ${expectOk ? 'success' : 'failure'}, got ${ok ? 'success' : `failure (${(r.stderr || '').split('\n').filter((l) => /Error|error/.test(l))[0] || r.status})`}`);
+    if (ok) console.error(`  output: ${r.stdout.trim().slice(0, 200)}`);
+    process.exit(1);
+  }
+  console.log(`ok: ${label}${ok ? ` -> ${r.stdout.trim().split('\n').pop().slice(0, 80)}` : ' (failed as expected)'}`);
+};
+
+probe('hot query on split bundle', HOT_SQL, true);
+probe('cold query lazy-loads deferred module', COLD_SQL, true);
+
+const deferred = join(dir, 'chdb.deferred.wasm');
+renameSync(deferred, deferred + '.hidden');
+try {
+  probe('hot query without deferred module', HOT_SQL, true);
+  probe('cold query without deferred module', COLD_SQL, false);
+} finally {
+  renameSync(deferred + '.hidden', deferred);
+}
+console.log('verify-split: PASS');

--- a/packages/chdb-wasm/tools/split/verify-split.mjs
+++ b/packages/chdb-wasm/tools/split/verify-split.mjs
@@ -13,7 +13,7 @@
 // Usage: verify-split.mjs <dir with chdb.mjs + chdb.wasm + chdb.deferred.wasm>
 
 import { spawnSync } from 'node:child_process';
-import { renameSync, existsSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { renameSync, existsSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -24,6 +24,12 @@ if (!dir || !existsSync(join(dir, 'chdb.deferred.wasm'))) {
   process.exit(2);
 }
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../..');
+
+// One temp root for all probe scripts, removed on exit (repeated runs would
+// otherwise accumulate chdb-verify-* dirs under the system temp dir).
+const tmpRoot = mkdtempSync(join(tmpdir(), 'chdb-verify-'));
+process.on('exit', () => rmSync(tmpRoot, { recursive: true, force: true }));
+let tmpSeq = 0;
 
 // Deliberately NOT in profile-corpus.sql — keep it that way.
 const COLD_SQL = 'SELECT toModifiedJulianDay(\'2024-03-15\'), fromModifiedJulianDay(60384)';
@@ -38,7 +44,8 @@ const probe = (label, sql, expectOk) => {
     await db.terminate();
     process.exit(0);
   `;
-  const scriptFile = join(mkdtempSync(join(tmpdir(), 'chdb-verify-')), 'probe.mjs');
+  mkdirSync(join(tmpRoot, String(++tmpSeq)));
+  const scriptFile = join(tmpRoot, String(tmpSeq), 'probe.mjs');
   writeFileSync(scriptFile, script);
   const r = spawnSync(process.execPath, [scriptFile], { encoding: 'utf8', timeout: 300000 });
   if (r.status === null) {

--- a/packages/chdb-wasm/tools/split/verify-split.mjs
+++ b/packages/chdb-wasm/tools/split/verify-split.mjs
@@ -13,8 +13,9 @@
 // Usage: verify-split.mjs <dir with chdb.mjs + chdb.wasm + chdb.deferred.wasm>
 
 import { spawnSync } from 'node:child_process';
-import { renameSync, existsSync } from 'node:fs';
+import { renameSync, existsSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const dir = process.argv[2];
@@ -37,7 +38,9 @@ const probe = (label, sql, expectOk) => {
     await db.close();
     process.exit(0);
   `;
-  const r = spawnSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8', timeout: 300000 });
+  const scriptFile = join(mkdtempSync(join(tmpdir(), 'chdb-verify-')), 'probe.mjs');
+  writeFileSync(scriptFile, script);
+  const r = spawnSync(process.execPath, [scriptFile], { encoding: 'utf8', timeout: 300000 });
   const ok = r.status === 0;
   if (ok !== expectOk) {
     console.error(`FAIL ${label}: expected ${expectOk ? 'success' : 'failure'}, got ${ok ? 'success' : `failure (${(r.stderr || '').split('\n').filter((l) => /Error|error/.test(l))[0] || r.status})`}`);

--- a/packages/chdb-wasm/tools/split/verify-split.mjs
+++ b/packages/chdb-wasm/tools/split/verify-split.mjs
@@ -41,6 +41,13 @@ const probe = (label, sql, expectOk) => {
   const scriptFile = join(mkdtempSync(join(tmpdir(), 'chdb-verify-')), 'probe.mjs');
   writeFileSync(scriptFile, script);
   const r = spawnSync(process.execPath, [scriptFile], { encoding: 'utf8', timeout: 300000 });
+  if (r.status === null) {
+    // Timeout/kill is the historical hang mode of a broken lazy loader —
+    // never an "expected failure", regardless of expectOk.
+    console.error(`FAIL ${label}: child killed (${r.error?.code || 'signal ' + r.signal}) — hang instead of a clean exit`);
+    failed = true;
+    return;
+  }
   const ok = r.status === 0;
   if (ok !== expectOk) {
     // No process.exit here: it would skip the caller's finally and leave

--- a/programs/wasm/CMakeLists.txt
+++ b/programs/wasm/CMakeLists.txt
@@ -89,6 +89,11 @@ if (WASM_SPLIT_MODULE)
         # SPLIT_MODULE is marked experimental; the warning would otherwise fail
         # the link under -Werror-style CI settings.
         -Wno-experimental
+        # Keep the wasm name section: the split pipeline matches functions BY
+        # NAME (keep-lists, transferring the st bundle's hot set onto the mt
+        # split). Only chdb.wasm.orig / the instrumented module carry it —
+        # wasm-split strips names from the shipped primary/deferred outputs.
+        --profiling-funcs
         )
 endif ()
 

--- a/programs/wasm/CMakeLists.txt
+++ b/programs/wasm/CMakeLists.txt
@@ -32,11 +32,34 @@ set (WASM_PTHREAD_POOL_SIZE "16" CACHE STRING "chdb-wasm pre-spawned worker pool
 set (WASM_PTHREAD_STACK_SIZE "2MB" CACHE STRING "chdb-wasm per-worker stack size")
 set (WASM_INITIAL_MEMORY "128MB" CACHE STRING "chdb-wasm initial heap size")
 
+# WASM_SPLIT_MODULE: link with -sSPLIT_MODULE so the module can be split with
+# Binaryen's wasm-split into a small hot "primary" wasm (downloaded up front)
+# and a cold "deferred" wasm fetched lazily on the first call into a cold
+# function. The link then emits chdb.wasm (instrumented for profile collection)
+# plus chdb.wasm.orig (the real artifact that gets split), and the JS glue gains
+# the placeholder-import proxy + loadSplitModule. The split itself (profiling
+# run + wasm-split) happens post-build; see packages/chdb-wasm/tools/split/.
+option (WASM_SPLIT_MODULE "Link for wasm-split lazy code loading" OFF)
+
 # Emit an ES module loadable from Node / the browser: chdb.mjs (+ chdb.wasm).
 set_target_properties (chdb_wasm PROPERTIES
     OUTPUT_NAME chdb
     SUFFIX ".mjs"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+# HEAPU8 + FS are used by the npm package (putFile/registerFile, result copy-out);
+# registerFile's lazy reader (ReadBufferFromJSFile) needs no extra exports — it
+# reads via MAIN_THREAD_EM_ASM. The split pipeline additionally needs wasmExports
+# (to reach the instrumentation's __write_profile) and PThread (to collect the
+# per-worker profiles); emcc keeps only the LAST -sEXPORTED_RUNTIME_METHODS, so
+# the list is assembled here instead of repeating the flag.
+set (WASM_RUNTIME_METHODS "ccall,cwrap,UTF8ToString,getValue,setValue,HEAPU8,FS")
+if (WASM_SPLIT_MODULE)
+    set (WASM_RUNTIME_METHODS "${WASM_RUNTIME_METHODS},wasmExports")
+    if (WASM_THREADS)
+        set (WASM_RUNTIME_METHODS "${WASM_RUNTIME_METHODS},PThread")
+    endif ()
+endif ()
 
 # Note: -sMEMORY64=1, -fwasm-exceptions and (when WASM_THREADS=ON) -pthread are
 # added globally in cmake/target.cmake's OS_WASM block.
@@ -55,13 +78,19 @@ target_link_options (chdb_wasm PRIVATE
     -sWASM_BIGINT
     -sFORCE_FILESYSTEM=1
     -sALLOW_TABLE_GROWTH=1
-    # HEAPU8 + FS are used by the npm package (putFile/registerFile, result copy-out);
-    # registerFile's lazy reader (ReadBufferFromJSFile) needs no extra exports — it
-    # reads via MAIN_THREAD_EM_ASM.
-    "SHELL:-s EXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString,getValue,setValue,HEAPU8,FS"
+    "SHELL:-s EXPORTED_RUNTIME_METHODS=${WASM_RUNTIME_METHODS}"
     "SHELL:-s EXPORTED_FUNCTIONS=@${CMAKE_CURRENT_SOURCE_DIR}/exported_functions.txt"
     -sENVIRONMENT=node,web,worker
     )
+
+if (WASM_SPLIT_MODULE)
+    target_link_options (chdb_wasm PRIVATE
+        -sSPLIT_MODULE
+        # SPLIT_MODULE is marked experimental; the warning would otherwise fail
+        # the link under -Werror-style CI settings.
+        -Wno-experimental
+        )
+endif ()
 
 # Pthread pool options only apply to the threaded build (-pthread). In the
 # single-threaded build (WASM_THREADS=OFF) there is no pool, so omit them.


### PR DESCRIPTION
Stacked on #106 (base is `wasm-datalake`; will retarget to `main` once that merges).

## What

Splits the wasm bundle with Emscripten `-sSPLIT_MODULE` + Binaryen `wasm-split` into a **primary** module holding the profile-hot functions (downloaded up front) and a **deferred** module (`chdb.deferred.wasm`) fetched lazily on the first call into a cold function. No functionality is lost — a query touching cold code stalls once for the download (then HTTP-cached).

| bundle | before | primary (up-front) | deferred (lazy) | gzip transfer |
| --- | --- | --- | --- | --- |
| mt | 99.3MB | **40.8MB** | 64.2MB | 21.2MB → **8.9MB** |
| st | 99.2MB | **38.3MB** | 66.4MB | → 8.3MB |

## How

- `-DWASM_SPLIT_MODULE=ON` (link-only option, default OFF, shipped bundles unchanged unless the split pipeline runs)
- `packages/chdb-wasm/tools/split/`: profiling corpus (`profile-corpus.sql`, ~400 statements covering operators/joins/window, scalar+aggregate function families, table functions incl. Iceberg/Delta/DataLakeCatalog, formats, DDL/DML, error paths), profile runner, glue patches, split orchestrator, verifier — runbook in the README there
- The st bundle's single instance sees the whole pipeline execute inline, so its hot set transfers onto the mt split (mt pool workers park in `Atomics.wait` and are invisible to profiling); worker-only thread-entry code is force-kept by pattern

## Verification

- `verify-split` 4/4 on both bundles: hot query / cold query lazy-loads / hot path self-contained without the deferred module / negative control
- Full test matrix on the split artifacts: smoke, matrix, iceberg-local, datalake (moto+REST catalog), datalake-unity — mt+st, 9/9

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split chdb.wasm into a hot primary and a lazily-loaded deferred module
> - Adds a `WASM_SPLIT_MODULE` CMake option that links `chdb_wasm` with `-sSPLIT_MODULE` and `--profiling-funcs` to produce an instrumented artifact suitable for Binaryen `wasm-split` post-processing.
> - Introduces a profiling pipeline ([run-profile.mjs](https://github.com/chdb-io/chdb-core/pull/121/files#diff-5b309f42f6a90a418dcde4cc677051ba91111bb02b5bf72b786600a8c475bf4c)) that executes a broad SQL corpus ([profile-corpus.sql](https://github.com/chdb-io/chdb-core/pull/121/files#diff-8f437620bd13da9a5b910a18cf66a0b0b49be5f81673ca5c1392f93f7c5dd589)) against the instrumented bundle, collecting per-instance Binaryen profiles for both main and worker threads.
> - Adds [split-wasm.mjs](https://github.com/chdb-io/chdb-core/pull/121/files#diff-72e5bc6a9527f632ea065fdcd0000c74b2ed4e8b84091a0db2df36adc3bc96ba), an end-to-end CLI pipeline that merges profiles, constructs a keep-list, invokes `wasm-split` to emit `chdb.wasm` (primary) and `chdb.deferred.wasm` (deferred), and patches Emscripten glue via [patch-glue.mjs](https://github.com/chdb-io/chdb-core/pull/121/files#diff-15819089bd4a539f7e8ec392614c15aa5fc7d38c636a015a075a0f58f1f97990) for lazy deferred loading.
> - Extends CI ([wasm.yml](https://github.com/chdb-io/chdb-core/pull/121/files#diff-7985cab97a05bfe5fc9e7b10f0a11e6889e2eddf3f937bb16f85e14409e3b35e)) to run the full split pipeline for both mt and st builds, execute split bundle tests, and upload split artifacts; also adds manual `workflow_dispatch` publishing.
> - Adds [split.test.mjs](https://github.com/chdb-io/chdb-core/pull/121/files#diff-4bb6bfd731de8fd42784e5c7553ca77e34acb9575fd22a467941b08a4404be00) to validate artifact shape, hot-path correctness, cold-path lazy loading, and negative controls (deferred module absent).
> - Risk: `copy-artifacts.mjs` now aborts when an instrumented build tree (`chdb.wasm.orig` present) is detected, requiring use of the split-wasm output directory instead.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #121 opened
>
> - Modified `patch-glue.mjs` to discover and validate exactly one placeholder `WebAssembly.Table` for redispatch in lazy-load mode, wrapped profiling message handler in try/catch to always reply with length or -1 on error, and prevented unnecessary file writes when no modifications were made [1bca434]
> - Implemented per-worker profile buffer allocation in `run-profile.mjs` with distinct memory slots and tag-based validation to prevent data races when collecting profiles from worker threads [1bca434]
> - Added process lifecycle management to `run-profile.mjs` including cleanup handlers registered before child process startup, signal handling for SIGKILL of spawned children, stdin pipe for `fixture-host` parent-death detection, and conditional `{HTTP}` URL substitution only when `INIT_PROBE` is false [1bca434]
> - Refactored `split.test.mjs` to fail explicitly when split bundle directories are missing required artifacts, centralized temporary file creation under a single root directory with cleanup on exit, and changed cold-path tests to operate on temporary copies instead of mutating the real bundle directory [1bca434]
> - Updated `copy-artifacts.mjs` to delete stale `chdb.deferred.wasm` files from the destination directory when the source build directory does not contain a deferred artifact [1bca434]
> - Modified `fixture-host.mjs` to use `pathToFileURL` for ESM imports of mock catalog modules for Windows compatibility and implemented parent process death detection by monitoring stdin stream close events [1bca434]
> - Replaced process 'exit' event handling with 'close' event handling and added 'error' event listener in the `split-wasm.mjs` tool [c8bbb2c]
> - Added explicit error handling for child process spawn failures and null exit statuses [1b663a9]
> - Replaced homedir-based wasm-split path resolution with EMSDK-based resolution and added existence validation [1b663a9]
> - Added proactive validation for profiles directory existence before attempting to read profiles [1b663a9]
> - Modified SQL corpus queries by changing join algorithm configuration, removing multiple aggregate and statistical functions, adjusting file glob patterns, and relocating certain statistical tests [1b663a9]
> - Added cleanup of existing `*.data` profile files before profiling runs in the `split-wasm.mjs` tool [3680954]
> - Refactored temporary directory management in the `verify-split.mjs` tool to use a shared root directory with cleanup [3680954]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b6b6ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->