### PR TITLE
Temporarily disable PyPI publishing of free-threading wheels

### DIFF
--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -160,20 +160,21 @@ jobs:
           name: chdb-ft-linux-x86_64
           path: ft_dist/*.whl
           overwrite: true
-      - name: Upload FT wheels to pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
-        run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          eval "$(pyenv init -)"
-          ft_full=$(pyenv versions --bare | grep 't$' | head -1)
-          if [ -z "$ft_full" ]; then
-            echo "ERROR: no free-threading Python found in pyenv (expected one ending in 't')" >&2
-            exit 1
-          fi
-          export PYENV_VERSION=$ft_full
-          python -m pip install twine
-          python -m twine upload ft_dist/*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # NOTE: Free-threading wheels PyPI publishing temporarily disabled; uncomment to re-enable.
+      # - name: Upload FT wheels to pypi
+      #   if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+      #   run: |
+      #     export PATH="$HOME/.pyenv/bin:$PATH"
+      #     eval "$(pyenv init -)"
+      #     ft_full=$(pyenv versions --bare | grep 't$' | head -1)
+      #     if [ -z "$ft_full" ]; then
+      #       echo "ERROR: no free-threading Python found in pyenv (expected one ending in 't')" >&2
+      #       exit 1
+      #     fi
+      #     export PYENV_VERSION=$ft_full
+      #     python -m pip install twine
+      #     python -m twine upload ft_dist/*.whl
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 


### PR DESCRIPTION
Comments out the PyPI upload step for **free-threading wheels** in `build_ft_wheels.yml`, so a tagged release no longer publishes FT wheels to PyPI.

Everything else is unchanged:
- FT wheels are still built and tested on every PR / release,
- CI artifacts still include the FT wheels,
- GitHub Release asset uploads are untouched.

The step is kept in place as a comment (with a NOTE line) so re-enabling is a one-line uncomment.

Split out of #102 (the FT part of that PR is superseded by this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable PyPI publishing step for free-threading wheels
> Comments out the 'Upload FT wheels to pypi' step in [build_ft_wheels.yml](.github/workflows/build_ft_wheels.yml) so free-threading wheels are no longer published to PyPI on tag builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23305d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->