### PR TITLE
docs: fix stale single-connection claims in connect() docstring

### DIFF
--- a/chdb/build/cpp-example/chdb_example.cpp
+++ b/chdb/build/cpp-example/chdb_example.cpp
@@ -30,8 +30,10 @@ int main(void) {
     //     - "mode=ro" would be "--readonly=1" for clickhouse (read-only mode)
 
     // Important:
-    //     - There can be only one session at a time. If you want to create a new session, you need to close the existing one.
-    //     - Creating a new session will close the existing one.
+    //     - A process hosts one embedded engine bound to one database path. Multiple connections
+    //       to that path can be open at the same time; each connection is independent.
+    //     - Connecting with a different path while other connections are open fails; close all
+    //       existing connections first.
     const char *argv[] = {
         "chdb_example",      // Program name
         // "--path=chdb_example"

--- a/chdb/session/state.py
+++ b/chdb/session/state.py
@@ -72,9 +72,9 @@ class Session:
     def close(self):
         """Close the session and cleanup resources.
 
-        This method closes the underlying connection and resets the global session state.
-        After calling this method, the session becomes invalid and cannot be used for
-        further queries.
+        This method closes the underlying connection. After calling this method,
+        the session becomes invalid and cannot be used for further queries. Other
+        open sessions are not affected.
 
         .. note::
             This method is automatically called when the session is used as a context manager

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -1427,8 +1427,10 @@ def connect(connection_string: str = ":memory:") -> Connection:
     """Create a connection to chDB background server.
 
     This function establishes a connection to the chDB (ClickHouse) database engine.
-    Only one open connection is allowed per process. Multiple calls with the same
-    connection string will return the same connection object.
+    Each call returns an independent connection object, and any number of connections
+    to the same database path may be open at the same time. Session state (such as
+    the current database selected with ``USE`` and settings applied with ``SET``)
+    is kept per connection and does not affect other connections.
 
     Args:
         connection_string (str, optional): Database connection string. Defaults to ":memory:".
@@ -1475,11 +1477,22 @@ def connect(connection_string: str = ":memory:") -> Connection:
         - Context manager protocol for automatic cleanup
 
     Raises:
-        RuntimeError: If connection to database fails
+        RuntimeError: If connection to database fails, or if a different database
+            path is requested while connections to another path are still open
+
+    .. note::
+        A process hosts a single embedded engine bound to a single database path.
+        Any number of connections to that path may coexist; ``close()`` releases
+        only its own connection, and the engine shuts down when the last open
+        connection is closed. To open a different database path, close all
+        existing connections first — otherwise ``connect()`` raises RuntimeError.
 
     .. warning::
-        Only one connection per process is supported. Creating a new connection
-        will close any existing connection.
+        Concurrent queries from different connections (or threads) are safe and
+        run in parallel. However, while a streaming query started with
+        :meth:`Connection.send_query` is still open on a connection, issuing
+        another query on that same connection returns an empty result. Serialize
+        queries per connection, or use separate connections.
 
     Examples:
         >>> # In-memory database

--- a/docs/session.rst
+++ b/docs/session.rst
@@ -330,8 +330,8 @@ Best Practices
 5. **Connection Strings**: Use connection string parameters for configuration
 
 .. note::
-   - Only one session can be active at a time per process
-   - Creating a new session will automatically close any existing session
+   - Multiple sessions on the same database path can be open at the same time; each session keeps its own state (current database, settings)
+   - A process hosts one embedded engine bound to one database path; opening a session on a different path requires closing all existing sessions first
    - Temporary sessions are automatically cleaned up when the session object is destroyed
    - File-based sessions persist data across Python interpreter restarts
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -196,23 +196,26 @@ If you encounter file access errors:
 Connection and Session Issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Session Already Exists Error**
+**Engine Already Initialized With a Different Path**
 
 .. code-block:: text
 
-   Session already exists
+   EmbeddedServer already initialized with path '...', cannot connect with different path '...'
 
-**Solution**: Only one session can be active at a time per process:
+**Solution**: A process hosts one embedded engine bound to one database path.
+Multiple sessions on the same path can be open at the same time, but opening a
+session on a different path requires closing all existing sessions and
+connections first:
 
 .. code-block:: python
 
    from chdb import session as chs
-   
-   # Close existing session before creating new one
+
+   # Close sessions on the old path before opening a different path
    if 'sess' in locals():
        sess.close()
-   
-   sess = chs.Session()
+
+   sess = chs.Session("/path/to/other.db")
 
 **DB-API Connection Issues**
 
@@ -490,8 +493,8 @@ When reporting errors, please include:
 Common Error Messages
 ---------------------
 
-**"Session already exists"**
-Only one session can be active per process. Close existing sessions before creating new ones.
+**"EmbeddedServer already initialized with path ..."**
+A process hosts one embedded engine bound to one database path. Sessions and connections on the same path can coexist; close all of them before opening a different path.
 
 **"Memory limit exceeded"**  
 Use streaming queries, file-based sessions, or process data in smaller batches.


### PR DESCRIPTION
The `connect()` docstring still describes the pre-4.0 global-singleton connection model: "Only one open connection is allowed per process", "multiple calls with the same connection string will return the same connection object", and a warning that creating a new connection closes the existing one. None of this has been true since the 4.0.0 EmbeddedServer refactor (688831c7f6f, first shipped in v4.0.0b1).

Current semantics, verified on published 4.1.7 and 4.2.1:

- A process hosts one engine bound to one data path; any number of independent connection handles may be open to it at once.
- `connect()` with a different path while any handle is open raises `RuntimeError` (BAD_ARGUMENTS); after the last handle closes, a different path can be opened.
- Session state (`USE`, `SET`) is per handle; handles are isolated from each other.
- `close()` releases only its own handle.
- Concurrent queries across handles are safe and run in parallel.
- One caveat: while a streaming query is open on a handle, another query on that same handle returns an empty result — serialize per handle or use separate handles.

Docs-only change: `connect()` docstring, `Session.close()` docstring, `docs/session.rst`, `docs/troubleshooting.rst` (the "Session already exists" error text no longer exists in the code; replaced with the actual 4.x message), and one stale comment in the cpp example. No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale single-connection claims in `connect()` docstring and related docs
> Updates documentation to reflect that multiple independent connections to the same database path can coexist, replacing incorrect claims that only one connection is allowed at a time.
>
> - Revises the `connect()` docstring in [sqlitelike.py](https://github.com/chdb-io/chdb-core/pull/130/files#diff-7bacb6b9f4713eb0ee855a9d1339406969f1dab6f568b7840351036612702611) to clarify that each call returns an independent connection, documents the error raised when connecting to a different path while other connections are open, and adds notes on engine lifecycle and concurrent queries.
> - Updates the `Session.close` docstring in [state.py](https://github.com/chdb-io/chdb-core/pull/130/files#diff-4479f56c76e60ce8fc755761973b8259df8b96c178db0f9ecf872252fbd8d094) to clarify that closing a session only affects its own connection, not other open sessions.
> - Replaces the 'Session Already Exists Error' section in [troubleshooting.rst](https://github.com/chdb-io/chdb-core/pull/130/files#diff-a7c720c9cc5fa1b93c92c33e3e75a0b0880d80915d867d57d48464ff4f472b0a) with guidance on the 'Engine Already Initialized With a Different Path' error.
> - Updates [session.rst](https://github.com/chdb-io/chdb-core/pull/130/files#diff-c4fa24be2f521771ecb62f883a068658babd4f5027a29baf3b5fb0625957a134) best practices to reflect concurrent session support and the one-engine-per-path-per-process constraint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3a2284.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->