### PR TITLE
Add ADBC driver support: export chdb_adbc_init from libchdb

### DIFF
--- a/.github/scripts/build_and_test_ft_linux.sh
+++ b/.github/scripts/build_and_test_ft_linux.sh
@@ -54,7 +54,7 @@ for ft_version in $FT_VERSIONS; do
     if [ -n "$ft_full" ]; then
         echo "Installing deps for Python $ft_full"
         PYENV_VERSION=$ft_full python -m pip install --upgrade pip
-        PYENV_VERSION=$ft_full python -m pip install setuptools wheel tox pandas pyarrow psutil
+        PYENV_VERSION=$ft_full python -m pip install setuptools wheel tox pandas pyarrow psutil adbc-driver-manager==1.8.0
     fi
 done
 

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -387,6 +387,8 @@ jobs:
               # (parquet::ParquetStatusException: Index not in dictionary bounds)
               # when loaded alongside chdb; x86_64 is unaffected. Pin until fixed.
               python -m pip install dist/*.whl "$PANDAS_CONSTRAINT" "pyarrow<25" --force-reinstall
+              # ADBC driver tests (tests/test_adbc_driver.py) load libchdb via the standard driver manager
+              python -c "import adbc_driver_manager" 2>/dev/null || python -m pip install -q adbc-driver-manager==1.8.0
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
               python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -368,6 +368,8 @@ jobs:
               echo "=============================================="
               pyenv shell $version
               python -m pip install dist/*.whl "$PANDAS_CONSTRAINT" --force-reinstall
+              # ADBC driver tests (tests/test_adbc_driver.py) load libchdb via the standard driver manager
+              python -c "import adbc_driver_manager" 2>/dev/null || python -m pip install -q adbc-driver-manager==1.8.0
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
               python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -392,6 +392,8 @@ jobs:
               echo "=============================================="
               pyenv shell $version
               python -m pip install dist/*.whl "$PANDAS_CONSTRAINT" --force-reinstall --no-cache-dir
+              # ADBC driver tests (tests/test_adbc_driver.py) load libchdb via the standard driver manager
+              python -c "import adbc_driver_manager" 2>/dev/null || python -m pip install -q adbc-driver-manager==1.8.0
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
               python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -393,6 +393,8 @@ jobs:
               echo "=============================================="
               pyenv shell $version
               python -m pip install dist/*.whl "$PANDAS_CONSTRAINT" --force-reinstall
+              # ADBC driver tests (tests/test_adbc_driver.py) load libchdb via the standard driver manager
+              python -c "import adbc_driver_manager" 2>/dev/null || python -m pip install -q adbc-driver-manager==1.8.0
               echo "Installed pandas version:"
               python -c "import pandas; print(pandas.__version__)"
               python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"

--- a/bindings.md
+++ b/bindings.md
@@ -29,6 +29,24 @@ chDB exposes four main capabilities through its C API ([`chdb.h`](programs/local
 | **PHP** | | | | | _Contributors Needed_ |
 | **R** | | | | | _Contributors Needed_ |
 
+### ADBC
+
+libchdb also exports an [ADBC](https://arrow.apache.org/adbc/) driver
+entrypoint (`chdb_adbc_init`), so any language with an ADBC driver manager
+(Python, Go, R, Ruby, Rust, C#, GLib) can use chDB through the standard ADBC
+API — streamed Arrow results, qmark parameters, bulk ingestion and catalog
+metadata — without a dedicated binding:
+
+```
+driver     = /path/to/libchdb.so
+entrypoint = chdb_adbc_init
+```
+
+For languages without a binding above, ADBC is the recommended path for
+standard database access; per-language bindings remain the home for
+chDB-specific features. See `examples/chdbAdbcTest.c` for the raw C-ABI
+contract and `tests/test_adbc_driver.py` for end-to-end usage.
+
 > **Legend:** ✅ Supported  |  Blank = not yet implemented
 
 ### chDB stable ABI

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -60,7 +60,13 @@
         chdb_query_arrow_n;
         chdb_stream_query_arrow;
         chdb_stream_query_arrow_n;
+        chdb_stream_query_arrow_with_params;
+        chdb_stream_query_arrow_with_params_n;
         chdb_stream_fetch_arrow;
+
+        /* ADBC driver entrypoint */
+        chdb_adbc_init;
+        AdbcDriverInit;
 
         /* Signal Handler Control */
         chdb_set_signal_handlers_enabled;

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -54,7 +54,11 @@ _chdb_query_arrow
 _chdb_query_arrow_n
 _chdb_stream_query_arrow
 _chdb_stream_query_arrow_n
+_chdb_stream_query_arrow_with_params
+_chdb_stream_query_arrow_with_params_n
 _chdb_stream_fetch_arrow
+_chdb_adbc_init
+_AdbcDriverInit
 
 _chdb_set_signal_handlers_enabled
 _chdb_reset_signal_handlers

--- a/chdb/pychdb_export.map
+++ b/chdb/pychdb_export.map
@@ -2,6 +2,10 @@
     global:
         PyInit__chdb;
 
+        /* ADBC driver entrypoint — the Python module doubles as the driver */
+        chdb_adbc_init;
+        AdbcDriverInit;
+
         /* C++ operator new/delete (mangled names) */
         _Znwm;              /* operator new(size_t) */
         _Znam;              /* operator new[](size_t) */

--- a/chdb/pychdb_export_macos.txt
+++ b/chdb/pychdb_export_macos.txt
@@ -1,1 +1,3 @@
 _PyInit__chdb
+_chdb_adbc_init
+_AdbcDriverInit

--- a/examples/chdbAdbcTest.c
+++ b/examples/chdbAdbcTest.c
@@ -1,0 +1,168 @@
+/**
+ * Drives the ADBC driver the way non-Python driver managers do: dlopen +
+ * chdb_adbc_init + the AdbcDriver function table — the C-ABI contract every
+ * language binding sits on.
+ *
+ *   clang -O2 -I./programs/local examples/chdbAdbcTest.c -ldl -o examples/chdbAdbcTest
+ *   ./examples/chdbAdbcTest ./libchdb.so
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "adbc/adbc.h"
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                              \
+    do {                                                              \
+        if (!(cond)) {                                                \
+            fprintf(stderr, "  FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+            failures += 1;                                            \
+        }                                                             \
+    } while (0)
+
+static void print_adbc_error(const char * where, struct AdbcError * err)
+{
+    fprintf(stderr, "  %s: %s\n", where, err->message ? err->message : "(no message)");
+    if (err->release)
+        err->release(err);
+    memset(err, 0, sizeof(*err));
+}
+
+int main(int argc, char ** argv)
+{
+    const char * lib_path = argc > 1 ? argv[1] : "./libchdb.so";
+
+    void * handle = dlopen(lib_path, RTLD_LOCAL | RTLD_NOW);
+    if (!handle) {
+        fprintf(stderr, "dlopen(%s) failed: %s\n", lib_path, dlerror());
+        return 2;
+    }
+
+    typedef AdbcStatusCode (*InitFunc)(int, void *, struct AdbcError *);
+    InitFunc init = (InitFunc)dlsym(handle, "chdb_adbc_init");
+    if (!init) {
+        fprintf(stderr, "chdb_adbc_init not exported by %s\n", lib_path);
+        return 2;
+    }
+
+    struct AdbcError error;
+    memset(&error, 0, sizeof(error));
+    struct AdbcDriver driver;
+    memset(&driver, 0, sizeof(driver));
+
+    CHECK(init(ADBC_VERSION_1_1_0, &driver, &error) == ADBC_STATUS_OK, "driver init (1.1.0)");
+
+    /* Database + Connection */
+    struct AdbcDatabase database;
+    memset(&database, 0, sizeof(database));
+    CHECK(driver.DatabaseNew(&database, &error) == ADBC_STATUS_OK, "DatabaseNew");
+    CHECK(driver.DatabaseSetOption(&database, "path", ":memory:", &error) == ADBC_STATUS_OK, "SetOption(path)");
+    CHECK(driver.DatabaseInit(&database, &error) == ADBC_STATUS_OK, "DatabaseInit");
+
+    struct AdbcConnection connection;
+    memset(&connection, 0, sizeof(connection));
+    CHECK(driver.ConnectionNew(&connection, &error) == ADBC_STATUS_OK, "ConnectionNew");
+    CHECK(driver.ConnectionInit(&connection, &database, &error) == ADBC_STATUS_OK, "ConnectionInit");
+
+    /* Plain streamed query */
+    {
+        struct AdbcStatement stmt;
+        memset(&stmt, 0, sizeof(stmt));
+        CHECK(driver.StatementNew(&connection, &stmt, &error) == ADBC_STATUS_OK, "StatementNew");
+        CHECK(driver.StatementSetSqlQuery(&stmt, "SELECT number FROM numbers(200000)", &error)
+                  == ADBC_STATUS_OK,
+              "SetSqlQuery");
+
+        struct ArrowArrayStream stream;
+        memset(&stream, 0, sizeof(stream));
+        int64_t rows_affected = 0;
+        AdbcStatusCode st = driver.StatementExecuteQuery(&stmt, &stream, &rows_affected, &error);
+        if (st != ADBC_STATUS_OK)
+            print_adbc_error("ExecuteQuery", &error);
+        CHECK(st == ADBC_STATUS_OK, "ExecuteQuery");
+
+        struct ArrowSchema schema;
+        memset(&schema, 0, sizeof(schema));
+        CHECK(stream.get_schema(&stream, &schema) == 0, "stream.get_schema");
+        CHECK(schema.n_children == 1, "one result column");
+        if (schema.release)
+            schema.release(&schema);
+
+        long long total = 0;
+        int batches = 0;
+        for (;;) {
+            struct ArrowArray array;
+            memset(&array, 0, sizeof(array));
+            if (stream.get_next(&stream, &array) != 0) {
+                CHECK(0, "stream.get_next");
+                break;
+            }
+            if (!array.release)
+                break; /* end of stream */
+            total += array.length;
+            batches += 1;
+            array.release(&array);
+        }
+        stream.release(&stream);
+        printf("streamed query: %lld rows in %d batches\n", total, batches);
+        CHECK(total == 200000, "row count");
+        CHECK(batches > 1, "arrived in multiple batches");
+
+        CHECK(driver.StatementRelease(&stmt, &error) == ADBC_STATUS_OK, "StatementRelease");
+    }
+
+    /* GetTableTypes through the metadata path */
+    {
+        struct ArrowArrayStream stream;
+        memset(&stream, 0, sizeof(stream));
+        CHECK(driver.ConnectionGetTableTypes(&connection, &stream, &error) == ADBC_STATUS_OK,
+              "GetTableTypes");
+        struct ArrowArray array;
+        memset(&array, 0, sizeof(array));
+        CHECK(stream.get_next(&stream, &array) == 0 && array.release, "table types batch");
+        CHECK(array.length == 2, "BASE TABLE + VIEW");
+        if (array.release)
+            array.release(&array);
+        stream.release(&stream);
+    }
+
+    /* DDL through ExecuteQuery (no result set -> empty zero-column stream) */
+    {
+        struct AdbcStatement stmt;
+        memset(&stmt, 0, sizeof(stmt));
+        CHECK(driver.StatementNew(&connection, &stmt, &error) == ADBC_STATUS_OK, "StatementNew(ddl)");
+        CHECK(driver.StatementSetSqlQuery(
+                  &stmt, "CREATE TABLE cabi_t (x Int64) ENGINE = MergeTree() ORDER BY x", &error)
+                  == ADBC_STATUS_OK,
+              "SetSqlQuery(ddl)");
+        struct ArrowArrayStream stream;
+        memset(&stream, 0, sizeof(stream));
+        AdbcStatusCode st = driver.StatementExecuteQuery(&stmt, &stream, NULL, &error);
+        if (st != ADBC_STATUS_OK)
+            print_adbc_error("ExecuteQuery(ddl)", &error);
+        CHECK(st == ADBC_STATUS_OK, "ExecuteQuery(ddl)");
+        struct ArrowSchema schema;
+        memset(&schema, 0, sizeof(schema));
+        CHECK(stream.get_schema(&stream, &schema) == 0 && schema.n_children == 0,
+              "DDL yields zero-column schema");
+        if (schema.release)
+            schema.release(&schema);
+        stream.release(&stream);
+        CHECK(driver.StatementRelease(&stmt, &error) == ADBC_STATUS_OK, "StatementRelease(ddl)");
+    }
+
+    CHECK(driver.ConnectionRelease(&connection, &error) == ADBC_STATUS_OK, "ConnectionRelease");
+    CHECK(driver.DatabaseRelease(&database, &error) == ADBC_STATUS_OK, "DatabaseRelease");
+    CHECK(driver.release(&driver, &error) == ADBC_STATUS_OK, "driver release");
+
+    if (failures) {
+        printf("FAILED: %d assertion(s)\n", failures);
+        return 1;
+    }
+    printf("all C-ABI checks passed\n");
+    return 0;
+}

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -23,16 +23,18 @@ else()
         ChdbClient.cpp
     )
 
-    if (NOT USE_PYTHON)
-        set (CHDB_ARROW_SOURCES
-            chdb-arrow.cpp
-            chdb-arrow-output.cpp
-            ArrowStreamSource.cpp
-            StorageArrowStream.cpp
-            TableFunctionArrowStream.cpp
-        )
-        set (CLICKHOUSE_LOCAL_SOURCES ${CLICKHOUSE_LOCAL_SOURCES} ${CHDB_ARROW_SOURCES})
-    endif()
+    # Arrow C Data Interface API + ADBC driver, compiled into both libchdb
+    # and the Python module (chdb_adbc_init is allowlisted in pychdb_export*)
+    # so the wheel doubles as the ADBC driver.
+    set (CHDB_ARROW_SOURCES
+        chdb-arrow.cpp
+        chdb-arrow-output.cpp
+        chdb-adbc.cpp
+        ArrowStreamSource.cpp
+        StorageArrowStream.cpp
+        TableFunctionArrowStream.cpp
+    )
+    set (CLICKHOUSE_LOCAL_SOURCES ${CLICKHOUSE_LOCAL_SOURCES} ${CHDB_ARROW_SOURCES})
 endif()
 
 # Add force function references only for static library builds

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -345,7 +345,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
 
 CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
     const char * query, size_t query_len,
-    const char * format, size_t format_len)
+    const char * format, size_t format_len, bool dataframe_over_chunks)
 {
     std::lock_guard<std::mutex> lock(client_mutex);
 
@@ -367,6 +367,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
             return std::make_unique<CHDB::StreamQueryResult>(getErrorMsg());
         }
         streaming_query_context->thread_group = DB::CurrentThread::getGroup();
+        streaming_query_context->dataframe_over_chunks = dataframe_over_chunks;
         auto result = std::make_unique<CHDB::StreamQueryResult>();
         streaming_query_context->streaming_result = result.get();
         return result;
@@ -437,15 +438,20 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
                     bytes_written - old_bytes_written);
 
 #if USE_PYTHON
-                py::gil_scoped_acquire acquire;
-                CHDB::PandasDataFrameBuilder builder(*chunk_result);
-                py::handle df = builder.getDataFrame().release();
+                if (streaming_query_context->dataframe_over_chunks)
+                {
+                    py::gil_scoped_acquire acquire;
+                    CHDB::PandasDataFrameBuilder builder(*chunk_result);
+                    py::handle df = builder.getDataFrame().release();
 
-                res = std::make_unique<CHDB::DataFrameQueryResult>(df, rows_read);
+                    res = std::make_unique<CHDB::DataFrameQueryResult>(df, rows_read);
+                }
+                else
+                {
+                    /// Arrow C Data / ADBC consumers want raw chunks.
+                    res = std::move(chunk_result);
+                }
 #else
-                /// Non-Python build: hand raw chunks back so the Arrow C
-                /// Data Interface output path can export them without
-                /// IPC serialization.
                 res = std::move(chunk_result);
 #endif
             }

--- a/programs/local/ChdbClient.h
+++ b/programs/local/ChdbClient.h
@@ -33,7 +33,11 @@ public:
 
     CHDB::QueryResultPtr executeMaterializedQuery(const char * query, size_t query_len, const char * format, size_t format_len);
 
-    CHDB::QueryResultPtr executeStreamingInit(const char * query, size_t query_len, const char * format, size_t format_len);
+    /// dataframe_over_chunks: what streaming iterate returns for chunk-collect
+    /// queries in Python builds — a pandas DataFrame (Python send_query) or
+    /// raw chunks (Arrow C Data / ADBC).
+    CHDB::QueryResultPtr executeStreamingInit(
+        const char * query, size_t query_len, const char * format, size_t format_len, bool dataframe_over_chunks = true);
 
     CHDB::QueryResultPtr executeStreamingIterate(void * streaming_result, bool is_canceled = false);
 

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -3,12 +3,14 @@
 #include "ChunkCollectorOutputFormat.h"
 #if USE_PYTHON
 #include "TableFunctionPython.h"
-#elif !defined(OS_WASM)
+#endif
+#if !defined(OS_WASM)
 #include "StorageArrowStream.h"
 #include "TableFunctionArrowStream.h"
 #endif
 #include <Formats/FormatFactory.h>
 #include <TableFunctions/TableFunctionFactory.h>
+#include <Storages/StorageFactory.h>
 
 #include <filesystem>
 #include <Access/AccessControl.h>
@@ -622,14 +624,16 @@ try
             auto & table_function_factory = TableFunctionFactory::instance();
 #if USE_PYTHON
             registerTableFunctionPython(table_function_factory);
-#elif !defined(OS_WASM)
+#endif
+#if !defined(OS_WASM)
+            /// Also in Python builds: the ADBC driver's ingest path uses it.
             registerTableFunctionArrowStream(table_function_factory);
 #endif
 
             registerDatabases();
             registerStorages();
             CHDB::registerDataFrameOutputFormat();
-#if !USE_PYTHON && !defined(OS_WASM)
+#if !defined(OS_WASM)
             auto & storage_factory = StorageFactory::instance();
             registerStorageArrowStream(storage_factory);
 #endif

--- a/programs/local/QueryResult.h
+++ b/programs/local/QueryResult.h
@@ -56,6 +56,10 @@ public:
         return false;
     }
 
+    /// Records iterate-time failures (e.g. unknown table caught at
+    /// execution) so chdb_result_error() can surface the engine message.
+    void setError(String message) { error_message = std::move(message); }
+
     /// Opaque per-stream state slot used by streaming-output binding code
     /// (currently the Arrow C Data Interface output path) to persist a
     /// converter, schema, and dictionary cache across fetches. The shared

--- a/programs/local/adbc/README.md
+++ b/programs/local/adbc/README.md
@@ -1,0 +1,12 @@
+# Vendored ADBC header
+
+`adbc.h` is vendored verbatim from Apache Arrow ADBC:
+
+- Source: https://github.com/apache/arrow-adbc/blob/apache-arrow-adbc-23/c/include/arrow-adbc/adbc.h
+- Tag: `apache-arrow-adbc-23`
+- License: Apache-2.0 (header retained in the file)
+
+It is the single-file, dependency-free C definition of the ADBC API
+(struct AdbcDriver, status codes, option constants) implemented by
+`../chdb-adbc.cpp`. To upgrade, replace the file with a newer tag's copy
+and update this note.

--- a/programs/local/adbc/adbc.h
+++ b/programs/local/adbc/adbc.h
@@ -1,0 +1,2413 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// \file arrow-adbc/adbc.h ADBC: Arrow Database connectivity
+///
+/// An Arrow-based interface between applications and database
+/// drivers.  ADBC aims to provide a vendor-independent API for SQL
+/// and Substrait-based database access that is targeted at
+/// analytics/OLAP use cases.
+///
+/// This API is intended to be implemented directly by drivers and
+/// used directly by client applications.  To assist portability
+/// between different vendors, a "driver manager" library is also
+/// provided, which implements this same API, but dynamically loads
+/// drivers internally and forwards calls appropriately.
+///
+/// ADBC uses structs with free functions that operate on those
+/// structs to model objects.
+///
+/// In general, objects allow serialized access from multiple threads,
+/// but not concurrent access.  Specific implementations may permit
+/// multiple threads.
+///
+/// \version 1.1.0
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/// \defgroup Arrow C Data Interface
+/// Definitions for the C Data Interface/C Stream Interface.
+///
+/// See https://arrow.apache.org/docs/format/CDataInterface.html
+///
+/// @{
+
+//! @cond Doxygen_Suppress
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Extra guard for versions of Arrow without the canonical guard
+#ifndef ARROW_FLAG_DICTIONARY_ORDERED
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
+
+struct ArrowArrayStream {
+  // Callback to get the stream type
+  // (will be the same for all arrays in the stream).
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowSchema must be released independently from the stream.
+  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
+
+  // Callback to get the next array
+  // (if no error and the array is released, the stream has ended)
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowArray must be released independently from the stream.
+  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
+
+  // Callback to get optional detailed error information.
+  // This must only be called if the last stream operation failed
+  // with a non-0 return code.
+  //
+  // Return value: pointer to a null-terminated character array describing
+  // the last error, or NULL if no description is available.
+  //
+  // The returned pointer is only valid until the next operation on this stream
+  // (including release).
+  const char* (*get_last_error)(struct ArrowArrayStream*);
+
+  // Release callback: release the stream's own resources.
+  // Note that arrays returned by `get_next` must be individually released.
+  void (*release)(struct ArrowArrayStream*);
+
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_STREAM_INTERFACE
+#endif  // ARROW_FLAG_DICTIONARY_ORDERED
+
+//! @endcond
+
+/// @}
+
+#ifndef ADBC
+#define ADBC
+
+// Storage class macros for Windows
+// Allow overriding/aliasing with application-defined macros
+#if !defined(ADBC_EXPORT)
+#if defined(_WIN32)
+#if defined(ADBC_EXPORTING)
+#define ADBC_EXPORT __declspec(dllexport)
+#else
+#define ADBC_EXPORT __declspec(dllimport)
+#endif  // defined(ADBC_EXPORTING)
+#else
+#define ADBC_EXPORT
+#endif  // defined(_WIN32)
+#endif  // !defined(ADBC_EXPORT)
+
+/// \defgroup adbc-error-handling Error Handling
+/// ADBC uses integer error codes to signal errors. To provide more
+/// detail about errors, functions may also return an AdbcError via an
+/// optional out parameter, which can be inspected. If provided, it is
+/// the responsibility of the caller to zero-initialize the AdbcError
+/// value.
+///
+/// @{
+
+/// \brief Error codes for operations that may fail.
+typedef uint8_t AdbcStatusCode;
+
+/// \brief No error.
+#define ADBC_STATUS_OK 0
+
+/// \brief An unknown error occurred.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_UNKNOWN 1
+
+/// \brief The operation is not implemented or supported.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_NOT_IMPLEMENTED 2
+
+/// \brief A requested resource was not found.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_NOT_FOUND 3
+
+/// \brief A requested resource already exists.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_ALREADY_EXISTS 4
+
+/// \brief The arguments are invalid, likely a programming error.
+///
+/// For instance, they may be of the wrong format, or out of range.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_INVALID_ARGUMENT 5
+
+/// \brief The preconditions for the operation are not met, likely a
+///   programming error.
+///
+/// For instance, the object may be uninitialized, or may have not
+/// been fully configured.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_INVALID_STATE 6
+
+/// \brief Invalid data was processed (not a programming error).
+///
+/// For instance, a division by zero may have occurred during query
+/// execution.
+///
+/// May indicate a database-side error only.
+#define ADBC_STATUS_INVALID_DATA 7
+
+/// \brief The database's integrity was affected.
+///
+/// For instance, a foreign key check may have failed, or a uniqueness
+/// constraint may have been violated.
+///
+/// May indicate a database-side error only.
+#define ADBC_STATUS_INTEGRITY 8
+
+/// \brief An error internal to the driver or database occurred.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_INTERNAL 9
+
+/// \brief An I/O error occurred.
+///
+/// For instance, a remote service may be unavailable.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_IO 10
+
+/// \brief The operation was cancelled, not due to a timeout.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_CANCELLED 11
+
+/// \brief The operation was cancelled due to a timeout.
+///
+/// May indicate a driver-side or database-side error.
+#define ADBC_STATUS_TIMEOUT 12
+
+/// \brief Authentication failed.
+///
+/// May indicate a database-side error only.
+#define ADBC_STATUS_UNAUTHENTICATED 13
+
+/// \brief The client is not authorized to perform the given operation.
+///
+/// May indicate a database-side error only.
+#define ADBC_STATUS_UNAUTHORIZED 14
+
+/// \brief Inform the driver/driver manager that we are using the extended
+///   AdbcError struct from ADBC 1.1.0.
+///
+/// See the AdbcError documentation for usage.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA INT32_MIN
+
+/// \brief A detailed error message for an operation.
+///
+/// The caller must zero-initialize this struct (clarified in ADBC 1.1.0).
+///
+/// The structure was extended in ADBC 1.1.0.  Drivers and clients using ADBC
+/// 1.0.0 will not have the private_data or private_driver fields.  Drivers
+/// should read/write these fields if and only if vendor_code is equal to
+/// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.  Clients are required to initialize
+/// this struct to avoid the possibility of uninitialized values confusing the
+/// driver.
+struct ADBC_EXPORT AdbcError {
+  /// \brief The error message.
+  char* message;
+
+  /// \brief A vendor-specific error code, if applicable.
+  int32_t vendor_code;
+
+  /// \brief A SQLSTATE error code, if provided, as defined by the
+  ///   SQL:2003 standard.  If not set, it should be set to
+  ///   "\0\0\0\0\0".
+  char sqlstate[5];
+
+  /// \brief Release the contained error.
+  ///
+  /// Unlike other structures, this is an embedded callback to make it
+  /// easier for the driver manager and driver to cooperate.
+  void (*release)(struct AdbcError* error);
+
+  /// \brief Opaque implementation-defined state.
+  ///
+  /// This field may not be used unless vendor_code is
+  /// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.  If present, this field is NULLPTR
+  /// iff the error is uninitialized/freed.
+  ///
+  /// \since ADBC API revision 1.1.0
+  void* private_data;
+
+  /// \brief The associated driver (used by the driver manager to help
+  ///   track state).
+  ///
+  /// This field may not be used unless vendor_code is
+  /// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.
+  ///
+  /// \since ADBC API revision 1.1.0
+  struct AdbcDriver* private_driver;
+};
+
+#ifdef __cplusplus
+/// \brief A helper to initialize the full AdbcError structure.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_ERROR_INIT                           \
+  (AdbcError{nullptr,                             \
+             ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA, \
+             {0, 0, 0, 0, 0},                     \
+             nullptr,                             \
+             nullptr,                             \
+             nullptr})
+#else
+/// \brief A helper to initialize the full AdbcError structure.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_ERROR_INIT \
+  ((struct AdbcError){  \
+      NULL, ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA, {0, 0, 0, 0, 0}, NULL, NULL, NULL})
+#endif
+
+/// \brief The size of the AdbcError structure in ADBC 1.0.0.
+///
+/// Drivers written for ADBC 1.1.0 and later should never touch more than this
+/// portion of an AdbcDriver struct when vendor_code is not
+/// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_ERROR_1_0_0_SIZE (offsetof(struct AdbcError, private_data))
+
+/// \brief The size of the AdbcError structure in ADBC 1.1.0.
+///
+/// Drivers written for ADBC 1.1.0 and later should never touch more than this
+/// portion of an AdbcDriver struct when vendor_code is
+/// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_ERROR_1_1_0_SIZE (sizeof(struct AdbcError))
+
+/// \brief Extra key-value metadata for an error.
+///
+/// The fields here are owned by the driver and should not be freed.  The
+/// fields here are invalidated when the release callback in AdbcError is
+/// called.
+///
+/// \since ADBC API revision 1.1.0
+struct ADBC_EXPORT AdbcErrorDetail {
+  /// \brief The metadata key.
+  const char* key;
+  /// \brief The binary metadata value.
+  const uint8_t* value;
+  /// \brief The length of the metadata value.
+  size_t value_length;
+};
+
+/// \brief Get the number of metadata values available in an error.
+///
+/// \since ADBC API revision 1.1.0
+ADBC_EXPORT
+int AdbcErrorGetDetailCount(const struct AdbcError* error);
+
+/// \brief Get a metadata value in an error by index.
+///
+/// If index is invalid, returns an AdbcErrorDetail initialized with NULL/0
+/// fields.
+///
+/// \since ADBC API revision 1.1.0
+ADBC_EXPORT
+struct AdbcErrorDetail AdbcErrorGetDetail(const struct AdbcError* error, int index);
+
+/// \brief Get an ADBC error from an ArrowArrayStream created by a driver.
+///
+/// This allows retrieving error details and other metadata that would
+/// normally be suppressed by the Arrow C Stream Interface.
+///
+/// The caller MUST NOT release the error; it is managed by the release
+/// callback in the stream itself.
+///
+/// \param[in] stream The stream to query.
+/// \param[out] status The ADBC status code, or ADBC_STATUS_OK if there is no
+///   error.  Not written to if the stream does not contain an ADBC error or
+///   if the pointer is NULL.
+/// \return NULL if not supported.
+/// \since ADBC API revision 1.1.0
+ADBC_EXPORT
+const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream,
+                                                 AdbcStatusCode* status);
+
+/// @}
+
+/// \defgroup adbc-constants Constants
+/// @{
+
+/// \brief ADBC revision 1.0.0.
+///
+/// When passed to an AdbcDriverInitFunc(), the driver parameter must
+/// point to an AdbcDriver.
+#define ADBC_VERSION_1_0_0 1000000
+
+/// \brief ADBC revision 1.1.0.
+///
+/// When passed to an AdbcDriverInitFunc(), the driver parameter must
+/// point to an AdbcDriver.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_VERSION_1_1_0 1001000
+
+/// \brief Canonical option value for enabling an option.
+///
+/// For use as the value in SetOption calls.
+#define ADBC_OPTION_VALUE_ENABLED "true"
+
+/// \brief Canonical option value for disabling an option.
+///
+/// For use as the value in SetOption calls.
+#define ADBC_OPTION_VALUE_DISABLED "false"
+
+/// \brief Canonical option name for URIs.
+///
+/// Should be used as the expected option name to specify a URI for
+/// any ADBC driver.
+///
+/// The type is char*.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_OPTION_URI "uri"
+
+/// \brief Canonical option name for usernames.
+///
+/// Should be used as the expected option name to specify a username
+/// to a driver for authentication.
+///
+/// The type is char*.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_OPTION_USERNAME "username"
+
+/// \brief Canonical option name for passwords.
+///
+/// Should be used as the expected option name to specify a password
+/// for authentication to a driver.
+///
+/// The type is char*.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_OPTION_PASSWORD "password"
+
+/// \brief The database vendor/product name (e.g. the server name).
+///   (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_NAME 0
+
+/// \brief The database vendor/product version (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_VERSION 1
+
+/// \brief The database vendor/product Arrow library version (type:
+///   utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_ARROW_VERSION 2
+
+/// \brief Indicates whether SQL queries are supported (type: bool).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_SQL 3
+
+/// \brief Indicates whether Substrait queries are supported (type: bool).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_SUBSTRAIT 4
+
+/// \brief The minimum supported Substrait version, or null if
+///   Substrait is not supported (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_SUBSTRAIT_MIN_VERSION 5
+
+/// \brief The maximum supported Substrait version, or null if
+///   Substrait is not supported (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_VENDOR_SUBSTRAIT_MAX_VERSION 6
+
+/// \brief The driver name (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_DRIVER_NAME 100
+
+/// \brief The driver version (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_DRIVER_VERSION 101
+
+/// \brief The driver Arrow library version (type: utf8).
+///
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_DRIVER_ARROW_VERSION 102
+
+/// \brief The driver ADBC API version (type: int64).
+///
+/// The value should be one of the ADBC_VERSION constants.
+///
+/// \since ADBC API revision 1.1.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_VERSION_1_0_0
+/// \see ADBC_VERSION_1_1_0
+#define ADBC_INFO_DRIVER_ADBC_VERSION 103
+
+/// \brief Return metadata on catalogs, schemas, tables, and columns.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_OBJECT_DEPTH_ALL 0
+
+/// \brief Return metadata on catalogs only.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_OBJECT_DEPTH_CATALOGS 1
+
+/// \brief Return metadata on catalogs and schemas.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_OBJECT_DEPTH_DB_SCHEMAS 2
+
+/// \brief Return metadata on catalogs, schemas, and tables.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_OBJECT_DEPTH_TABLES 3
+
+/// \brief Return metadata on catalogs, schemas, tables, and columns.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_OBJECT_DEPTH_COLUMNS ADBC_OBJECT_DEPTH_ALL
+
+/// \defgroup adbc-table-statistics ADBC Statistic Types
+/// Standard statistic names for AdbcConnectionGetStatistics.
+/// @{
+
+/// \brief The dictionary-encoded name of the average byte width statistic.
+#define ADBC_STATISTIC_AVERAGE_BYTE_WIDTH_KEY 0
+
+/// \brief The average byte width statistic.  The average size in bytes of a
+///   row in the column.  Value type is float64.
+///
+/// For example, this is roughly the average length of a string for a string
+/// column.
+#define ADBC_STATISTIC_AVERAGE_BYTE_WIDTH_NAME "adbc.statistic.byte_width"
+
+/// \brief The dictionary-encoded name of the distinct value count statistic.
+#define ADBC_STATISTIC_DISTINCT_COUNT_KEY 1
+
+/// \brief The distinct value count (NDV) statistic.  The number of distinct
+///   values in the column.  Value type is int64 (when not approximate) or
+///   float64 (when approximate).
+#define ADBC_STATISTIC_DISTINCT_COUNT_NAME "adbc.statistic.distinct_count"
+
+/// \brief The dictionary-encoded name of the max byte width statistic.
+#define ADBC_STATISTIC_MAX_BYTE_WIDTH_KEY 2
+
+/// \brief The max byte width statistic.  The maximum size in bytes of a row
+///   in the column.  Value type is int64 (when not approximate) or float64
+///   (when approximate).
+///
+/// For example, this is the maximum length of a string for a string column.
+#define ADBC_STATISTIC_MAX_BYTE_WIDTH_NAME "adbc.statistic.max_byte_width"
+
+/// \brief The dictionary-encoded name of the max value statistic.
+#define ADBC_STATISTIC_MAX_VALUE_KEY 3
+
+/// \brief The max value statistic.  Value type is column-dependent.
+#define ADBC_STATISTIC_MAX_VALUE_NAME "adbc.statistic.max_value"
+
+/// \brief The dictionary-encoded name of the min value statistic.
+#define ADBC_STATISTIC_MIN_VALUE_KEY 4
+
+/// \brief The min value statistic.  Value type is column-dependent.
+#define ADBC_STATISTIC_MIN_VALUE_NAME "adbc.statistic.min_value"
+
+/// \brief The dictionary-encoded name of the null count statistic.
+#define ADBC_STATISTIC_NULL_COUNT_KEY 5
+
+/// \brief The null count statistic.  The number of values that are null in
+///   the column.  Value type is int64 (when not approximate) or float64
+///   (when approximate).
+#define ADBC_STATISTIC_NULL_COUNT_NAME "adbc.statistic.null_count"
+
+/// \brief The dictionary-encoded name of the row count statistic.
+#define ADBC_STATISTIC_ROW_COUNT_KEY 6
+
+/// \brief The row count statistic.  The number of rows in the column or
+///   table.  Value type is int64 (when not approximate) or float64 (when
+///   approximate).
+#define ADBC_STATISTIC_ROW_COUNT_NAME "adbc.statistic.row_count"
+/// @}
+
+/// \brief The name of the canonical option for whether autocommit is
+///   enabled.
+///
+/// The type is char*.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_CONNECTION_OPTION_AUTOCOMMIT "adbc.connection.autocommit"
+
+/// \brief The name of the canonical option for whether the current
+///   connection should be restricted to being read-only.
+///
+/// The type is char*.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_CONNECTION_OPTION_READ_ONLY "adbc.connection.readonly"
+
+/// \brief The name of the canonical option for the current catalog.
+///
+/// The type is char*.
+///
+/// \see AdbcConnectionGetOption
+/// \see AdbcConnectionSetOption
+/// \since ADBC API revision 1.1.0
+#define ADBC_CONNECTION_OPTION_CURRENT_CATALOG "adbc.connection.catalog"
+
+/// \brief The name of the canonical option for the current schema.
+///
+/// The type is char*.
+///
+/// \see AdbcConnectionGetOption
+/// \see AdbcConnectionSetOption
+/// \since ADBC API revision 1.1.0
+#define ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA "adbc.connection.db_schema"
+
+/// \brief The name of the canonical option for making query execution
+///   nonblocking.
+///
+/// When enabled, AdbcStatementExecutePartitions will return
+/// partitions as soon as they are available, instead of returning
+/// them all at the end.  When there are no more to return, it will
+/// return an empty set of partitions.  AdbcStatementExecuteQuery and
+/// AdbcStatementExecuteSchema are not affected.
+///
+/// The default is ADBC_OPTION_VALUE_DISABLED.
+///
+/// The type is char*.
+///
+/// \see AdbcStatementSetOption
+/// \since ADBC API revision 1.1.0
+#define ADBC_STATEMENT_OPTION_INCREMENTAL "adbc.statement.exec.incremental"
+
+/// \brief The name of the option for getting the progress of a query.
+///
+/// The value is not necessarily in any particular range or have any
+/// particular units.  (For example, it might be a percentage, bytes of data,
+/// rows of data, number of workers, etc.)  The max value can be retrieved via
+/// ADBC_STATEMENT_OPTION_MAX_PROGRESS.  This represents the progress of
+/// execution, not of consumption (i.e., it is independent of how much of the
+/// result set has been read by the client via ArrowArrayStream.get_next().)
+///
+/// The type is double.
+///
+/// \see AdbcStatementGetOptionDouble
+/// \since ADBC API revision 1.1.0
+#define ADBC_STATEMENT_OPTION_PROGRESS "adbc.statement.exec.progress"
+
+/// \brief The name of the option for getting the maximum progress of a query.
+///
+/// This is the value of ADBC_STATEMENT_OPTION_PROGRESS for a completed query.
+/// If not supported, or if the value is nonpositive, then the maximum is not
+/// known.  (For instance, the query may be fully streaming and the driver
+/// does not know when the result set will end.)
+///
+/// The type is double.
+///
+/// \see AdbcStatementGetOptionDouble
+/// \since ADBC API revision 1.1.0
+#define ADBC_STATEMENT_OPTION_MAX_PROGRESS "adbc.statement.exec.max_progress"
+
+/// \brief The name of the canonical option for setting the isolation
+///   level of a transaction.
+///
+/// Should only be used in conjunction with autocommit disabled and
+/// AdbcConnectionCommit / AdbcConnectionRollback. If the desired
+/// isolation level is not supported by a driver, it should return an
+/// appropriate error.
+///
+/// The type is char*.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_CONNECTION_OPTION_ISOLATION_LEVEL \
+  "adbc.connection.transaction.isolation_level"
+
+/// \brief Use database or driver default isolation level
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_DEFAULT \
+  "adbc.connection.transaction.isolation.default"
+
+/// \brief The lowest isolation level. Dirty reads are allowed, so one
+///   transaction may see not-yet-committed changes made by others.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_READ_UNCOMMITTED \
+  "adbc.connection.transaction.isolation.read_uncommitted"
+
+/// \brief Lock-based concurrency control keeps write locks until the
+///   end of the transaction, but read locks are released as soon as a
+///   SELECT is performed. Non-repeatable reads can occur in this
+///   isolation level.
+///
+/// More simply put, Read Committed is an isolation level that guarantees
+/// that any data read is committed at the moment it is read. It simply
+/// restricts the reader from seeing any intermediate, uncommitted,
+/// 'dirty' reads. It makes no promise whatsoever that if the transaction
+/// re-issues the read, it will find the same data; data is free to change
+/// after it is read.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_READ_COMMITTED \
+  "adbc.connection.transaction.isolation.read_committed"
+
+/// \brief Lock-based concurrency control keeps read AND write locks
+///   (acquired on selection data) until the end of the transaction.
+///
+/// However, range-locks are not managed, so phantom reads can occur.
+/// Write skew is possible at this isolation level in some systems.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_REPEATABLE_READ \
+  "adbc.connection.transaction.isolation.repeatable_read"
+
+/// \brief This isolation guarantees that all reads in the transaction
+///   will see a consistent snapshot of the database and the transaction
+///   should only successfully commit if no updates conflict with any
+///   concurrent updates made since that snapshot.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_SNAPSHOT \
+  "adbc.connection.transaction.isolation.snapshot"
+
+/// \brief Serializability requires read and write locks to be released
+///   only at the end of the transaction. This includes acquiring range-
+///   locks when a select query uses a ranged WHERE clause to avoid
+///   phantom reads.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_SERIALIZABLE \
+  "adbc.connection.transaction.isolation.serializable"
+
+/// \brief The central distinction between serializability and linearizability
+///   is that serializability is a global property; a property of an entire
+///   history of operations and transactions. Linearizability is a local
+///   property; a property of a single operation/transaction.
+///
+/// Linearizability can be viewed as a special case of strict serializability
+/// where transactions are restricted to consist of a single operation applied
+/// to a single object.
+///
+/// \see AdbcConnectionSetOption
+#define ADBC_OPTION_ISOLATION_LEVEL_LINEARIZABLE \
+  "adbc.connection.transaction.isolation.linearizable"
+
+/// \defgroup adbc-statement-ingestion Bulk Data Ingestion
+/// While it is possible to insert data via prepared statements, it can
+/// be more efficient to explicitly perform a bulk insert.  For
+/// compatible drivers, this can be accomplished by setting up and
+/// executing a statement.  Instead of setting a SQL query or Substrait
+/// plan, bind the source data via AdbcStatementBind, and set the name
+/// of the table to be created via AdbcStatementSetOption and the
+/// options below.  Then, call AdbcStatementExecute with a NULL for
+/// the out parameter (to indicate you do not expect a result set).
+///
+/// @{
+
+/// \brief The name of the target table for a bulk insert.
+///
+/// The driver should attempt to create the table if it does not
+/// exist.  If the table exists but has a different schema,
+/// ADBC_STATUS_ALREADY_EXISTS should be raised.  Else, data should be
+/// appended to the target table.
+///
+/// The type is char*.
+#define ADBC_INGEST_OPTION_TARGET_TABLE "adbc.ingest.target_table"
+
+/// \brief Whether to create (the default) or append.
+///
+/// The type is char*.
+#define ADBC_INGEST_OPTION_MODE "adbc.ingest.mode"
+
+/// \brief Create the table and insert data; error if the table exists.
+#define ADBC_INGEST_OPTION_MODE_CREATE "adbc.ingest.mode.create"
+
+/// \brief Do not create the table, and insert data; error if the
+///   table does not exist (ADBC_STATUS_NOT_FOUND) or does not match
+///   the schema of the data to append (ADBC_STATUS_ALREADY_EXISTS).
+#define ADBC_INGEST_OPTION_MODE_APPEND "adbc.ingest.mode.append"
+
+/// \brief Create the table and insert data; drop the original table
+///   if it already exists.
+/// \since ADBC API revision 1.1.0
+#define ADBC_INGEST_OPTION_MODE_REPLACE "adbc.ingest.mode.replace"
+
+/// \brief Insert data; create the table if it does not exist, or
+///   error if the table exists, but the schema does not match the
+///   schema of the data to append (ADBC_STATUS_ALREADY_EXISTS).
+/// \since ADBC API revision 1.1.0
+#define ADBC_INGEST_OPTION_MODE_CREATE_APPEND "adbc.ingest.mode.create_append"
+
+/// \brief The catalog of the table for bulk insert.
+///
+/// The type is char*.
+#define ADBC_INGEST_OPTION_TARGET_CATALOG "adbc.ingest.target_catalog"
+
+/// \brief The schema of the table for bulk insert.
+///
+/// The type is char*.
+#define ADBC_INGEST_OPTION_TARGET_DB_SCHEMA "adbc.ingest.target_db_schema"
+
+/// \brief Use a temporary table for ingestion.
+///
+/// The value should be ADBC_OPTION_VALUE_ENABLED or
+/// ADBC_OPTION_VALUE_DISABLED (the default).
+///
+/// This is not supported with ADBC_INGEST_OPTION_TARGET_CATALOG and
+/// ADBC_INGEST_OPTION_TARGET_DB_SCHEMA.
+///
+/// The type is char*.
+#define ADBC_INGEST_OPTION_TEMPORARY "adbc.ingest.temporary"
+
+/// @}
+
+/// @}
+
+/// \defgroup adbc-database Database Initialization
+/// Clients first initialize a database, then create a connection
+/// (below).  This gives the implementation a place to initialize and
+/// own any common connection state.  For example, in-memory databases
+/// can place ownership of the actual database in this object.
+/// @{
+
+/// \brief An instance of a database.
+///
+/// Must be kept alive as long as any connections exist.
+struct ADBC_EXPORT AdbcDatabase {
+  /// \brief Opaque implementation-defined state.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
+  void* private_data;
+  /// \brief The associated driver (used by the driver manager to help
+  ///   track state).
+  struct AdbcDriver* private_driver;
+};
+
+/// @}
+
+/// \defgroup adbc-connection Connection Establishment
+/// Functions for creating, using, and releasing database connections.
+/// @{
+
+/// \brief An active database connection.
+///
+/// Provides methods for query execution, managing prepared
+/// statements, using transactions, and so on.
+///
+/// Connections are not required to be thread-safe, but they can be
+/// used from multiple threads so long as clients take care to
+/// serialize accesses to a connection.
+struct ADBC_EXPORT AdbcConnection {
+  /// \brief Opaque implementation-defined state.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
+  void* private_data;
+  /// \brief The associated driver (used by the driver manager to help
+  ///   track state).
+  struct AdbcDriver* private_driver;
+};
+
+/// @}
+
+/// \defgroup adbc-statement Managing Statements
+/// Applications should first initialize a statement with
+/// AdbcStatementNew. Then, the statement should be configured with
+/// functions like AdbcStatementSetSqlQuery and
+/// AdbcStatementSetOption. Finally, the statement can be executed
+/// with AdbcStatementExecuteQuery (or call AdbcStatementPrepare first
+/// to turn it into a prepared statement instead).
+/// @{
+
+/// \brief A container for all state needed to execute a database
+/// query, such as the query itself, parameters for prepared
+/// statements, driver parameters, etc.
+///
+/// Statements may represent queries or prepared statements.
+///
+/// Statements may be used multiple times and can be reconfigured
+/// (e.g. they can be reused to execute multiple different queries).
+/// However, executing a statement (and changing certain other state)
+/// will invalidate result sets obtained prior to that execution.
+///
+/// Multiple statements may be created from a single connection.
+/// However, the driver may block or error if they are used
+/// concurrently (whether from a single thread or multiple threads).
+///
+/// Statements are not required to be thread-safe, but they can be
+/// used from multiple threads so long as clients take care to
+/// serialize accesses to a statement.
+struct ADBC_EXPORT AdbcStatement {
+  /// \brief Opaque implementation-defined state.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
+  void* private_data;
+
+  /// \brief The associated driver (used by the driver manager to help
+  ///   track state).
+  struct AdbcDriver* private_driver;
+};
+
+/// \defgroup adbc-statement-partition Partitioned Results
+/// Some backends may internally partition the results. These
+/// partitions are exposed to clients who may wish to integrate them
+/// with a threaded or distributed execution model, where partitions
+/// can be divided among threads or machines and fetched in parallel.
+///
+/// To use partitioning, execute the statement with
+/// AdbcStatementExecutePartitions to get the partition descriptors.
+/// Call AdbcConnectionReadPartition to turn the individual
+/// descriptors into ArrowArrayStream instances.  This may be done on
+/// a different connection than the one the partition was created
+/// with, or even in a different process on another machine.
+///
+/// Drivers are not required to support partitioning.
+///
+/// @{
+
+/// \brief The partitions of a distributed/partitioned result set.
+struct AdbcPartitions {
+  /// \brief The number of partitions.
+  size_t num_partitions;
+
+  /// \brief The partitions of the result set, where each entry (up to
+  ///   num_partitions entries) is an opaque identifier that can be
+  ///   passed to AdbcConnectionReadPartition.
+  const uint8_t** partitions;
+
+  /// \brief The length of each corresponding entry in partitions.
+  const size_t* partition_lengths;
+
+  /// \brief Opaque implementation-defined state.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
+  void* private_data;
+
+  /// \brief Release the contained partitions.
+  ///
+  /// Unlike other structures, this is an embedded callback to make it
+  /// easier for the driver manager and driver to cooperate.
+  void (*release)(struct AdbcPartitions* partitions);
+};
+
+/// @}
+
+/// @}
+
+/// \defgroup adbc-driver Driver Initialization
+///
+/// These functions are intended to help support integration between a
+/// driver and the driver manager.
+/// @{
+
+/// \brief An instance of an initialized database driver.
+///
+/// This provides a common interface for vendor-specific driver
+/// initialization routines. Drivers should populate this struct, and
+/// applications can call ADBC functions through this struct, without
+/// worrying about multiple definitions of the same symbol.
+struct ADBC_EXPORT AdbcDriver {
+  /// \brief Opaque driver-defined state.
+  /// This field is NULL if the driver is uninitialized/freed (but
+  /// it need not have a value even if the driver is initialized).
+  void* private_data;
+  /// \brief Opaque driver manager-defined state.
+  /// This field is NULL if the driver is uninitialized/freed (but
+  /// it need not have a value even if the driver is initialized).
+  void* private_manager;
+
+  /// \brief Release the driver and perform any cleanup.
+  ///
+  /// This is an embedded callback to make it easier for the driver
+  /// manager and driver to cooperate.
+  AdbcStatusCode (*release)(struct AdbcDriver* driver, struct AdbcError* error);
+
+  AdbcStatusCode (*DatabaseInit)(struct AdbcDatabase*, struct AdbcError*);
+  AdbcStatusCode (*DatabaseNew)(struct AdbcDatabase*, struct AdbcError*);
+  AdbcStatusCode (*DatabaseSetOption)(struct AdbcDatabase*, const char*, const char*,
+                                      struct AdbcError*);
+  AdbcStatusCode (*DatabaseRelease)(struct AdbcDatabase*, struct AdbcError*);
+
+  AdbcStatusCode (*ConnectionCommit)(struct AdbcConnection*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetInfo)(struct AdbcConnection*, const uint32_t*, size_t,
+                                      struct ArrowArrayStream*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetObjects)(struct AdbcConnection*, int, const char*,
+                                         const char*, const char*, const char**,
+                                         const char*, struct ArrowArrayStream*,
+                                         struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetTableSchema)(struct AdbcConnection*, const char*,
+                                             const char*, const char*,
+                                             struct ArrowSchema*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetTableTypes)(struct AdbcConnection*,
+                                            struct ArrowArrayStream*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionInit)(struct AdbcConnection*, struct AdbcDatabase*,
+                                   struct AdbcError*);
+  AdbcStatusCode (*ConnectionNew)(struct AdbcConnection*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionSetOption)(struct AdbcConnection*, const char*, const char*,
+                                        struct AdbcError*);
+  AdbcStatusCode (*ConnectionReadPartition)(struct AdbcConnection*, const uint8_t*,
+                                            size_t, struct ArrowArrayStream*,
+                                            struct AdbcError*);
+  AdbcStatusCode (*ConnectionRelease)(struct AdbcConnection*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionRollback)(struct AdbcConnection*, struct AdbcError*);
+
+  AdbcStatusCode (*StatementBind)(struct AdbcStatement*, struct ArrowArray*,
+                                  struct ArrowSchema*, struct AdbcError*);
+  AdbcStatusCode (*StatementBindStream)(struct AdbcStatement*, struct ArrowArrayStream*,
+                                        struct AdbcError*);
+  AdbcStatusCode (*StatementExecuteQuery)(struct AdbcStatement*, struct ArrowArrayStream*,
+                                          int64_t*, struct AdbcError*);
+  AdbcStatusCode (*StatementExecutePartitions)(struct AdbcStatement*, struct ArrowSchema*,
+                                               struct AdbcPartitions*, int64_t*,
+                                               struct AdbcError*);
+  AdbcStatusCode (*StatementGetParameterSchema)(struct AdbcStatement*,
+                                                struct ArrowSchema*, struct AdbcError*);
+  AdbcStatusCode (*StatementNew)(struct AdbcConnection*, struct AdbcStatement*,
+                                 struct AdbcError*);
+  AdbcStatusCode (*StatementPrepare)(struct AdbcStatement*, struct AdbcError*);
+  AdbcStatusCode (*StatementRelease)(struct AdbcStatement*, struct AdbcError*);
+  AdbcStatusCode (*StatementSetOption)(struct AdbcStatement*, const char*, const char*,
+                                       struct AdbcError*);
+  AdbcStatusCode (*StatementSetSqlQuery)(struct AdbcStatement*, const char*,
+                                         struct AdbcError*);
+  AdbcStatusCode (*StatementSetSubstraitPlan)(struct AdbcStatement*, const uint8_t*,
+                                              size_t, struct AdbcError*);
+
+  /// \defgroup adbc-1.1.0 ADBC API Revision 1.1.0
+  ///
+  /// Functions added in ADBC 1.1.0.  For backwards compatibility,
+  /// these members must not be accessed unless the version passed to
+  /// the AdbcDriverInitFunc is greater than or equal to
+  /// ADBC_VERSION_1_1_0.
+  ///
+  /// For a 1.0.0 driver being loaded by a 1.1.0 driver manager: the
+  /// 1.1.0 manager will allocate the new, expanded AdbcDriver struct
+  /// and attempt to have the driver initialize it with
+  /// ADBC_VERSION_1_1_0.  This must return an error, after which the
+  /// driver will try again with ADBC_VERSION_1_0_0.  The driver must
+  /// not access the new fields, which will carry undefined values.
+  ///
+  /// For a 1.1.0 driver being loaded by a 1.0.0 driver manager: the
+  /// 1.0.0 manager will allocate the old AdbcDriver struct and
+  /// attempt to have the driver initialize it with
+  /// ADBC_VERSION_1_0_0.  The driver must not access the new fields,
+  /// and should initialize the old fields.
+  ///
+  /// @{
+
+  int (*ErrorGetDetailCount)(const struct AdbcError* error);
+  struct AdbcErrorDetail (*ErrorGetDetail)(const struct AdbcError* error, int index);
+  const struct AdbcError* (*ErrorFromArrayStream)(struct ArrowArrayStream* stream,
+                                                  AdbcStatusCode* status);
+
+  AdbcStatusCode (*DatabaseGetOption)(struct AdbcDatabase*, const char*, char*, size_t*,
+                                      struct AdbcError*);
+  AdbcStatusCode (*DatabaseGetOptionBytes)(struct AdbcDatabase*, const char*, uint8_t*,
+                                           size_t*, struct AdbcError*);
+  AdbcStatusCode (*DatabaseGetOptionDouble)(struct AdbcDatabase*, const char*, double*,
+                                            struct AdbcError*);
+  AdbcStatusCode (*DatabaseGetOptionInt)(struct AdbcDatabase*, const char*, int64_t*,
+                                         struct AdbcError*);
+  AdbcStatusCode (*DatabaseSetOptionBytes)(struct AdbcDatabase*, const char*,
+                                           const uint8_t*, size_t, struct AdbcError*);
+  AdbcStatusCode (*DatabaseSetOptionDouble)(struct AdbcDatabase*, const char*, double,
+                                            struct AdbcError*);
+  AdbcStatusCode (*DatabaseSetOptionInt)(struct AdbcDatabase*, const char*, int64_t,
+                                         struct AdbcError*);
+
+  AdbcStatusCode (*ConnectionCancel)(struct AdbcConnection*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetOption)(struct AdbcConnection*, const char*, char*,
+                                        size_t*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetOptionBytes)(struct AdbcConnection*, const char*,
+                                             uint8_t*, size_t*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetOptionDouble)(struct AdbcConnection*, const char*,
+                                              double*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetOptionInt)(struct AdbcConnection*, const char*, int64_t*,
+                                           struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetStatistics)(struct AdbcConnection*, const char*,
+                                            const char*, const char*, char,
+                                            struct ArrowArrayStream*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionGetStatisticNames)(struct AdbcConnection*,
+                                                struct ArrowArrayStream*,
+                                                struct AdbcError*);
+  AdbcStatusCode (*ConnectionSetOptionBytes)(struct AdbcConnection*, const char*,
+                                             const uint8_t*, size_t, struct AdbcError*);
+  AdbcStatusCode (*ConnectionSetOptionDouble)(struct AdbcConnection*, const char*, double,
+                                              struct AdbcError*);
+  AdbcStatusCode (*ConnectionSetOptionInt)(struct AdbcConnection*, const char*, int64_t,
+                                           struct AdbcError*);
+
+  AdbcStatusCode (*StatementCancel)(struct AdbcStatement*, struct AdbcError*);
+  AdbcStatusCode (*StatementExecuteSchema)(struct AdbcStatement*, struct ArrowSchema*,
+                                           struct AdbcError*);
+  AdbcStatusCode (*StatementGetOption)(struct AdbcStatement*, const char*, char*, size_t*,
+                                       struct AdbcError*);
+  AdbcStatusCode (*StatementGetOptionBytes)(struct AdbcStatement*, const char*, uint8_t*,
+                                            size_t*, struct AdbcError*);
+  AdbcStatusCode (*StatementGetOptionDouble)(struct AdbcStatement*, const char*, double*,
+                                             struct AdbcError*);
+  AdbcStatusCode (*StatementGetOptionInt)(struct AdbcStatement*, const char*, int64_t*,
+                                          struct AdbcError*);
+  AdbcStatusCode (*StatementSetOptionBytes)(struct AdbcStatement*, const char*,
+                                            const uint8_t*, size_t, struct AdbcError*);
+  AdbcStatusCode (*StatementSetOptionDouble)(struct AdbcStatement*, const char*, double,
+                                             struct AdbcError*);
+  AdbcStatusCode (*StatementSetOptionInt)(struct AdbcStatement*, const char*, int64_t,
+                                          struct AdbcError*);
+
+  /// @}
+};
+
+/// \brief The size of the AdbcDriver structure in ADBC 1.0.0.
+/// Drivers written for ADBC 1.1.0 and later should never touch more
+/// than this portion of an AdbcDriver struct when given
+/// ADBC_VERSION_1_0_0.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_DRIVER_1_0_0_SIZE (offsetof(struct AdbcDriver, ErrorGetDetailCount))
+
+/// \brief The size of the AdbcDriver structure in ADBC 1.1.0.
+/// Drivers written for ADBC 1.1.0 and later should never touch more
+/// than this portion of an AdbcDriver struct when given
+/// ADBC_VERSION_1_1_0.
+///
+/// \since ADBC API revision 1.1.0
+#define ADBC_DRIVER_1_1_0_SIZE (sizeof(struct AdbcDriver))
+
+/// @}
+
+/// \addtogroup adbc-database
+/// @{
+
+/// \brief Allocate a new (but uninitialized) database.
+///
+/// Callers pass in a zero-initialized AdbcDatabase.
+///
+/// Drivers should allocate their internal data structure and set the private_data
+/// field to point to the newly allocated struct. This struct should be released
+/// when AdbcDatabaseRelease is called.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseNew(struct AdbcDatabase* database, struct AdbcError* error);
+
+/// \brief Get a string option of the database.
+///
+/// This must always be thread-safe (other operations are not), though
+/// given the semantics here, it is not recommended to call GetOption
+/// concurrently with itself.
+///
+/// length must be provided and must be the size of the buffer pointed
+/// to by value.  If there is sufficient space, the driver will copy
+/// the option value (including the null terminator) to buffer and set
+/// length to the size of the actual value.  If the buffer is too
+/// small, no data will be written and length will be set to the
+/// required length.
+///
+/// In other words:
+///
+/// - If output length <= input length, value will contain a value
+///   with length bytes.
+/// - If output length > input length, nothing has been written to
+///   value.
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[in,out] length The length of value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseGetOption(struct AdbcDatabase* database, const char* key,
+                                     char* value, size_t* length,
+                                     struct AdbcError* error);
+
+/// \brief Get a bytestring option of the database.
+///
+/// This must always be thread-safe (other operations are not), though
+/// given the semantics here, it is not recommended to call
+/// GetOptionBytes concurrently with itself.
+///
+/// length must be provided and must be the size of the buffer pointed
+/// to by value.  If there is sufficient space, the driver will copy
+/// the option value to buffer and set length to the size of the
+/// actual value.  If the buffer is too small, no data will be written
+/// and length will be set to the required length.
+///
+/// In other words:
+///
+/// - If output length <= input length, value will contain a value
+///   with length bytes.
+/// - If output length > input length, nothing has been written to
+///   value.
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[in,out] length The option value length.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseGetOptionBytes(struct AdbcDatabase* database, const char* key,
+                                          uint8_t* value, size_t* length,
+                                          struct AdbcError* error);
+
+/// \brief Get a double option of the database.
+///
+/// This must always be thread-safe (other operations are not).
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the double
+/// representation of an integer option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseGetOptionDouble(struct AdbcDatabase* database, const char* key,
+                                           double* value, struct AdbcError* error);
+
+/// \brief Get an integer option of the database.
+///
+/// This must always be thread-safe (other operations are not).
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the integer
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseGetOptionInt(struct AdbcDatabase* database, const char* key,
+                                        int64_t* value, struct AdbcError* error);
+
+/// \brief Set a char* option.
+///
+/// Options may be set before AdbcDatabaseInit.  Some drivers may
+/// support setting options after initialization as well.
+///
+/// Driver managers may treat some option keys as manager-reserved and
+/// handle them without forwarding them to the underlying driver.  In
+/// particular, the option key "profile" is reserved for connection
+/// profiles and must not be implemented or interpreted by drivers.
+///
+/// \param[in] database The database.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseSetOption(struct AdbcDatabase* database, const char* key,
+                                     const char* value, struct AdbcError* error);
+
+/// \brief Set a bytestring option on a database.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[in] length The option value length.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseSetOptionBytes(struct AdbcDatabase* database, const char* key,
+                                          const uint8_t* value, size_t length,
+                                          struct AdbcError* error);
+
+/// \brief Set a double option on a database.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseSetOptionDouble(struct AdbcDatabase* database, const char* key,
+                                           double value, struct AdbcError* error);
+
+/// \brief Set an integer option on a database.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] database The database.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseSetOptionInt(struct AdbcDatabase* database, const char* key,
+                                        int64_t value, struct AdbcError* error);
+
+/// \brief Finish setting options and initialize the database.
+///
+/// Some drivers may support setting options after initialization
+/// as well.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseInit(struct AdbcDatabase* database, struct AdbcError* error);
+
+/// \brief Destroy this database. No connections may exist.
+/// \param[in] database The database to release.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+ADBC_EXPORT
+AdbcStatusCode AdbcDatabaseRelease(struct AdbcDatabase* database,
+                                   struct AdbcError* error);
+
+/// @}
+
+/// \addtogroup adbc-connection
+/// @{
+
+/// \brief Allocate a new (but uninitialized) connection.
+///
+/// Callers pass in a zero-initialized AdbcConnection.
+///
+/// Drivers should allocate their internal data structure and set the private_data
+/// field to point to the newly allocated struct. This struct should be released
+/// when AdbcConnectionRelease is called.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionNew(struct AdbcConnection* connection,
+                                 struct AdbcError* error);
+
+/// \brief Set a char* option.
+///
+/// Options may be set before AdbcConnectionInit.  Some drivers may
+/// support setting options after initialization as well.
+///
+/// \param[in] connection The database connection.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionSetOption(struct AdbcConnection* connection, const char* key,
+                                       const char* value, struct AdbcError* error);
+
+/// \brief Set a bytestring option on a connection.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The connection.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[in] length The option value length.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionSetOptionBytes(struct AdbcConnection* connection,
+                                            const char* key, const uint8_t* value,
+                                            size_t length, struct AdbcError* error);
+
+/// \brief Set an integer option.
+///
+/// Options may be set before AdbcConnectionInit.  Some drivers may
+/// support setting options after initialization as well.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionSetOptionInt(struct AdbcConnection* connection,
+                                          const char* key, int64_t value,
+                                          struct AdbcError* error);
+
+/// \brief Set a double option.
+///
+/// Options may be set before AdbcConnectionInit.  Some drivers may
+/// support setting options after initialization as well.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionSetOptionDouble(struct AdbcConnection* connection,
+                                             const char* key, double value,
+                                             struct AdbcError* error);
+
+/// \brief Finish setting options and initialize the connection.
+///
+/// Some drivers may support setting options after initialization
+/// as well.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionInit(struct AdbcConnection* connection,
+                                  struct AdbcDatabase* database, struct AdbcError* error);
+
+/// \brief Destroy this connection.
+///
+/// \param[in] connection The connection to release.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
+                                     struct AdbcError* error);
+
+/// \brief Cancel the in-progress operation on a connection.
+///
+/// This can be called during AdbcConnectionGetObjects (or similar),
+/// or while consuming an ArrowArrayStream returned from such.
+/// Calling this function should make the other functions return
+/// ADBC_STATUS_CANCELLED (from ADBC functions) or ECANCELED (from
+/// methods of ArrowArrayStream).  (It is not guaranteed to, for
+/// instance, the result set may be buffered in memory already.)
+///
+/// This must always be thread-safe (other operations are not).  It is
+/// not necessarily signal-safe.
+///
+/// \since ADBC API revision 1.1.0
+///
+/// \param[in] connection The connection to cancel.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+///
+/// \return ADBC_STATUS_INVALID_STATE if there is no operation to cancel.
+/// \return ADBC_STATUS_UNKNOWN if the operation could not be cancelled.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionCancel(struct AdbcConnection* connection,
+                                    struct AdbcError* error);
+
+/// \defgroup adbc-connection-metadata Metadata
+/// Functions for retrieving metadata about the database.
+///
+/// Generally, these functions return an ArrowArrayStream that can be
+/// consumed to get the metadata as Arrow data.  The returned metadata
+/// has an expected schema given in the function docstring. Schema
+/// fields are nullable unless otherwise marked.  While no
+/// AdbcStatement is used in these functions, the result set may count
+/// as an active statement to the driver for the purposes of
+/// concurrency management (e.g. if the driver has a limit on
+/// concurrent active statements and it must execute a SQL query
+/// internally in order to implement the metadata function).
+///
+/// This AdbcConnection must outlive the returned ArrowArrayStream.
+///
+/// Some functions accept "search pattern" arguments, which are
+/// strings that can contain the special character "%" to match zero
+/// or more characters, or "_" to match exactly one character.  (See
+/// the documentation of DatabaseMetaData in JDBC or "Pattern Value
+/// Arguments" in the ODBC documentation.)  Escaping is not currently
+/// supported.
+///
+/// @{
+
+/// \brief Get metadata about the database/driver.
+///
+/// The result is an Arrow dataset with the following schema:
+///
+/// Field Name                  | Field Type
+/// ----------------------------|------------------------
+/// info_name                   | uint32 not null
+/// info_value                  | INFO_SCHEMA
+///
+/// INFO_SCHEMA is a dense union with members:
+///
+/// Field Name (Type Code)      | Field Type
+/// ----------------------------|------------------------
+/// string_value (0)            | utf8
+/// bool_value (1)              | bool
+/// int64_value (2)             | int64
+/// int32_bitmask (3)           | int32
+/// string_list (4)             | list<utf8>
+/// int32_to_int32_list_map (5) | map<int32, list<int32>>
+///
+/// Each metadatum is identified by an integer code.  The recognized
+/// codes are defined as constants.  Codes [0, 10_000) are reserved
+/// for ADBC usage.  Drivers/vendors will ignore requests for
+/// unrecognized codes (the row will be omitted from the result).
+///
+/// Since ADBC 1.1.0: the range [500, 1_000) is reserved for "XDBC"
+/// information, which is the same metadata provided by the same info
+/// code range in the Arrow Flight SQL GetSqlInfo RPC.
+///
+/// \param[in] connection The connection to query.
+/// \param[in] info_codes A list of metadata codes to fetch, or NULL
+///   to fetch all.
+/// \param[in] info_codes_length The length of the info_codes
+///   parameter.  Ignored if info_codes is NULL.
+/// \param[out] out The result set.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
+                                     const uint32_t* info_codes, size_t info_codes_length,
+                                     struct ArrowArrayStream* out,
+                                     struct AdbcError* error);
+
+/// \brief Get a hierarchical view of all catalogs, database schemas,
+///   tables, and columns.
+///
+/// The result is an Arrow dataset with the following schema:
+///
+/// | Field Name               | Field Type              |
+/// |--------------------------|-------------------------|
+/// | catalog_name             | utf8                    |
+/// | catalog_db_schemas       | list<DB_SCHEMA_SCHEMA>  |
+///
+/// DB_SCHEMA_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type              |
+/// |--------------------------|-------------------------|
+/// | db_schema_name           | utf8                    |
+/// | db_schema_tables         | list<TABLE_SCHEMA>      |
+///
+/// TABLE_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type              |
+/// |--------------------------|-------------------------|
+/// | table_name               | utf8 not null           |
+/// | table_type               | utf8 not null           |
+/// | table_columns            | list<COLUMN_SCHEMA>     |
+/// | table_constraints        | list<CONSTRAINT_SCHEMA> |
+///
+/// COLUMN_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | column_name              | utf8 not null           |          |
+/// | ordinal_position         | int32                   | (1)      |
+/// | remarks                  | utf8                    | (2)      |
+/// | xdbc_data_type           | int16                   | (3)      |
+/// | xdbc_type_name           | utf8                    | (3)      |
+/// | xdbc_column_size         | int32                   | (3)      |
+/// | xdbc_decimal_digits      | int16                   | (3)      |
+/// | xdbc_num_prec_radix      | int16                   | (3)      |
+/// | xdbc_nullable            | int16                   | (3)      |
+/// | xdbc_column_def          | utf8                    | (3)      |
+/// | xdbc_sql_data_type       | int16                   | (3)      |
+/// | xdbc_datetime_sub        | int16                   | (3)      |
+/// | xdbc_char_octet_length   | int32                   | (3)      |
+/// | xdbc_is_nullable         | utf8                    | (3)      |
+/// | xdbc_scope_catalog       | utf8                    | (3)      |
+/// | xdbc_scope_schema        | utf8                    | (3)      |
+/// | xdbc_scope_table         | utf8                    | (3)      |
+/// | xdbc_is_autoincrement    | bool                    | (3)      |
+/// | xdbc_is_generatedcolumn  | bool                    | (3)      |
+///
+/// 1. The column's ordinal position in the table (starting from 1).
+/// 2. Database-specific description of the column.
+/// 3. Optional value.  Should be null if not supported by the driver.
+///    xdbc_ values are meant to provide JDBC/ODBC-compatible metadata
+///    in an agnostic manner.
+///
+/// CONSTRAINT_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | constraint_name          | utf8                    |          |
+/// | constraint_type          | utf8 not null           | (1)      |
+/// | constraint_column_names  | list<utf8> not null     | (2)      |
+/// | constraint_column_usage  | list<USAGE_SCHEMA>      | (3)      |
+///
+/// 1. One of 'CHECK', 'FOREIGN KEY', 'PRIMARY KEY', or 'UNIQUE'.
+/// 2. The columns on the current table that are constrained, in
+///    order.
+/// 3. For FOREIGN KEY only, the referenced table and columns.
+///
+/// USAGE_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type              |
+/// |--------------------------|-------------------------|
+/// | fk_catalog               | utf8                    |
+/// | fk_db_schema             | utf8                    |
+/// | fk_table                 | utf8 not null           |
+/// | fk_column_name           | utf8 not null           |
+///
+/// This AdbcConnection must outlive the returned ArrowArrayStream.
+///
+/// \param[in] connection The database connection.
+/// \param[in] depth The level of nesting to display. If 0, display
+///   all levels. If 1, display only catalogs (i.e.  catalog_schemas
+///   will be null). If 2, display only catalogs and schemas
+///   (i.e. db_schema_tables will be null), and so on.
+/// \param[in] catalog Only show tables in the given catalog. If NULL,
+///   do not filter by catalog. If an empty string, only show tables
+///   without a catalog.  May be a search pattern (see section
+///   documentation).
+/// \param[in] db_schema Only show tables in the given database schema. If
+///   NULL, do not filter by database schema. If an empty string, only show
+///   tables without a database schema. May be a search pattern (see section
+///   documentation).
+/// \param[in] table_name Only show tables with the given name. If NULL, do not
+///   filter by name. May be a search pattern (see section documentation).
+/// \param[in] table_type Only show tables matching one of the given table
+///   types. If NULL, show tables of any type. Valid table types can be fetched
+///   from GetTableTypes.  Terminate the list with a NULL entry.
+/// \param[in] column_name Only show columns with the given name. If
+///   NULL, do not filter by name.  May be a search pattern (see
+///   section documentation).
+/// \param[out] out The result set.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetObjects(struct AdbcConnection* connection, int depth,
+                                        const char* catalog, const char* db_schema,
+                                        const char* table_name, const char** table_type,
+                                        const char* column_name,
+                                        struct ArrowArrayStream* out,
+                                        struct AdbcError* error);
+
+/// \brief Get a string option of the connection.
+///
+/// This must always be thread-safe (other operations are not), though
+/// given the semantics here, it is not recommended to call GetOption
+/// concurrently with itself.
+///
+/// length must be provided and must be the size of the buffer pointed
+/// to by value.  If there is sufficient space, the driver will copy
+/// the option value (including the null terminator) to buffer and set
+/// length to the size of the actual value.  If the buffer is too
+/// small, no data will be written and length will be set to the
+/// required length.
+///
+/// In other words:
+///
+/// - If output length <= input length, value will contain a value
+///   with length bytes.
+/// - If output length > input length, nothing has been written to
+///   value.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[in,out] length The length of value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetOption(struct AdbcConnection* connection, const char* key,
+                                       char* value, size_t* length,
+                                       struct AdbcError* error);
+
+/// \brief Get a bytestring option of the connection.
+///
+/// This must always be thread-safe (other operations are not), though
+/// given the semantics here, it is not recommended to call
+/// GetOptionBytes concurrently with itself.
+///
+/// length must be provided and must be the size of the buffer pointed
+/// to by value.  If there is sufficient space, the driver will copy
+/// the option value to buffer and set length to the size of the
+/// actual value.  If the buffer is too small, no data will be written
+/// and length will be set to the required length.
+///
+/// In other words:
+///
+/// - If output length <= input length, value will contain a value
+///   with length bytes.
+/// - If output length > input length, nothing has been written to
+///   value.
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The connection.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[in,out] length The option value length.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetOptionBytes(struct AdbcConnection* connection,
+                                            const char* key, uint8_t* value,
+                                            size_t* length, struct AdbcError* error);
+
+/// \brief Get an integer option of the connection.
+///
+/// This must always be thread-safe (other operations are not).
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetOptionInt(struct AdbcConnection* connection,
+                                          const char* key, int64_t* value,
+                                          struct AdbcError* error);
+
+/// \brief Get a double option of the connection.
+///
+/// This must always be thread-safe (other operations are not).
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetOptionDouble(struct AdbcConnection* connection,
+                                             const char* key, double* value,
+                                             struct AdbcError* error);
+
+/// \brief Get statistics about the data distribution of table(s).
+///
+/// The result is an Arrow dataset with the following schema:
+///
+/// | Field Name               | Field Type                       |
+/// |--------------------------|----------------------------------|
+/// | catalog_name             | utf8                             |
+/// | catalog_db_schemas       | list<DB_SCHEMA_SCHEMA> not null  |
+///
+/// DB_SCHEMA_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type                       |
+/// |--------------------------|----------------------------------|
+/// | db_schema_name           | utf8                             |
+/// | db_schema_statistics     | list<STATISTICS_SCHEMA> not null |
+///
+/// STATISTICS_SCHEMA is a Struct with fields:
+///
+/// | Field Name               | Field Type                       | Comments |
+/// |--------------------------|----------------------------------| -------- |
+/// | table_name               | utf8 not null                    |          |
+/// | column_name              | utf8                             | (1)      |
+/// | statistic_key            | int16 not null                   | (2)      |
+/// | statistic_value          | VALUE_SCHEMA not null            |          |
+/// | statistic_is_approximate | bool not null                    | (3)      |
+///
+/// 1. If null, then the statistic applies to the entire table.
+/// 2. A dictionary-encoded statistic name (although we do not use the Arrow
+///    dictionary type). Values in [0, 1024) are reserved for ADBC.  Other
+///    values are for implementation-specific statistics.  For the definitions
+///    of predefined statistic types, see \ref adbc-table-statistics.  To get
+///    driver-specific statistic names, use AdbcConnectionGetStatisticNames.
+/// 3. If true, then the value is approximate or best-effort.
+///
+/// VALUE_SCHEMA is a dense union with members:
+///
+/// | Field Name               | Field Type                       |
+/// |--------------------------|----------------------------------|
+/// | int64                    | int64                            |
+/// | uint64                   | uint64                           |
+/// | float64                  | float64                          |
+/// | binary                   | binary                           |
+///
+/// This AdbcConnection must outlive the returned ArrowArrayStream.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[in] catalog The catalog (or nullptr).  May be a search
+///   pattern (see section documentation).
+/// \param[in] db_schema The database schema (or nullptr).  May be a
+///   search pattern (see section documentation).
+/// \param[in] table_name The table name (or nullptr).  May be a
+///   search pattern (see section documentation).
+/// \param[in] approximate If zero, request exact values of
+///   statistics, else allow for best-effort, approximate, or cached
+///   values.  The database may return approximate values regardless,
+///   as indicated in the result.  Requesting exact values may be
+///   expensive or unsupported.
+/// \param[out] out The result set.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetStatistics(struct AdbcConnection* connection,
+                                           const char* catalog, const char* db_schema,
+                                           const char* table_name, char approximate,
+                                           struct ArrowArrayStream* out,
+                                           struct AdbcError* error);
+
+/// \brief Get the names of statistics specific to this driver.
+///
+/// The result is an Arrow dataset with the following schema:
+///
+/// Field Name     | Field Type
+/// ---------------|----------------
+/// statistic_name | utf8 not null
+/// statistic_key  | int16 not null
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] connection The database connection.
+/// \param[out] out The result set.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetStatisticNames(struct AdbcConnection* connection,
+                                               struct ArrowArrayStream* out,
+                                               struct AdbcError* error);
+
+/// \brief Get the Arrow schema of a table.
+///
+/// \param[in] connection The database connection.
+/// \param[in] catalog The catalog (or nullptr if not applicable).
+/// \param[in] db_schema The database schema (or nullptr if not applicable).
+/// \param[in] table_name The table name.
+/// \param[out] schema The table schema.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetTableSchema(struct AdbcConnection* connection,
+                                            const char* catalog, const char* db_schema,
+                                            const char* table_name,
+                                            struct ArrowSchema* schema,
+                                            struct AdbcError* error);
+
+/// \brief Get a list of table types in the database.
+///
+/// The result is an Arrow dataset with the following schema:
+///
+/// Field Name     | Field Type
+/// ---------------|--------------
+/// table_type     | utf8 not null
+///
+/// This AdbcConnection must outlive the returned ArrowArrayStream.
+///
+/// \param[in] connection The database connection.
+/// \param[out] out The result set.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionGetTableTypes(struct AdbcConnection* connection,
+                                           struct ArrowArrayStream* out,
+                                           struct AdbcError* error);
+
+/// @}
+
+/// \defgroup adbc-connection-partition Partitioned Results
+/// Some databases may internally partition the results. These
+/// partitions are exposed to clients who may wish to integrate them
+/// with a threaded or distributed execution model, where partitions
+/// can be divided among threads or machines for processing.
+///
+/// Drivers are not required to support partitioning.
+///
+/// Partitions are not ordered. If the result set is sorted,
+/// implementations should return a single partition.
+///
+/// @{
+
+/// \brief Construct a statement for a partition of a query. The
+///   results can then be read independently.
+///
+/// A partition can be retrieved from AdbcPartitions.
+///
+/// This AdbcConnection must outlive the returned ArrowArrayStream.
+///
+/// \param[in] connection The connection to use.  This does not have
+///   to be the same connection that the partition was created on.
+/// \param[in] serialized_partition The partition descriptor.
+/// \param[in] serialized_length The partition descriptor length.
+/// \param[out] out The result set.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionReadPartition(struct AdbcConnection* connection,
+                                           const uint8_t* serialized_partition,
+                                           size_t serialized_length,
+                                           struct ArrowArrayStream* out,
+                                           struct AdbcError* error);
+
+/// @}
+
+/// \defgroup adbc-connection-transaction Transaction Semantics
+///
+/// Connections start out in auto-commit mode by default (if
+/// applicable for the given vendor). Use AdbcConnectionSetOption and
+/// ADBC_CONNECTION_OPTION_AUTO_COMMIT to change this.
+///
+/// @{
+
+/// \brief Commit any pending transactions. Only used if autocommit is
+///   disabled.
+///
+/// Behavior is undefined if this is mixed with SQL transaction
+/// statements.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionCommit(struct AdbcConnection* connection,
+                                    struct AdbcError* error);
+
+/// \brief Roll back any pending transactions. Only used if autocommit
+///   is disabled.
+///
+/// Behavior is undefined if this is mixed with SQL transaction
+/// statements.
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionRollback(struct AdbcConnection* connection,
+                                      struct AdbcError* error);
+
+/// @}
+
+/// @}
+
+/// \addtogroup adbc-statement
+/// @{
+
+/// \brief Create a new statement for a given connection.
+///
+/// Callers pass in a zero-initialized AdbcStatement.
+///
+/// Drivers should allocate their internal data structure and set the private_data
+/// field to point to the newly allocated struct. This struct should be released
+/// when AdbcStatementRelease is called.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementNew(struct AdbcConnection* connection,
+                                struct AdbcStatement* statement, struct AdbcError* error);
+
+/// \brief Destroy a statement.
+/// \param[in] statement The statement to release.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementRelease(struct AdbcStatement* statement,
+                                    struct AdbcError* error);
+
+/// \brief Execute a statement and get the results.
+///
+/// This invalidates any prior result sets.  This AdbcStatement must
+/// outlive the returned ArrowArrayStream.
+///
+/// Since ADBC 1.1.0: releasing the returned ArrowArrayStream without
+/// consuming it fully is equivalent to calling AdbcStatementCancel.
+///
+/// \param[in] statement The statement to execute.
+/// \param[out] out The results. Pass NULL if the client does not
+///   expect a result set.
+/// \param[out] rows_affected The number of rows affected if known,
+///   else -1. Pass NULL if the client does not want this information.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementExecuteQuery(struct AdbcStatement* statement,
+                                         struct ArrowArrayStream* out,
+                                         int64_t* rows_affected, struct AdbcError* error);
+
+/// \brief Get the schema of the result set of a query without
+///   executing it.
+///
+/// This invalidates any prior result sets.
+///
+/// Depending on the driver, this may require first executing
+/// AdbcStatementPrepare.
+///
+/// \since ADBC API revision 1.1.0
+///
+/// \param[in] statement The statement to execute.
+/// \param[out] schema The result schema.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+///
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the driver does not support this.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
+                                          struct ArrowSchema* schema,
+                                          struct AdbcError* error);
+
+/// \brief Turn this statement into a prepared statement to be
+///   executed multiple times.
+///
+/// This invalidates any prior result sets.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementPrepare(struct AdbcStatement* statement,
+                                    struct AdbcError* error);
+
+/// \defgroup adbc-statement-sql SQL Semantics
+/// Functions for executing SQL queries, or querying SQL-related
+/// metadata. Drivers are not required to support both SQL and
+/// Substrait semantics. If they do, it may be via converting
+/// between representations internally.
+/// @{
+
+/// \brief Set the SQL query to execute.
+///
+/// The query can then be executed with AdbcStatementExecute.  For
+/// queries expected to be executed repeatedly, AdbcStatementPrepare
+/// the statement first.
+///
+/// \param[in] statement The statement.
+/// \param[in] query The query to execute.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementSetSqlQuery(struct AdbcStatement* statement,
+                                        const char* query, struct AdbcError* error);
+
+/// @}
+
+/// \defgroup adbc-statement-substrait Substrait Semantics
+/// Functions for executing Substrait plans, or querying
+/// Substrait-related metadata.  Drivers are not required to support
+/// both SQL and Substrait semantics.  If they do, it may be via
+/// converting between representations internally.
+/// @{
+
+/// \brief Set the Substrait plan to execute.
+///
+/// The query can then be executed with AdbcStatementExecute.  For
+/// queries expected to be executed repeatedly, AdbcStatementPrepare
+/// the statement first.
+///
+/// \param[in] statement The statement.
+/// \param[in] plan The serialized substrait.Plan to execute.
+/// \param[in] length The length of the serialized plan.
+/// \param[out] error Error details, if an error occurs.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementSetSubstraitPlan(struct AdbcStatement* statement,
+                                             const uint8_t* plan, size_t length,
+                                             struct AdbcError* error);
+
+/// @}
+
+/// \brief Bind Arrow data. This can be used for bulk inserts or
+///   prepared statements.
+///
+/// \param[in] statement The statement to bind to.
+/// \param[in] values The values to bind. The driver will call the
+///   release callback itself, although it may not do this until the
+///   statement is released.
+/// \param[in] schema The schema of the values to bind.
+/// \param[out] error An optional location to return an error message
+///   if necessary.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementBind(struct AdbcStatement* statement,
+                                 struct ArrowArray* values, struct ArrowSchema* schema,
+                                 struct AdbcError* error);
+
+/// \brief Bind Arrow data. This can be used for bulk inserts or
+///   prepared statements.
+/// \param[in] statement The statement to bind to.
+/// \param[in] stream The values to bind. The driver will call the
+///   release callback itself, although it may not do this until the
+///   statement is released.
+/// \param[out] error An optional location to return an error message
+///   if necessary.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementBindStream(struct AdbcStatement* statement,
+                                       struct ArrowArrayStream* stream,
+                                       struct AdbcError* error);
+
+/// \brief Cancel execution of an in-progress query.
+///
+/// This can be called during AdbcStatementExecuteQuery (or similar),
+/// or while consuming an ArrowArrayStream returned from such.
+/// Calling this function should make the other functions return
+/// ADBC_STATUS_CANCELLED (from ADBC functions) or ECANCELED (from
+/// methods of ArrowArrayStream).  (It is not guaranteed to, for
+/// instance, the result set may be buffered in memory already.)
+///
+/// This must always be thread-safe (other operations are not).  It is
+/// not necessarily signal-safe.
+///
+/// \since ADBC API revision 1.1.0
+///
+/// \param[in] statement The statement to cancel.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+///
+/// \return ADBC_STATUS_INVALID_STATE if there is no query to cancel.
+/// \return ADBC_STATUS_UNKNOWN if the query could not be cancelled.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementCancel(struct AdbcStatement* statement,
+                                   struct AdbcError* error);
+
+/// \brief Get a string option of the statement.
+///
+/// This must always be thread-safe (other operations are not), though
+/// given the semantics here, it is not recommended to call GetOption
+/// concurrently with itself.
+///
+/// length must be provided and must be the size of the buffer pointed
+/// to by value.  If there is sufficient space, the driver will copy
+/// the option value (including the null terminator) to buffer and set
+/// length to the size of the actual value.  If the buffer is too
+/// small, no data will be written and length will be set to the
+/// required length.
+///
+/// In other words:
+///
+/// - If output length <= input length, value will contain a value
+///   with length bytes.
+/// - If output length > input length, nothing has been written to
+///   value.
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[in,out] length The length of value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementGetOption(struct AdbcStatement* statement, const char* key,
+                                      char* value, size_t* length,
+                                      struct AdbcError* error);
+
+/// \brief Get a bytestring option of the statement.
+///
+/// This must always be thread-safe (other operations are not), though
+/// given the semantics here, it is not recommended to call
+/// GetOptionBytes concurrently with itself.
+///
+/// length must be provided and must be the size of the buffer pointed
+/// to by value.  If there is sufficient space, the driver will copy
+/// the option value to buffer and set length to the size of the
+/// actual value.  If the buffer is too small, no data will be written
+/// and length will be set to the required length.
+///
+/// In other words:
+///
+/// - If output length <= input length, value will contain a value
+///   with length bytes.
+/// - If output length > input length, nothing has been written to
+///   value.
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[in,out] length The option value length.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementGetOptionBytes(struct AdbcStatement* statement,
+                                           const char* key, uint8_t* value,
+                                           size_t* length, struct AdbcError* error);
+
+/// \brief Get an integer option of the statement.
+///
+/// This must always be thread-safe (other operations are not).
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementGetOptionInt(struct AdbcStatement* statement, const char* key,
+                                         int64_t* value, struct AdbcError* error);
+
+/// \brief Get a double option of the statement.
+///
+/// This must always be thread-safe (other operations are not).
+///
+/// For standard options, drivers must always support getting the
+/// option value (if they support getting option values at all) via
+/// the type specified in the option.  (For example, an option set via
+/// SetOptionDouble must be retrievable via GetOptionDouble.)  Drivers
+/// may also support getting a converted option value via other
+/// getters if needed.  (For example, getting the string
+/// representation of a double option.)
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to get.
+/// \param[out] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_FOUND if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementGetOptionDouble(struct AdbcStatement* statement,
+                                            const char* key, double* value,
+                                            struct AdbcError* error);
+
+/// \brief Get the schema for bound parameters.
+///
+/// This retrieves an Arrow schema describing the number, names, and
+/// types of the parameters in a parameterized statement.  The fields
+/// of the schema should be in order of the ordinal position of the
+/// parameters; named parameters should appear only once.
+///
+/// If the parameter does not have a name, or the name cannot be
+/// determined, the name of the corresponding field in the schema will
+/// be an empty string.  If the type cannot be determined, the type of
+/// the corresponding field will be NA (NullType).
+///
+/// This should be called after AdbcStatementPrepare.
+///
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the schema cannot be determined.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementGetParameterSchema(struct AdbcStatement* statement,
+                                               struct ArrowSchema* schema,
+                                               struct AdbcError* error);
+
+/// \brief Set a string option on a statement.
+/// \param[in] statement The statement.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementSetOption(struct AdbcStatement* statement, const char* key,
+                                      const char* value, struct AdbcError* error);
+
+/// \brief Set a bytestring option on a statement.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[in] length The option value length.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementSetOptionBytes(struct AdbcStatement* statement,
+                                           const char* key, const uint8_t* value,
+                                           size_t length, struct AdbcError* error);
+
+/// \brief Set an integer option on a statement.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementSetOptionInt(struct AdbcStatement* statement, const char* key,
+                                         int64_t value, struct AdbcError* error);
+
+/// \brief Set a double option on a statement.
+///
+/// \since ADBC API revision 1.1.0
+/// \param[in] statement The statement.
+/// \param[in] key The option to set.
+/// \param[in] value The option value.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the option is not recognized
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementSetOptionDouble(struct AdbcStatement* statement,
+                                            const char* key, double value,
+                                            struct AdbcError* error);
+
+/// \addtogroup adbc-statement-partition
+/// @{
+
+/// \brief Execute a statement and get the results as a partitioned
+///   result set.
+///
+/// \param[in] statement The statement to execute.
+/// \param[out] schema The schema of the result set.
+/// \param[out] partitions The result partitions.
+/// \param[out] rows_affected The number of rows affected if known,
+///   else -1. Pass NULL if the client does not want this information.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the driver does not support
+///   partitioned results
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementExecutePartitions(struct AdbcStatement* statement,
+                                              struct ArrowSchema* schema,
+                                              struct AdbcPartitions* partitions,
+                                              int64_t* rows_affected,
+                                              struct AdbcError* error);
+
+/// @}
+
+/// @}
+
+/// \addtogroup adbc-driver
+/// @{
+
+/// \brief Common entry point for drivers via the driver manager
+///   (which uses dlopen(3)/LoadLibrary). The driver manager is told
+///   to load a library and call a function of this type to load the
+///   driver.
+///
+/// Although drivers may choose any name for this function, the
+/// recommended name is "AdbcDriverInit", or a name derived from the
+/// name of the driver's shared library as follows: remove the 'lib'
+/// prefix (on Unix systems) and all file extensions, then PascalCase
+/// the driver name, append Init, and prepend Adbc (if not already
+/// there).  For example:
+///
+/// - libadbc_driver_sqlite.so.2.0.0 -> AdbcDriverSqliteInit
+/// - adbc_driver_sqlite.dll -> AdbcDriverSqliteInit
+/// - proprietary_driver.dll -> AdbcProprietaryDriverInit
+///
+/// \param[in] version The ADBC revision to attempt to initialize (see
+///   ADBC_VERSION_1_0_0).
+/// \param[out] driver The table of function pointers to
+///   initialize. Should be a pointer to the appropriate struct for
+///   the given version (see the documentation for the version).
+/// \param[out] error An optional location to return an error message
+///   if necessary.
+/// \return ADBC_STATUS_OK if the driver was initialized, or
+///   ADBC_STATUS_NOT_IMPLEMENTED if the version is not supported.  In
+///   that case, clients may retry with a different version.
+typedef AdbcStatusCode (*AdbcDriverInitFunc)(int version, void* driver,
+                                             struct AdbcError* error);
+
+/// @}
+
+#endif  // ADBC
+
+#ifdef __cplusplus
+}
+#endif

--- a/programs/local/chdb-adbc.cpp
+++ b/programs/local/chdb-adbc.cpp
@@ -1,0 +1,2415 @@
+/// ADBC driver entrypoint for libchdb: implements the AdbcDatabase /
+/// AdbcConnection / AdbcStatement contract on top of the public chdb C API,
+/// so the library itself is loadable by the standard driver managers
+/// (driver=<libchdb path>, entrypoint=chdb_adbc_init).
+///
+/// Results travel through the Arrow C Data Interface; bulk ingestion goes
+/// through chdb_arrow_scan + INSERT ... SELECT FROM arrowstream(...).
+///
+/// Result streams: the engine runs one statement at a time per connection,
+/// so any new operation invalidates the connection's outstanding streamed
+/// result (the stale reader fails with a clear error). Independent
+/// concurrent readers work over separate connections; note that session
+/// state (SET, temporary tables) is per-connection.
+///
+/// Tracking: chdb-io/chdb-core#122.
+
+#include "chdb.h"
+#include "chdb-internal.h"
+
+#include <Parsers/Lexer.h>
+
+#include <arrow/c/abi.h>
+
+#include "adbc/adbc.h"
+
+#include <arrow/array.h>
+#include <arrow/buffer.h>
+#include <arrow/builder.h>
+#include <arrow/c/bridge.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/record_batch.h>
+#include <arrow/scalar.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <arrow/util/config.h>
+
+#include <Common/config_version.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+/// ---------------------------------------------------------------------
+/// Error helpers
+/// ---------------------------------------------------------------------
+
+void releaseAdbcError(AdbcError * error)
+{
+    if (!error)
+        return;
+    delete[] error->message;
+    error->message = nullptr;
+    error->release = nullptr;
+}
+
+AdbcStatusCode setError(AdbcError * error, AdbcStatusCode code, const std::string & message)
+{
+    if (error)
+    {
+        if (error->release)
+            error->release(error);
+        error->message = new char[message.size() + 1];
+        std::memcpy(error->message, message.c_str(), message.size() + 1);
+        error->vendor_code = 0;
+        std::memset(error->sqlstate, 0, sizeof(error->sqlstate));
+        error->release = releaseAdbcError;
+    }
+    return code;
+}
+
+AdbcStatusCode notImplemented(AdbcError * error, const std::string & what)
+{
+    return setError(error, ADBC_STATUS_NOT_IMPLEMENTED, "[chdb] " + what + " is not implemented");
+}
+
+/// Engine errors name their ClickHouse error class, e.g. "... (UNKNOWN_TABLE)".
+/// The classes with a direct ADBC counterpart map to it so callers can act on
+/// the status code; everything else stays INTERNAL.
+AdbcStatusCode statusForEngineError(const std::string & message)
+{
+    /// ClickHouse names its error class in the message, e.g. "... (UNKNOWN_TABLE)".
+    /// The names are stable enum identifiers, so match them (a substring test
+    /// also tolerates the "(NAME)" wrapping). Classes with a direct ADBC
+    /// counterpart map to it; the rest stay INTERNAL.
+    auto has = [&](const char * name) { return message.find(name) != std::string::npos; };
+
+    if (has("UNKNOWN_TABLE") || has("UNKNOWN_DATABASE") || has("UNKNOWN_IDENTIFIER")
+        || has("UNKNOWN_FUNCTION") || has("UNKNOWN_SETTING") || has("FILE_DOESNT_EXIST"))
+        return ADBC_STATUS_NOT_FOUND;
+    if (has("TABLE_ALREADY_EXISTS") || has("DATABASE_ALREADY_EXISTS"))
+        return ADBC_STATUS_ALREADY_EXISTS;
+    if (has("SYNTAX_ERROR") || has("CANNOT_PARSE") || has("TYPE_MISMATCH")
+        || has("ILLEGAL_TYPE_OF_ARGUMENT") || has("NUMBER_OF_ARGUMENTS_DOESNT_MATCH")
+        || has("BAD_ARGUMENTS") || has("BAD_QUERY_PARAMETER") || has("VALUE_IS_OUT_OF_RANGE")
+        || has("ARGUMENT_OUT_OF_BOUND") || has("UNKNOWN_TYPE") || has("NO_COMMON_TYPE"))
+        return ADBC_STATUS_INVALID_ARGUMENT;
+    if (has("CANNOT_OPEN_FILE") || has("CANNOT_READ") || has("CANNOT_WRITE")
+        || has("NETWORK_ERROR") || has("SOCKET_TIMEOUT") || has("CANNOT_READ_FROM_SOCKET")
+        || has("CANNOT_WRITE_TO_SOCKET") || has("FILE_ALREADY_EXISTS"))
+        return ADBC_STATUS_IO;
+    if (has("NOT_IMPLEMENTED") || has("SUPPORT_IS_DISABLED"))
+        return ADBC_STATUS_NOT_IMPLEMENTED;
+    return ADBC_STATUS_INTERNAL;
+}
+
+/// ---------------------------------------------------------------------
+/// Private handle state
+/// ---------------------------------------------------------------------
+
+struct DatabaseImpl
+{
+    /// Database path (":memory:" by default) plus extra engine arguments
+    /// collected from "chdb."-prefixed options.
+    std::string path = ":memory:";
+    std::vector<std::string> extra_args;
+};
+
+struct StreamingResultState;
+
+struct ConnectionImpl
+{
+    /// Handle returned by chdb_connect(); the engine instance is shared,
+    /// ref-counted process state (one storage path per process).
+    chdb_connection * conn = nullptr;
+    /// Serializes statement execution on this connection.
+    std::mutex mutex;
+    /// The connection's outstanding streamed result, if any. The engine runs
+    /// one statement at a time per connection, so any new operation must
+    /// invalidate this first (see invalidateActiveStream).
+    std::mutex stream_mutex;
+    StreamingResultState * active_stream = nullptr;
+};
+
+std::atomic<uint64_t> statement_id_counter{1};
+
+struct StatementImpl
+{
+    ConnectionImpl * connection = nullptr;
+    /// Stable identity for stream-ownership checks. A raw StatementImpl* is
+    /// unsafe here: a released statement's address can be reused by a new
+    /// statement while the old stream is still live, causing a false match.
+    /// A monotonic id never collides. 0 is reserved for "not a statement".
+    const uint64_t id = statement_id_counter.fetch_add(1);
+    std::string query;
+    bool has_query = false;
+
+    /// Bulk ingestion state (ADBC_INGEST_OPTION_*).
+    std::string ingest_table;
+    std::string ingest_db_schema;
+    std::string ingest_mode = ADBC_INGEST_OPTION_MODE_CREATE;
+
+    /// Data bound via StatementBind / StatementBindStream, moved into the
+    /// statement (C Data Interface move semantics).
+    ArrowArrayStream bound_stream;
+    bool has_bound_stream = false;
+
+    void releaseBoundStream()
+    {
+        if (has_bound_stream && bound_stream.release)
+            bound_stream.release(&bound_stream);
+        has_bound_stream = false;
+        std::memset(&bound_stream, 0, sizeof(bound_stream));
+    }
+};
+
+std::atomic<uint64_t> ingest_name_counter{0};
+
+/// Streaming result adapter: exposes chdb's pull-one-batch streaming
+/// (chdb_stream_query_arrow + chdb_stream_fetch_arrow, where each fetch
+/// yields a single-batch ArrowArrayStream) as one continuous
+/// ArrowArrayStream, so large results never materialize in full.
+struct StreamingResultState
+{
+    ConnectionImpl * owner = nullptr;
+    /// Identity of the statement that produced this stream (compared, never
+    /// dereferenced). The spec lets the SAME statement's next Execute
+    /// invalidate its own prior result, but a DIFFERENT statement (or a
+    /// metadata call) must not silently invalidate it — see reclaimActiveStream.
+    /// Stored as the owning statement's monotonic id (0 = none), never a
+    /// pointer, so a reused statement address cannot cause a false match.
+    uint64_t owner_statement = 0;
+    chdb_connection conn = nullptr;
+    chdb_result * stream_result = nullptr;
+    std::shared_ptr<arrow::Schema> schema;
+    ArrowArray pending{};
+    bool has_pending = false;
+    bool exhausted = false;
+    /// Set when a subsequent statement on the same connection (or closing
+    /// the connection) takes over: the engine runs one statement at a time
+    /// per connection, so the older stream must stop touching it.
+    bool invalidated = false;
+    std::string last_error;
+    /// Guards all mutable members: get_next runs on the consumer's thread
+    /// while invalidation comes from the thread executing the next statement.
+    std::mutex mutex;
+
+    /// Caller holds `mutex`.
+    void releaseEngineStream()
+    {
+        if (stream_result)
+        {
+            if (!exhausted)
+                chdb_stream_cancel_query(conn, stream_result);
+            chdb_destroy_query_result(stream_result);
+            stream_result = nullptr;
+        }
+    }
+
+    ~StreamingResultState()
+    {
+        if (owner)
+        {
+            std::lock_guard reg(owner->stream_mutex);
+            if (owner->active_stream == this)
+                owner->active_stream = nullptr;
+        }
+        std::lock_guard guard(mutex);
+        if (has_pending && pending.release)
+            pending.release(&pending);
+        releaseEngineStream();
+    }
+};
+
+/// A new operation wants the connection, which runs one statement at a time.
+/// The ADBC concurrency spec offers three ways to handle an outstanding
+/// result stream: buffer it, execute concurrently, or error. chDB can do
+/// neither of the first two for a live stream, so it takes the error option —
+/// EXCEPT the spec also *requires* the same statement's next Execute to
+/// invalidate its own prior result. owner_for_reuse identifies the caller
+/// when it is that statement's Execute (nullptr for metadata calls and other
+/// statements, which may never reuse and so always get the error).
+///
+/// A stream that is already exhausted or invalidated is not "live": it is
+/// silently detached so ordinary sequential use is unaffected.
+[[nodiscard]] AdbcStatusCode reclaimActiveStream(
+    ConnectionImpl * connection, uint64_t owner_for_reuse, const char * reason, AdbcError * error)
+{
+    std::lock_guard reg(connection->stream_mutex);
+    auto * old = connection->active_stream;
+    if (!old)
+        return ADBC_STATUS_OK;
+    std::lock_guard guard(old->mutex);
+    const bool consumed = old->exhausted || old->invalidated;
+    if (!consumed && !(owner_for_reuse != 0 && old->owner_statement == owner_for_reuse))
+        return setError(
+            error,
+            ADBC_STATUS_INVALID_STATE,
+            "[chdb] another result stream is still open on this connection; release it "
+            "before running new operations (chDB executes one statement at a time per "
+            "connection)");
+    old->invalidated = true;
+    old->last_error = reason;
+    old->releaseEngineStream();
+    connection->active_stream = nullptr;
+    return ADBC_STATUS_OK;
+}
+
+constexpr const char * kStreamInvalidatedBySuccessor
+    = "[chdb] result stream invalidated by a subsequent statement on this connection";
+constexpr const char * kStreamInvalidatedByClose
+    = "[chdb] result stream invalidated: connection closed";
+
+/// ---------------------------------------------------------------------
+/// Small utilities
+/// ---------------------------------------------------------------------
+
+/// Decodes %XX escapes (RFC 3986); malformed escapes are kept verbatim.
+std::string percentDecode(const std::string & in)
+{
+    std::string out;
+    out.reserve(in.size());
+    for (size_t i = 0; i < in.size(); ++i)
+    {
+        if (in[i] == '%' && i + 2 < in.size() && std::isxdigit(in[i + 1]) && std::isxdigit(in[i + 2]))
+        {
+            out += static_cast<char>(std::stoi(in.substr(i + 1, 2), nullptr, 16));
+            i += 2;
+        }
+        else
+            out += in[i];
+    }
+    return out;
+}
+
+/// Quotes an identifier with backticks, ClickHouse-style.
+std::string quoteIdentifier(const std::string & name)
+{
+    std::string quoted = "`";
+    for (char c : name)
+    {
+        if (c == '`' || c == '\\')
+            quoted += '\\';
+        quoted += c;
+    }
+    quoted += '`';
+    return quoted;
+}
+
+/// Consumes a chdb_result: on error fills the AdbcError and returns a
+/// non-OK status; otherwise reports rows written through rows_affected.
+/// True when the first significant token is INSERT — the statement kind for
+/// which a rows_written of zero is a known count, not "not applicable".
+bool statementIsInsert(const std::string & sql)
+{
+    DB::Lexer lexer(sql.data(), sql.data() + sql.size());
+    auto t = lexer.nextToken();
+    while (t.type == DB::TokenType::Whitespace || t.type == DB::TokenType::Comment)
+        t = lexer.nextToken();
+    static constexpr char kw[] = "INSERT";
+    if (t.type != DB::TokenType::BareWord || t.end - t.begin != 6)
+        return false;
+    for (int i = 0; i < 6; ++i)
+        if (std::toupper(t.begin[i]) != kw[i])
+            return false;
+    return true;
+}
+
+/// zero_rows_known distinguishes a known count of zero (write statements)
+/// from "not applicable" (-1, e.g. DDL).
+AdbcStatusCode consumeResult(
+    chdb_result * result, int64_t * rows_affected, AdbcError * error, bool zero_rows_known = false)
+{
+    if (!result)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] query returned no result handle");
+
+    const char * err = chdb_result_error(result);
+    if (err)
+    {
+        std::string message(err);
+        chdb_destroy_query_result(result);
+        return setError(error, statusForEngineError(message), "[chdb] " + message);
+    }
+
+    if (rows_affected)
+    {
+        uint64_t written = chdb_result_rows_written(result);
+        *rows_affected = (written > 0 || zero_rows_known) ? static_cast<int64_t>(written) : -1;
+    }
+    chdb_destroy_query_result(result);
+    return ADBC_STATUS_OK;
+}
+
+/// Runs a query whose output is discarded (DDL / INSERT ... SELECT).
+/// zero_rows_known_override marks callers that know the statement writes
+/// (bulk ingestion) even when it doesn't start with INSERT.
+AdbcStatusCode runUpdateQuery(
+    ConnectionImpl * connection,
+    const std::string & sql,
+    int64_t * rows_affected,
+    AdbcError * error,
+    bool zero_rows_known_override = false)
+{
+    chdb_result * result = chdb_query_n(*connection->conn, sql.c_str(), sql.size(), "Null", 4);
+    return consumeResult(result, rows_affected, error, zero_rows_known_override || statementIsInsert(sql));
+}
+
+/// Runs a scalar query and returns the first line of CSV output.
+AdbcStatusCode runScalarQuery(
+    ConnectionImpl * connection, const std::string & sql, std::string & value, AdbcError * error)
+{
+    chdb_result * result = chdb_query_n(*connection->conn, sql.c_str(), sql.size(), "CSV", 3);
+    if (!result)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] query returned no result handle");
+    const char * err = chdb_result_error(result);
+    if (err)
+    {
+        std::string message(err);
+        chdb_destroy_query_result(result);
+        return setError(error, statusForEngineError(message), "[chdb] " + message);
+    }
+    value.assign(chdb_result_buffer(result), chdb_result_length(result));
+    while (!value.empty() && (value.back() == '\n' || value.back() == '\r'))
+        value.pop_back();
+    chdb_destroy_query_result(result);
+    return ADBC_STATUS_OK;
+}
+
+/// Exports record batches as an ArrowArrayStream via arrow C++.
+AdbcStatusCode exportBatch(
+    const std::shared_ptr<arrow::Schema> & schema,
+    const std::shared_ptr<arrow::RecordBatch> & batch,
+    ArrowArrayStream * out,
+    AdbcError * error)
+{
+    auto reader_result = arrow::RecordBatchReader::Make({batch}, schema);
+    if (!reader_result.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + reader_result.status().ToString());
+    auto status = arrow::ExportRecordBatchReader(reader_result.ValueUnsafe(), out);
+    if (!status.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + status.ToString());
+    return ADBC_STATUS_OK;
+}
+
+/// Quotes a string as a ClickHouse SQL string literal.
+std::string quoteStringLiteral(const std::string & value)
+{
+    std::string quoted = "'";
+    for (char c : value)
+    {
+        if (c == '\'' || c == '\\')
+            quoted += '\\';
+        quoted += c;
+    }
+    quoted += '\'';
+    return quoted;
+}
+
+/// Finds `?` placeholders through the engine's own lexer, so every literal
+/// form the dialect knows (strings, quoted identifiers, comments, heredocs)
+/// is handled by construction and stays in step with the dialect.
+std::vector<size_t> findPlaceholders(const std::string & sql)
+{
+    std::vector<size_t> positions;
+    DB::Lexer lexer(sql.data(), sql.data() + sql.size());
+    for (auto token = lexer.nextToken(); !token.isEnd(); token = lexer.nextToken())
+    {
+        if (token.isError())
+            break; /// the engine reports malformed SQL at execution
+        if (token.type == DB::TokenType::QuestionMark)
+            positions.push_back(static_cast<size_t>(token.begin - sql.data()));
+    }
+    return positions;
+}
+
+/// Matches the exact shape `INSERT INTO [db.]table [(col, ...)] VALUES
+/// (?, ...)` on the engine's token stream. On match, head_out is the SQL
+/// up to (excluding) VALUES — quoting preserved verbatim — and
+/// placeholder_count the arity, so executemany can stream all bound rows
+/// through one INSERT ... SELECT instead of one parse/execute per row.
+bool matchPlainInsertShape(const std::string & sql, std::string & head_out, size_t & placeholder_count)
+{
+    DB::Lexer lexer(sql.data(), sql.data() + sql.size());
+    auto next = [&]() -> DB::Token
+    {
+        auto t = lexer.nextToken();
+        while (t.type == DB::TokenType::Whitespace || t.type == DB::TokenType::Comment)
+            t = lexer.nextToken();
+        return t;
+    };
+    auto is_keyword = [&](const DB::Token & t, const char * kw)
+    {
+        if (t.type != DB::TokenType::BareWord)
+            return false;
+        const size_t len = std::strlen(kw);
+        if (static_cast<size_t>(t.end - t.begin) != len)
+            return false;
+        for (size_t i = 0; i < len; ++i)
+            if (std::toupper(t.begin[i]) != kw[i])
+                return false;
+        return true;
+    };
+    auto is_ident = [](const DB::Token & t)
+    { return t.type == DB::TokenType::BareWord || t.type == DB::TokenType::QuotedIdentifier; };
+
+    if (!is_keyword(next(), "INSERT") || !is_keyword(next(), "INTO"))
+        return false;
+    if (!is_ident(next()))
+        return false;
+    auto t = next();
+    if (t.type == DB::TokenType::Dot)
+    {
+        if (!is_ident(next()))
+            return false;
+        t = next();
+    }
+    if (t.type == DB::TokenType::OpeningRoundBracket)
+    {
+        /// column list: idents separated by commas
+        for (;;)
+        {
+            if (!is_ident(next()))
+                return false;
+            auto sep = next();
+            if (sep.type == DB::TokenType::ClosingRoundBracket)
+                break;
+            if (sep.type != DB::TokenType::Comma)
+                return false;
+        }
+        t = next();
+    }
+    if (!is_keyword(t, "VALUES"))
+        return false;
+    head_out.assign(sql.data(), static_cast<size_t>(t.begin - sql.data()));
+    if (next().type != DB::TokenType::OpeningRoundBracket)
+        return false;
+    placeholder_count = 0;
+    for (;;)
+    {
+        if (next().type != DB::TokenType::QuestionMark)
+            return false;
+        ++placeholder_count;
+        auto sep = next();
+        if (sep.type == DB::TokenType::ClosingRoundBracket)
+            break;
+        if (sep.type != DB::TokenType::Comma)
+            return false;
+    }
+    t = next();
+    if (t.type == DB::TokenType::Semicolon)
+        t = next();
+    return t.isEnd();
+}
+
+/// Maps an Arrow type to the ClickHouse type name used in a {name:Type}
+/// placeholder.
+AdbcStatusCode clickhouseTypeFor(
+    const std::shared_ptr<arrow::DataType> & type, std::string & out, AdbcError * error)
+{
+    switch (type->id())
+    {
+        case arrow::Type::BOOL: out = "Bool"; return ADBC_STATUS_OK;
+        case arrow::Type::INT8: out = "Int8"; return ADBC_STATUS_OK;
+        case arrow::Type::INT16: out = "Int16"; return ADBC_STATUS_OK;
+        case arrow::Type::INT32: out = "Int32"; return ADBC_STATUS_OK;
+        case arrow::Type::INT64: out = "Int64"; return ADBC_STATUS_OK;
+        case arrow::Type::UINT8: out = "UInt8"; return ADBC_STATUS_OK;
+        case arrow::Type::UINT16: out = "UInt16"; return ADBC_STATUS_OK;
+        case arrow::Type::UINT32: out = "UInt32"; return ADBC_STATUS_OK;
+        case arrow::Type::UINT64: out = "UInt64"; return ADBC_STATUS_OK;
+        case arrow::Type::FLOAT: out = "Float32"; return ADBC_STATUS_OK;
+        case arrow::Type::DOUBLE: out = "Float64"; return ADBC_STATUS_OK;
+        case arrow::Type::STRING:
+        case arrow::Type::LARGE_STRING:
+        case arrow::Type::BINARY:
+        case arrow::Type::LARGE_BINARY:
+        case arrow::Type::FIXED_SIZE_BINARY: out = "String"; return ADBC_STATUS_OK;
+        /// All-null columns arrive as Arrow's null type; the values are
+        /// rewritten to literal NULLs, so the placeholder type is moot.
+        case arrow::Type::NA: out = "Nullable(String)"; return ADBC_STATUS_OK;
+        case arrow::Type::DATE32: out = "Date32"; return ADBC_STATUS_OK;
+        case arrow::Type::DATE64: out = "DateTime64(3)"; return ADBC_STATUS_OK;
+        case arrow::Type::TIMESTAMP:
+        {
+            const auto & ts = static_cast<const arrow::TimestampType &>(*type);
+            int scale = 0;
+            switch (ts.unit())
+            {
+                case arrow::TimeUnit::SECOND: scale = 0; break;
+                case arrow::TimeUnit::MILLI: scale = 3; break;
+                case arrow::TimeUnit::MICRO: scale = 6; break;
+                case arrow::TimeUnit::NANO: scale = 9; break;
+            }
+            out = "DateTime64(" + std::to_string(scale);
+            if (!ts.timezone().empty())
+                out += ", " + quoteStringLiteral(ts.timezone());
+            out += ")";
+            return ADBC_STATUS_OK;
+        }
+        case arrow::Type::DECIMAL128:
+        {
+            const auto & dec = static_cast<const arrow::Decimal128Type &>(*type);
+            out = "Decimal(" + std::to_string(dec.precision()) + ", " + std::to_string(dec.scale()) + ")";
+            return ADBC_STATUS_OK;
+        }
+        default:
+            return setError(
+                error,
+                ADBC_STATUS_NOT_IMPLEMENTED,
+                "[chdb] binding parameters of Arrow type " + type->ToString() + " is not implemented");
+    }
+}
+
+/// Textual parameter value for a non-null Arrow scalar, as consumed by the
+/// engine's {name:Type} parser. The engine reads parameter values as escaped
+/// text: an unescaped tab or newline terminates the value mid-parse, and a
+/// bare \N reads as NULL — so string/binary payloads must be escaped or they
+/// error out (or worse, silently change value).
+std::string scalarToParamString(const std::shared_ptr<arrow::Scalar> & scalar)
+{
+    switch (scalar->type->id())
+    {
+        case arrow::Type::STRING:
+        case arrow::Type::LARGE_STRING:
+        case arrow::Type::BINARY:
+        case arrow::Type::LARGE_BINARY:
+        case arrow::Type::FIXED_SIZE_BINARY:
+        {
+            const auto & binary = static_cast<const arrow::BaseBinaryScalar &>(*scalar);
+            const std::string raw = binary.value->ToString();
+            std::string escaped;
+            escaped.reserve(raw.size());
+            for (char c : raw)
+            {
+                switch (c)
+                {
+                    case '\\':
+                        escaped += "\\\\";
+                        break;
+                    case '\t':
+                        escaped += "\\t";
+                        break;
+                    case '\n':
+                        escaped += "\\n";
+                        break;
+                    case '\r':
+                        escaped += "\\r";
+                        break;
+                    case '\0':
+                        escaped += "\\0";
+                        break;
+                    default:
+                        escaped += c;
+                }
+            }
+            return escaped;
+        }
+        default:
+            return scalar->ToString();
+    }
+}
+
+/// Wraps a chdb_result buffer as an arrow::Buffer, tying the result's
+/// lifetime to the buffer (used for zero-copy IPC import).
+class ChdbResultBuffer : public arrow::Buffer
+{
+public:
+    explicit ChdbResultBuffer(chdb_result * result)
+        : arrow::Buffer(
+              reinterpret_cast<const uint8_t *>(chdb_result_buffer(result)),
+              static_cast<int64_t>(chdb_result_length(result)))
+        , result_(result)
+    {
+    }
+    ~ChdbResultBuffer() override { chdb_destroy_query_result(result_); }
+
+private:
+    chdb_result * result_;
+};
+
+/// Exposes an ArrowStream-format (IPC) chdb_result through the caller's
+/// ArrowArrayStream. Takes ownership of the result.
+AdbcStatusCode exportIpcResult(chdb_result * result, ArrowArrayStream * out, AdbcError * error)
+{
+    if (!result)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] query returned no result handle");
+    const char * err = chdb_result_error(result);
+    if (err)
+    {
+        std::string message(err);
+        chdb_destroy_query_result(result);
+        return setError(error, statusForEngineError(message), "[chdb] " + message);
+    }
+    if (chdb_result_length(result) == 0)
+    {
+        /// No result bytes: a statement without a result set (DDL, ...) —
+        /// hand back an empty zero-column stream instead of failing to
+        /// parse an empty IPC payload.
+        chdb_destroy_query_result(result);
+        auto schema = arrow::schema(arrow::FieldVector{});
+        auto batch = arrow::RecordBatch::Make(schema, 0, std::vector<std::shared_ptr<arrow::Array>>{});
+        return exportBatch(schema, batch, out, error);
+    }
+    auto buffer = std::make_shared<ChdbResultBuffer>(result);
+    auto reader = arrow::ipc::RecordBatchStreamReader::Open(std::make_shared<arrow::io::BufferReader>(buffer));
+    if (!reader.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + reader.status().ToString());
+    auto status = arrow::ExportRecordBatchReader(reader.ValueUnsafe(), out);
+    if (!status.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + status.ToString());
+    return ADBC_STATUS_OK;
+}
+
+/// Materializes an IPC result's batches (the batches keep the underlying
+/// chdb buffer alive through their shared_ptr chain). A result without bytes
+/// contributes nothing: the statement executed but had no result set.
+AdbcStatusCode ipcResultToBatches(
+    chdb_result * result,
+    std::shared_ptr<arrow::Schema> & schema,
+    std::vector<std::shared_ptr<arrow::RecordBatch>> & batches,
+    AdbcError * error)
+{
+    if (!result)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] query returned no result handle");
+    const char * err = chdb_result_error(result);
+    if (err)
+    {
+        std::string message(err);
+        chdb_destroy_query_result(result);
+        return setError(error, statusForEngineError(message), "[chdb] " + message);
+    }
+    if (chdb_result_length(result) == 0)
+    {
+        chdb_destroy_query_result(result);
+        return ADBC_STATUS_OK;
+    }
+    auto buffer = std::make_shared<ChdbResultBuffer>(result);
+    auto reader = arrow::ipc::RecordBatchStreamReader::Open(std::make_shared<arrow::io::BufferReader>(buffer));
+    if (!reader.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + reader.status().ToString());
+    if (!schema)
+        schema = reader.ValueUnsafe()->schema();
+    while (true)
+    {
+        auto next = reader.ValueUnsafe()->Next();
+        if (!next.ok())
+            return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + next.status().ToString());
+        if (!next.ValueUnsafe())
+            break;
+        batches.push_back(next.ValueUnsafe());
+    }
+    return ADBC_STATUS_OK;
+}
+
+/// Runs a query through the Arrow C Data output path and materializes the
+/// result as a single-chunk arrow::Table.
+AdbcStatusCode queryToTable(
+    ConnectionImpl * connection, const std::string & sql, std::shared_ptr<arrow::Table> & table, AdbcError * error)
+{
+    /// Metadata helper: never a statement reuse, so a live stream is rejected.
+    if (AdbcStatusCode s = reclaimActiveStream(connection, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+        s != ADBC_STATUS_OK)
+        return s;
+    ArrowArrayStream stream;
+    std::memset(&stream, 0, sizeof(stream));
+    chdb_result * result = chdb_query_arrow_n(
+        *connection->conn, sql.c_str(), sql.size(), reinterpret_cast<chdb_arrow_stream>(&stream), nullptr);
+    AdbcStatusCode status = consumeResult(result, nullptr, error);
+    if (status != ADBC_STATUS_OK)
+    {
+        if (stream.release)
+            stream.release(&stream);
+        return status;
+    }
+    auto reader = arrow::ImportRecordBatchReader(&stream);
+    if (!reader.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + reader.status().ToString());
+    auto table_result = reader.ValueUnsafe()->ToTable();
+    if (!table_result.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + table_result.status().ToString());
+    auto combined = table_result.ValueUnsafe()->CombineChunks();
+    if (!combined.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + combined.status().ToString());
+    table = combined.ValueUnsafe();
+    return ADBC_STATUS_OK;
+}
+
+/// Name-based, type-checked column access: drift in a metadata SELECT list
+/// or in the engine's Arrow output surfaces as INTERNAL instead of undefined
+/// behavior from a blind positional cast.
+template <typename ArrayType>
+AdbcStatusCode getTypedColumn(
+    const std::shared_ptr<arrow::Table> & table,
+    const std::string & name,
+    arrow::Type::type expected,
+    std::shared_ptr<ArrayType> & out,
+    AdbcError * error)
+{
+    auto column = table->GetColumnByName(name);
+    if (!column || column->num_chunks() != 1)
+        return setError(
+            error, ADBC_STATUS_INTERNAL, "[chdb] metadata query result is missing column '" + name + "'");
+    if (column->chunk(0)->type_id() != expected)
+        return setError(
+            error,
+            ADBC_STATUS_INTERNAL,
+            "[chdb] metadata column '" + name + "' has unexpected Arrow type "
+                + column->chunk(0)->type()->ToString());
+    out = std::static_pointer_cast<ArrayType>(column->chunk(0));
+    return ADBC_STATUS_OK;
+}
+
+/// Resolves a struct child builder by field name with a type check, so the
+/// population code cannot silently misalign if the schema definition above
+/// is reordered or extended.
+template <typename BuilderType>
+AdbcStatusCode getFieldBuilder(
+    arrow::StructBuilder * parent,
+    const char * field_name,
+    arrow::Type::type expected,
+    BuilderType *& out,
+    int * index_out,
+    AdbcError * error)
+{
+    auto struct_type = std::static_pointer_cast<arrow::StructType>(parent->type());
+    const int index = struct_type->GetFieldIndex(field_name);
+    if (index < 0 || parent->field_builder(index)->type()->id() != expected)
+        return setError(
+            error,
+            ADBC_STATUS_INTERNAL,
+            std::string("[chdb] GetObjects result schema is missing field '") + field_name + "'");
+    out = static_cast<BuilderType *>(parent->field_builder(index));
+    if (index_out)
+        *index_out = index;
+    return ADBC_STATUS_OK;
+}
+
+/// ---------------------------------------------------------------------
+/// Database functions
+/// ---------------------------------------------------------------------
+
+AdbcStatusCode chdbDatabaseNew(AdbcDatabase * database, AdbcError * error)
+{
+    if (!database)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] database is null");
+    database->private_data = new DatabaseImpl();
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbDatabaseSetOption(
+    AdbcDatabase * database, const char * key, const char * value, AdbcError * error)
+{
+    if (!database || !database->private_data || !key)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] database is not allocated");
+    auto * impl = static_cast<DatabaseImpl *>(database->private_data);
+
+    std::string option(key);
+    std::string option_value(value ? value : "");
+    /// "path" and "uri" are aliases; the last one set wins. The uri form
+    /// accepts the file scheme per RFC 8089: file:name, file:/abs,
+    /// file:///abs and file://localhost/abs, with %XX percent-decoding.
+    if (option == "path" || option == "uri")
+    {
+        if (option_value.rfind("file:", 0) == 0)
+        {
+            std::string rest = option_value.substr(5);
+            if (rest.rfind("//", 0) == 0)
+            {
+                rest = rest.substr(2);
+                const auto slash = rest.find('/');
+                const std::string authority = slash == std::string::npos ? rest : rest.substr(0, slash);
+                if (!authority.empty() && authority != "localhost")
+                    return setError(
+                        error, ADBC_STATUS_INVALID_ARGUMENT,
+                        "[chdb] unsupported file URI authority '" + authority + "'");
+                rest = slash == std::string::npos ? "" : rest.substr(slash);
+            }
+            option_value = percentDecode(rest);
+        }
+        else if (option == "uri" && option_value.find("://") != std::string::npos)
+            return notImplemented(error, "URI scheme other than file");
+        impl->path = option_value.empty() ? ":memory:" : option_value;
+        return ADBC_STATUS_OK;
+    }
+    /// "chdb.<flag>" passes through as an engine argument "--<flag>=<value>".
+    constexpr const char * chdb_prefix = "chdb.";
+    if (option.rfind(chdb_prefix, 0) == 0)
+    {
+        impl->extra_args.push_back("--" + option.substr(std::strlen(chdb_prefix)) + "=" + option_value);
+        return ADBC_STATUS_OK;
+    }
+    return notImplemented(error, "database option '" + option + "'");
+}
+
+AdbcStatusCode chdbDatabaseInit(AdbcDatabase * database, AdbcError * error)
+{
+    if (!database || !database->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] database is not allocated");
+    /// Engine startup is deferred to ConnectionInit (chdb_connect).
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbDatabaseRelease(AdbcDatabase * database, AdbcError * error)
+{
+    if (!database || !database->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] database is not allocated");
+    delete static_cast<DatabaseImpl *>(database->private_data);
+    database->private_data = nullptr;
+    return ADBC_STATUS_OK;
+}
+
+/// ---------------------------------------------------------------------
+/// Connection functions
+/// ---------------------------------------------------------------------
+
+AdbcStatusCode chdbConnectionNew(AdbcConnection * connection, AdbcError * error)
+{
+    if (!connection)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] connection is null");
+    connection->private_data = new ConnectionImpl();
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbConnectionSetOption(
+    AdbcConnection * connection, const char * key, const char * value, AdbcError * error)
+{
+    if (!connection || !connection->private_data || !key)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not allocated");
+    if (std::strcmp(key, ADBC_CONNECTION_OPTION_AUTOCOMMIT) == 0)
+    {
+        if (value && std::strcmp(value, ADBC_OPTION_VALUE_ENABLED) == 0)
+            return ADBC_STATUS_OK; /// autocommit is the only supported mode
+        return notImplemented(error, "disabling autocommit (ClickHouse has no classic transactions)");
+    }
+    return notImplemented(error, std::string("connection option '") + key + "'");
+}
+
+AdbcStatusCode chdbConnectionInit(
+    AdbcConnection * connection, AdbcDatabase * database, AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not allocated");
+    if (!database || !database->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] database is not initialized");
+
+    auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+    auto * db = static_cast<DatabaseImpl *>(database->private_data);
+
+    /// ":memory:" is the engine default and must NOT be passed as --path:
+    /// an explicit --path value is treated as a directory name literally.
+    std::vector<std::string> args = {"chdb"};
+    if (db->path != ":memory:")
+        args.push_back("--path=" + db->path);
+    args.insert(args.end(), db->extra_args.begin(), db->extra_args.end());
+    std::vector<char *> argv;
+    argv.reserve(args.size());
+    for (auto & arg : args)
+        argv.push_back(arg.data());
+
+    impl->conn = chdb_connect(static_cast<int>(argv.size()), argv.data());
+    if (!impl->conn)
+        return setError(
+            error,
+            ADBC_STATUS_IO,
+            "[chdb] chdb_connect failed for path '" + db->path
+                + "' (note: all connections in a process must share one storage path)");
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbConnectionRelease(AdbcConnection * connection, AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not allocated");
+    auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+    /// Defensive: an outstanding stream must release the engine before the
+    /// connection closes and stop pointing at the impl we delete below.
+    {
+        std::lock_guard reg(impl->stream_mutex);
+        if (auto * s = impl->active_stream)
+        {
+            std::lock_guard guard(s->mutex);
+            s->invalidated = true;
+            s->last_error = kStreamInvalidatedByClose;
+            s->releaseEngineStream();
+            s->owner = nullptr;
+            impl->active_stream = nullptr;
+        }
+    }
+    if (impl->conn)
+        chdb_close_conn(impl->conn);
+    delete impl;
+    connection->private_data = nullptr;
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbConnectionCommit(AdbcConnection *, AdbcError * error)
+{
+    return setError(
+        error, ADBC_STATUS_INVALID_STATE, "[chdb] no active transaction: connections are autocommit-only");
+}
+
+AdbcStatusCode chdbConnectionRollback(AdbcConnection *, AdbcError * error)
+{
+    return setError(
+        error, ADBC_STATUS_INVALID_STATE, "[chdb] no active transaction: connections are autocommit-only");
+}
+
+AdbcStatusCode chdbConnectionGetOption(
+    AdbcConnection * connection, const char * key, char * value, size_t * length, AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!key || !length)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] key/length is null");
+    auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+    if (!impl->conn)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+
+    if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0)
+    {
+        std::string current;
+        {
+            std::lock_guard lock(impl->mutex);
+            /// Metadata read: reject (don't silently kill) a live stream.
+            if (AdbcStatusCode s = reclaimActiveStream(impl, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+                s != ADBC_STATUS_OK)
+                return s;
+            AdbcStatusCode status = runScalarQuery(impl, "SELECT currentDatabase()", current, error);
+            if (status != ADBC_STATUS_OK)
+                return status;
+        }
+        /// The scalar helper hands back a CSV cell: strip the quoting.
+        if (current.size() >= 2 && current.front() == '"' && current.back() == '"')
+        {
+            current = current.substr(1, current.size() - 2);
+            size_t pos = 0;
+            while ((pos = current.find("\"\"", pos)) != std::string::npos)
+            {
+                current.erase(pos, 1);
+                ++pos;
+            }
+        }
+        /// Standard get-option contract: report the required size (with NUL)
+        /// and copy only when the caller's buffer already fits it.
+        const size_t needed = current.size() + 1;
+        if (value && *length >= needed)
+            std::memcpy(value, current.c_str(), needed);
+        *length = needed;
+        return ADBC_STATUS_OK;
+    }
+    return setError(error, ADBC_STATUS_NOT_FOUND, "[chdb] unknown connection option '" + std::string(key) + "'");
+}
+
+AdbcStatusCode chdbConnectionGetInfo(
+    AdbcConnection * connection,
+    const uint32_t * info_codes,
+    size_t info_codes_length,
+    ArrowArrayStream * out,
+    AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!out)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] out stream is null");
+
+    enum class InfoKind
+    {
+        String,
+        Int64,
+        Bool
+    };
+    struct InfoValue
+    {
+        uint32_t code;
+        InfoKind kind;
+        std::string string_value;
+        int64_t int_value;
+        bool bool_value;
+    };
+    /// The driver ships with the engine, so its version is the engine's
+    /// major.minor.patch (a semver-shaped string, unlike the four-component
+    /// VERSION_STRING reported as the vendor version).
+    const std::string driver_version = std::to_string(VERSION_MAJOR) + "." + std::to_string(VERSION_MINOR) + "."
+        + std::to_string(VERSION_PATCH);
+    std::vector<InfoValue> all = {
+        {ADBC_INFO_VENDOR_NAME, InfoKind::String, "ClickHouse", 0, false},
+        {ADBC_INFO_VENDOR_VERSION, InfoKind::String, VERSION_STRING, 0, false},
+        {ADBC_INFO_VENDOR_ARROW_VERSION, InfoKind::String, "v" ARROW_VERSION_STRING, 0, false},
+        {ADBC_INFO_VENDOR_SQL, InfoKind::Bool, "", 0, true},
+        {ADBC_INFO_VENDOR_SUBSTRAIT, InfoKind::Bool, "", 0, false},
+        {ADBC_INFO_DRIVER_NAME, InfoKind::String, "ADBC chDB Driver", 0, false},
+        {ADBC_INFO_DRIVER_VERSION, InfoKind::String, driver_version, 0, false},
+        {ADBC_INFO_DRIVER_ARROW_VERSION, InfoKind::String, "v" ARROW_VERSION_STRING, 0, false},
+        {ADBC_INFO_DRIVER_ADBC_VERSION, InfoKind::Int64, "", ADBC_VERSION_1_1_0, false},
+    };
+
+    std::vector<InfoValue> selected;
+    if (!info_codes)
+        selected = all;
+    else
+        for (size_t i = 0; i < info_codes_length; ++i)
+            for (const auto & info : all)
+                if (info.code == info_codes[i])
+                    selected.push_back(info);
+
+    /// Result schema mandated by the ADBC spec: info_name uint32 not null,
+    /// info_value dense_union<string_value, bool_value, int64_value,
+    /// int32_bitmask, string_list, int32_to_int32_list_map>.
+    arrow::UInt32Builder name_builder;
+    auto string_builder = std::make_shared<arrow::StringBuilder>();
+    auto bool_builder = std::make_shared<arrow::BooleanBuilder>();
+    auto int64_builder = std::make_shared<arrow::Int64Builder>();
+    auto bitmask_builder = std::make_shared<arrow::Int32Builder>();
+    auto list_builder = std::make_shared<arrow::ListBuilder>(
+        arrow::default_memory_pool(), std::make_shared<arrow::StringBuilder>());
+    auto map_builder = std::make_shared<arrow::MapBuilder>(
+        arrow::default_memory_pool(),
+        std::make_shared<arrow::Int32Builder>(),
+        std::make_shared<arrow::ListBuilder>(
+            arrow::default_memory_pool(), std::make_shared<arrow::Int32Builder>()));
+
+    arrow::DenseUnionBuilder value_builder(arrow::default_memory_pool());
+    const int8_t string_code = value_builder.AppendChild(string_builder, "string_value");
+    const int8_t bool_code = value_builder.AppendChild(bool_builder, "bool_value");
+    const int8_t int64_code = value_builder.AppendChild(int64_builder, "int64_value");
+    value_builder.AppendChild(bitmask_builder, "int32_bitmask");
+    value_builder.AppendChild(list_builder, "string_list");
+    value_builder.AppendChild(map_builder, "int32_to_int32_list_map");
+
+    auto check = [&](const arrow::Status & status) { return status.ok(); };
+    for (const auto & info : selected)
+    {
+        if (!check(name_builder.Append(info.code)))
+            return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to build GetInfo result");
+        bool ok = false;
+        switch (info.kind)
+        {
+            case InfoKind::String:
+                ok = check(value_builder.Append(string_code)) && check(string_builder->Append(info.string_value));
+                break;
+            case InfoKind::Bool:
+                ok = check(value_builder.Append(bool_code)) && check(bool_builder->Append(info.bool_value));
+                break;
+            case InfoKind::Int64:
+                ok = check(value_builder.Append(int64_code)) && check(int64_builder->Append(info.int_value));
+                break;
+        }
+        if (!ok)
+            return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to build GetInfo result");
+    }
+
+    std::shared_ptr<arrow::Array> names;
+    std::shared_ptr<arrow::Array> values;
+    if (!check(name_builder.Finish(&names)) || !check(value_builder.Finish(&values)))
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to build GetInfo result");
+
+    auto schema = arrow::schema(
+        {arrow::field("info_name", arrow::uint32(), /*nullable=*/false),
+         arrow::field("info_value", values->type())});
+    auto batch = arrow::RecordBatch::Make(schema, names->length(), {names, values});
+    return exportBatch(schema, batch, out, error);
+}
+
+/// Spec-mandated nested schema for GetObjects results. chDB has no catalog
+/// concept, so everything lives under a single NULL catalog with ClickHouse
+/// databases as db_schemas (matching GetTableSchema's db_schema semantics).
+std::shared_ptr<arrow::DataType> getObjectsDbSchemaType()
+{
+    auto usage_type = arrow::struct_(
+        {arrow::field("fk_catalog", arrow::utf8()),
+         arrow::field("fk_db_schema", arrow::utf8()),
+         arrow::field("fk_table", arrow::utf8(), /*nullable=*/false),
+         arrow::field("fk_column_name", arrow::utf8(), /*nullable=*/false)});
+    auto constraint_type = arrow::struct_(
+        {arrow::field("constraint_name", arrow::utf8()),
+         arrow::field("constraint_type", arrow::utf8(), /*nullable=*/false),
+         arrow::field("constraint_column_names", arrow::list(arrow::utf8()), /*nullable=*/false),
+         arrow::field("constraint_column_usage", arrow::list(usage_type))});
+    auto column_type = arrow::struct_(
+        {arrow::field("column_name", arrow::utf8(), /*nullable=*/false),
+         arrow::field("ordinal_position", arrow::int32()),
+         arrow::field("remarks", arrow::utf8()),
+         arrow::field("xdbc_data_type", arrow::int16()),
+         arrow::field("xdbc_type_name", arrow::utf8()),
+         arrow::field("xdbc_column_size", arrow::int32()),
+         arrow::field("xdbc_decimal_digits", arrow::int16()),
+         arrow::field("xdbc_num_prec_radix", arrow::int16()),
+         arrow::field("xdbc_nullable", arrow::int16()),
+         arrow::field("xdbc_column_def", arrow::utf8()),
+         arrow::field("xdbc_sql_data_type", arrow::int16()),
+         arrow::field("xdbc_datetime_sub", arrow::int16()),
+         arrow::field("xdbc_char_octet_length", arrow::int32()),
+         arrow::field("xdbc_is_nullable", arrow::utf8()),
+         arrow::field("xdbc_scope_catalog", arrow::utf8()),
+         arrow::field("xdbc_scope_schema", arrow::utf8()),
+         arrow::field("xdbc_scope_table", arrow::utf8()),
+         arrow::field("xdbc_is_autoincrement", arrow::boolean()),
+         arrow::field("xdbc_is_generatedcolumn", arrow::boolean())});
+    auto table_type = arrow::struct_(
+        {arrow::field("table_name", arrow::utf8(), /*nullable=*/false),
+         arrow::field("table_type", arrow::utf8(), /*nullable=*/false),
+         arrow::field("table_columns", arrow::list(column_type)),
+         arrow::field("table_constraints", arrow::list(constraint_type))});
+    return arrow::struct_(
+        {arrow::field("db_schema_name", arrow::utf8()),
+         arrow::field("db_schema_tables", arrow::list(table_type))});
+}
+
+AdbcStatusCode chdbConnectionGetObjects(
+    AdbcConnection * connection,
+    int depth,
+    const char * catalog,
+    const char * db_schema,
+    const char * table_name,
+    const char ** table_type,
+    const char * column_name,
+    ArrowArrayStream * out,
+    AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+    if (!impl->conn)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!out)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] out stream is null");
+
+    /// Requested table types ("BASE TABLE" / "VIEW"); NULL means all.
+    bool want_base = true;
+    bool want_view = true;
+    if (table_type)
+    {
+        want_base = want_view = false;
+        for (const char ** t = table_type; *t; ++t)
+        {
+            if (std::strcmp(*t, "BASE TABLE") == 0)
+                want_base = true;
+            else if (std::strcmp(*t, "VIEW") == 0)
+                want_view = true;
+        }
+    }
+
+    /// Everything lives under one NULL catalog: a non-empty catalog filter
+    /// other than the match-all pattern selects nothing.
+    /// Our objects carry no catalog: NULL, "" ("objects without a catalog",
+    /// per spec) and the match-all pattern select them; anything else
+    /// selects nothing — zero result rows. An empty db_schema filter means
+    /// "objects without a database schema", which never matches here.
+    const bool catalog_matches = !catalog || !*catalog || std::strcmp(catalog, "%") == 0;
+    const bool schema_filter_excludes_all = db_schema && !*db_schema;
+
+    struct ColumnInfo
+    {
+        std::string name;
+        int32_t position;
+        std::string type;
+        std::string comment;
+    };
+    struct TableInfo
+    {
+        std::string name;
+        std::string type;
+        std::vector<ColumnInfo> columns;
+    };
+    /// databases in deterministic order + per-database tables
+    std::vector<std::string> databases;
+    std::vector<std::vector<TableInfo>> tables_per_db;
+
+    std::lock_guard lock(impl->mutex);
+    if (catalog_matches && !schema_filter_excludes_all)
+    {
+        std::string db_where;
+        if (db_schema && *db_schema)
+            db_where = " WHERE name LIKE " + quoteStringLiteral(db_schema);
+        std::shared_ptr<arrow::Table> dbs;
+        AdbcStatusCode status
+            = queryToTable(impl, "SELECT name FROM system.databases" + db_where + " ORDER BY name", dbs, error);
+        if (status != ADBC_STATUS_OK)
+            return status;
+        if (dbs->num_rows() > 0)
+        {
+            std::shared_ptr<arrow::StringArray> names;
+            AdbcStatusCode col_status = getTypedColumn(dbs, "name", arrow::Type::STRING, names, error);
+            if (col_status != ADBC_STATUS_OK)
+                return col_status;
+            for (int64_t i = 0; i < names->length(); ++i)
+                databases.push_back(names->GetString(i));
+        }
+        tables_per_db.resize(databases.size());
+
+        if (depth == ADBC_OBJECT_DEPTH_ALL || depth >= ADBC_OBJECT_DEPTH_TABLES)
+        {
+            std::string where = db_schema && *db_schema
+                ? " WHERE database LIKE " + quoteStringLiteral(db_schema)
+                : " WHERE 1";
+            if (table_name && *table_name)
+                where += " AND name LIKE " + quoteStringLiteral(table_name);
+            const char * type_expr
+                = "if(engine IN ('View', 'MaterializedView', 'LiveView', 'WindowView'), 'VIEW', 'BASE TABLE')";
+            if (!want_base && !want_view)
+                where += " AND 0";
+            else if (!want_base)
+                where += std::string(" AND ") + type_expr + " = 'VIEW'";
+            else if (!want_view)
+                where += std::string(" AND ") + type_expr + " = 'BASE TABLE'";
+
+            std::shared_ptr<arrow::Table> tbls;
+            AdbcStatusCode status2 = queryToTable(
+                impl,
+                std::string("SELECT database, name, ") + type_expr
+                    + " AS ttype FROM system.tables" + where + " ORDER BY database, name",
+                tbls,
+                error);
+            if (status2 != ADBC_STATUS_OK)
+                return status2;
+
+            std::shared_ptr<arrow::Table> cols;
+            if (depth == ADBC_OBJECT_DEPTH_ALL)
+            {
+                /// system.columns has no `engine` column, so the table-type
+                /// filter is applied via the table lookup below instead.
+                std::string col_where = db_schema && *db_schema
+                    ? " WHERE database LIKE " + quoteStringLiteral(db_schema)
+                    : " WHERE 1";
+                if (table_name && *table_name)
+                    col_where += " AND table LIKE " + quoteStringLiteral(table_name);
+                if (column_name && *column_name)
+                    col_where += " AND name LIKE " + quoteStringLiteral(column_name);
+                AdbcStatusCode status3 = queryToTable(
+                    impl,
+                    "SELECT database, table, name, toInt32(position) AS pos, type, comment FROM system.columns"
+                        + col_where + " ORDER BY database, table, pos",
+                    cols,
+                    error);
+                if (status3 != ADBC_STATUS_OK)
+                    return status3;
+            }
+
+            /// Index tables by (database, name) and attach columns.
+            auto findDb = [&](const std::string & name) -> int64_t
+            {
+                for (size_t i = 0; i < databases.size(); ++i)
+                    if (databases[i] == name)
+                        return static_cast<int64_t>(i);
+                return -1;
+            };
+
+            if (tbls->num_rows() > 0)
+            {
+                std::shared_ptr<arrow::StringArray> t_db;
+                std::shared_ptr<arrow::StringArray> t_name;
+                std::shared_ptr<arrow::StringArray> t_type;
+                AdbcStatusCode col_status = getTypedColumn(tbls, "database", arrow::Type::STRING, t_db, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(tbls, "name", arrow::Type::STRING, t_name, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(tbls, "ttype", arrow::Type::STRING, t_type, error);
+                if (col_status != ADBC_STATUS_OK)
+                    return col_status;
+                for (int64_t i = 0; i < tbls->num_rows(); ++i)
+                {
+                    int64_t db_idx = findDb(t_db->GetString(i));
+                    if (db_idx < 0)
+                        continue;
+                    tables_per_db[static_cast<size_t>(db_idx)].push_back(
+                        TableInfo{t_name->GetString(i), t_type->GetString(i), {}});
+                }
+            }
+            if (cols && cols->num_rows() > 0)
+            {
+                std::shared_ptr<arrow::StringArray> c_db;
+                std::shared_ptr<arrow::StringArray> c_table;
+                std::shared_ptr<arrow::StringArray> c_name;
+                std::shared_ptr<arrow::Int32Array> c_pos;
+                std::shared_ptr<arrow::StringArray> c_type;
+                std::shared_ptr<arrow::StringArray> c_comment;
+                AdbcStatusCode col_status = getTypedColumn(cols, "database", arrow::Type::STRING, c_db, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(cols, "table", arrow::Type::STRING, c_table, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(cols, "name", arrow::Type::STRING, c_name, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(cols, "pos", arrow::Type::INT32, c_pos, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(cols, "type", arrow::Type::STRING, c_type, error);
+                if (col_status == ADBC_STATUS_OK)
+                    col_status = getTypedColumn(cols, "comment", arrow::Type::STRING, c_comment, error);
+                if (col_status != ADBC_STATUS_OK)
+                    return col_status;
+                for (int64_t i = 0; i < cols->num_rows(); ++i)
+                {
+                    int64_t db_idx = findDb(c_db->GetString(i));
+                    if (db_idx < 0)
+                        continue;
+                    auto & tables = tables_per_db[static_cast<size_t>(db_idx)];
+                    const std::string tname = c_table->GetString(i);
+                    for (auto & t : tables)
+                        if (t.name == tname)
+                        {
+                            t.columns.push_back(ColumnInfo{
+                                c_name->GetString(i), c_pos->Value(i), c_type->GetString(i), c_comment->GetString(i)});
+                            break;
+                        }
+                }
+            }
+        }
+    }
+
+    /// Assemble the nested result (single NULL-catalog row).
+    auto db_schema_type = getObjectsDbSchemaType();
+    std::unique_ptr<arrow::ArrayBuilder> top_builder;
+    auto make_status
+        = arrow::MakeBuilder(arrow::default_memory_pool(), arrow::list(db_schema_type), &top_builder);
+    if (!make_status.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + make_status.ToString());
+
+    /// Child builders resolved by field name (never by position), so the
+    /// population below cannot silently misalign against the schema
+    /// definition in getObjectsDbSchemaType().
+    auto * schemas_lb = static_cast<arrow::ListBuilder *>(top_builder.get());
+    auto * schema_sb = static_cast<arrow::StructBuilder *>(schemas_lb->value_builder());
+    arrow::StringBuilder * schema_name_b = nullptr;
+    arrow::ListBuilder * tables_lb = nullptr;
+    AdbcStatusCode nav_status
+        = getFieldBuilder(schema_sb, "db_schema_name", arrow::Type::STRING, schema_name_b, nullptr, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status = getFieldBuilder(schema_sb, "db_schema_tables", arrow::Type::LIST, tables_lb, nullptr, error);
+    if (nav_status != ADBC_STATUS_OK)
+        return nav_status;
+
+    auto * table_sb = static_cast<arrow::StructBuilder *>(tables_lb->value_builder());
+    arrow::StringBuilder * table_name_b = nullptr;
+    arrow::StringBuilder * table_type_b = nullptr;
+    arrow::ListBuilder * columns_lb = nullptr;
+    arrow::ListBuilder * constraints_lb = nullptr;
+    nav_status = getFieldBuilder(table_sb, "table_name", arrow::Type::STRING, table_name_b, nullptr, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status = getFieldBuilder(table_sb, "table_type", arrow::Type::STRING, table_type_b, nullptr, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status = getFieldBuilder(table_sb, "table_columns", arrow::Type::LIST, columns_lb, nullptr, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status = getFieldBuilder(table_sb, "table_constraints", arrow::Type::LIST, constraints_lb, nullptr, error);
+    if (nav_status != ADBC_STATUS_OK)
+        return nav_status;
+
+    auto * column_sb = static_cast<arrow::StructBuilder *>(columns_lb->value_builder());
+    arrow::StringBuilder * col_name_b = nullptr;
+    arrow::Int32Builder * col_pos_b = nullptr;
+    arrow::StringBuilder * col_remarks_b = nullptr;
+    arrow::StringBuilder * col_type_name_b = nullptr;
+    int idx_col_name = -1;
+    int idx_col_pos = -1;
+    int idx_col_remarks = -1;
+    int idx_col_type_name = -1;
+    nav_status = getFieldBuilder(column_sb, "column_name", arrow::Type::STRING, col_name_b, &idx_col_name, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status
+            = getFieldBuilder(column_sb, "ordinal_position", arrow::Type::INT32, col_pos_b, &idx_col_pos, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status = getFieldBuilder(column_sb, "remarks", arrow::Type::STRING, col_remarks_b, &idx_col_remarks, error);
+    if (nav_status == ADBC_STATUS_OK)
+        nav_status = getFieldBuilder(
+            column_sb, "xdbc_type_name", arrow::Type::STRING, col_type_name_b, &idx_col_type_name, error);
+    if (nav_status != ADBC_STATUS_OK)
+        return nav_status;
+
+    bool builder_ok = true;
+    auto ok = [&](const arrow::Status & s) { builder_ok = builder_ok && s.ok(); };
+
+    if (catalog_matches && depth == ADBC_OBJECT_DEPTH_CATALOGS)
+    {
+        ok(schemas_lb->AppendNull());
+    }
+    else if (catalog_matches)
+    {
+        ok(schemas_lb->Append());
+        for (size_t db = 0; db < databases.size(); ++db)
+        {
+            ok(schema_sb->Append());
+            ok(schema_name_b->Append(databases[db]));
+            if (depth == ADBC_OBJECT_DEPTH_DB_SCHEMAS)
+            {
+                ok(tables_lb->AppendNull());
+                continue;
+            }
+            ok(tables_lb->Append());
+            for (const auto & t : tables_per_db[db])
+            {
+                ok(table_sb->Append());
+                ok(table_name_b->Append(t.name));
+                ok(table_type_b->Append(t.type));
+                if (depth != ADBC_OBJECT_DEPTH_ALL)
+                {
+                    ok(columns_lb->AppendNull());
+                    ok(constraints_lb->AppendNull());
+                    continue;
+                }
+                ok(columns_lb->Append());
+                for (const auto & c : t.columns)
+                {
+                    ok(column_sb->Append());
+                    ok(col_name_b->Append(c.name));
+                    ok(col_pos_b->Append(c.position));
+                    if (c.comment.empty())
+                        ok(col_remarks_b->AppendNull());
+                    else
+                        ok(col_remarks_b->Append(c.comment));
+                    ok(col_type_name_b->Append(c.type));
+                    /// remaining xdbc_* fields are not provided
+                    for (int f = 0; f < column_sb->num_fields(); ++f)
+                        if (f != idx_col_name && f != idx_col_pos && f != idx_col_remarks
+                            && f != idx_col_type_name)
+                            ok(column_sb->field_builder(f)->AppendNull());
+                }
+                /// ClickHouse has no SQL constraints to report
+                ok(constraints_lb->Append());
+            }
+        }
+    }
+
+    arrow::StringBuilder catalog_name_b;
+    if (catalog_matches)
+        ok(catalog_name_b.AppendNull());
+    std::shared_ptr<arrow::Array> catalog_names;
+    std::shared_ptr<arrow::Array> catalog_schemas;
+    ok(catalog_name_b.Finish(&catalog_names));
+    ok(schemas_lb->Finish(&catalog_schemas));
+    if (!builder_ok)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to build GetObjects result");
+
+    auto result_schema = arrow::schema(
+        {arrow::field("catalog_name", arrow::utf8()),
+         arrow::field("catalog_db_schemas", arrow::list(db_schema_type))});
+    auto batch = arrow::RecordBatch::Make(
+        result_schema, catalog_matches ? 1 : 0, {catalog_names, catalog_schemas});
+    return exportBatch(result_schema, batch, out, error);
+}
+
+AdbcStatusCode chdbConnectionGetTableSchema(
+    AdbcConnection * connection,
+    const char * catalog,
+    const char * db_schema,
+    const char * table_name,
+    ArrowSchema * schema,
+    AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+    if (!impl->conn)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!table_name || !schema)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] table_name/schema is null");
+    if (catalog && *catalog)
+        return notImplemented(error, "catalogs (ClickHouse has databases only)");
+
+    std::string qualified = quoteIdentifier(table_name);
+    if (db_schema && *db_schema)
+        qualified = quoteIdentifier(db_schema) + "." + qualified;
+    std::string sql = "SELECT * FROM " + qualified + " WHERE 0";
+
+    std::lock_guard lock(impl->mutex);
+    /// Metadata read: reject (don't silently kill) a live stream.
+    if (AdbcStatusCode s = reclaimActiveStream(impl, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+        s != ADBC_STATUS_OK)
+        return s;
+    ArrowArrayStream stream;
+    std::memset(&stream, 0, sizeof(stream));
+    chdb_result * result = chdb_query_arrow_n(
+        *impl->conn, sql.c_str(), sql.size(), reinterpret_cast<chdb_arrow_stream>(&stream), nullptr);
+    AdbcStatusCode status = consumeResult(result, nullptr, error);
+    if (status != ADBC_STATUS_OK)
+        return status;
+
+    if (!stream.release || stream.get_schema(&stream, schema) != 0)
+    {
+        if (stream.release)
+            stream.release(&stream);
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to read schema of " + qualified);
+    }
+    stream.release(&stream);
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbConnectionGetTableTypes(
+    AdbcConnection * connection, ArrowArrayStream * out, AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!out)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] out stream is null");
+
+    arrow::StringBuilder builder;
+    std::shared_ptr<arrow::Array> types;
+    if (!builder.Append("BASE TABLE").ok() || !builder.Append("VIEW").ok() || !builder.Finish(&types).ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to build GetTableTypes result");
+
+    auto schema = arrow::schema({arrow::field("table_type", arrow::utf8(), /*nullable=*/false)});
+    auto batch = arrow::RecordBatch::Make(schema, types->length(), {types});
+    return exportBatch(schema, batch, out, error);
+}
+
+AdbcStatusCode chdbConnectionReadPartition(
+    AdbcConnection *, const uint8_t *, size_t, ArrowArrayStream *, AdbcError * error)
+{
+    return notImplemented(error, "ConnectionReadPartition");
+}
+
+/// ---------------------------------------------------------------------
+/// Statement functions
+/// ---------------------------------------------------------------------
+
+AdbcStatusCode chdbStatementNew(
+    AdbcConnection * connection, AdbcStatement * statement, AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!statement)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] statement is null");
+    auto * impl = new StatementImpl();
+    impl->connection = static_cast<ConnectionImpl *>(connection->private_data);
+    std::memset(&impl->bound_stream, 0, sizeof(impl->bound_stream));
+    statement->private_data = impl;
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbStatementRelease(AdbcStatement * statement, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    impl->releaseBoundStream();
+    delete impl;
+    statement->private_data = nullptr;
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbStatementSetSqlQuery(
+    AdbcStatement * statement, const char * query, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    if (!query)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] query is null");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    impl->query = query;
+    impl->has_query = true;
+    impl->ingest_table.clear();
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbStatementSetOption(
+    AdbcStatement * statement, const char * key, const char * value, AdbcError * error)
+{
+    if (!statement || !statement->private_data || !key)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+
+    if (std::strcmp(key, ADBC_INGEST_OPTION_TARGET_TABLE) == 0)
+    {
+        impl->ingest_table = value ? value : "";
+        impl->has_query = false;
+        return ADBC_STATUS_OK;
+    }
+    if (std::strcmp(key, ADBC_INGEST_OPTION_TARGET_DB_SCHEMA) == 0)
+    {
+        impl->ingest_db_schema = value ? value : "";
+        return ADBC_STATUS_OK;
+    }
+    if (std::strcmp(key, ADBC_INGEST_OPTION_MODE) == 0)
+    {
+        std::string mode(value ? value : "");
+        if (mode != ADBC_INGEST_OPTION_MODE_CREATE && mode != ADBC_INGEST_OPTION_MODE_APPEND
+            && mode != ADBC_INGEST_OPTION_MODE_REPLACE && mode != ADBC_INGEST_OPTION_MODE_CREATE_APPEND)
+            return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] unknown ingest mode '" + mode + "'");
+        impl->ingest_mode = mode;
+        return ADBC_STATUS_OK;
+    }
+    return notImplemented(error, std::string("statement option '") + key + "'");
+}
+
+AdbcStatusCode chdbStatementPrepare(AdbcStatement * statement, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    if (impl->query.empty() && impl->ingest_table.empty())
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] no query to prepare (SetSqlQuery first)");
+    /// Queries execute in one shot; there is no server-side prepared state.
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbStatementBind(
+    AdbcStatement * statement, ArrowArray * values, ArrowSchema * schema, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    if (!values || !schema)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] values/schema is null");
+
+    /// Import the single batch (taking ownership, C Data move semantics)
+    /// and re-export it as a one-batch stream.
+    auto imported_schema = arrow::ImportSchema(schema);
+    if (!imported_schema.ok())
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] " + imported_schema.status().ToString());
+    auto batch = arrow::ImportRecordBatch(values, imported_schema.ValueUnsafe());
+    if (!batch.ok())
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] " + batch.status().ToString());
+    auto reader = arrow::RecordBatchReader::Make({batch.ValueUnsafe()}, imported_schema.ValueUnsafe());
+    if (!reader.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + reader.status().ToString());
+
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    impl->releaseBoundStream();
+    auto status = arrow::ExportRecordBatchReader(reader.ValueUnsafe(), &impl->bound_stream);
+    if (!status.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + status.ToString());
+    impl->has_bound_stream = true;
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbStatementBindStream(
+    AdbcStatement * statement, ArrowArrayStream * stream, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    if (!stream || !stream->release)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] stream is null or released");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    impl->releaseBoundStream();
+    impl->bound_stream = *stream;
+    stream->release = nullptr; /// moved
+    impl->has_bound_stream = true;
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode executeIngest(StatementImpl * impl, int64_t * rows_affected, AdbcError * error)
+{
+    if (!impl->has_bound_stream)
+        return setError(
+            error, ADBC_STATUS_INVALID_STATE, "[chdb] bulk ingestion requires bound data (Bind/BindStream)");
+
+    std::string qualified = quoteIdentifier(impl->ingest_table);
+    if (!impl->ingest_db_schema.empty())
+        qualified = quoteIdentifier(impl->ingest_db_schema) + "." + qualified;
+
+    const std::string reg_name = "adbc_ingest_" + std::to_string(ingest_name_counter.fetch_add(1));
+    if (chdb_arrow_scan(
+            *impl->connection->conn,
+            reg_name.c_str(),
+            reinterpret_cast<chdb_arrow_stream>(&impl->bound_stream))
+        != CHDBSuccess)
+    {
+        impl->releaseBoundStream();
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to register bound Arrow stream");
+    }
+
+    const std::string create_sql = "CREATE TABLE " + qualified
+        + " ENGINE = MergeTree() ORDER BY tuple() AS SELECT * FROM arrowstream(" + reg_name + ")";
+    const std::string insert_sql = "INSERT INTO " + qualified + " SELECT * FROM arrowstream(" + reg_name + ")";
+
+    AdbcStatusCode status = ADBC_STATUS_OK;
+    if (impl->ingest_mode == ADBC_INGEST_OPTION_MODE_CREATE)
+    {
+        status = runUpdateQuery(impl->connection, create_sql, rows_affected, error, /*zero_rows_known_override=*/true);
+    }
+    else if (impl->ingest_mode == ADBC_INGEST_OPTION_MODE_REPLACE)
+    {
+        /// Single-statement swap: the old table stays intact if this fails.
+        status = runUpdateQuery(
+            impl->connection,
+            "CREATE OR REPLACE TABLE " + qualified
+                + " ENGINE = MergeTree() ORDER BY tuple() AS SELECT * FROM arrowstream(" + reg_name + ")",
+            rows_affected,
+            error,
+            /*zero_rows_known_override=*/true);
+    }
+    else if (impl->ingest_mode == ADBC_INGEST_OPTION_MODE_APPEND)
+    {
+        status = runUpdateQuery(impl->connection, insert_sql, rows_affected, error);
+    }
+    else /// create_append
+    {
+        std::string exists;
+        status = runScalarQuery(impl->connection, "EXISTS TABLE " + qualified, exists, error);
+        if (status == ADBC_STATUS_OK && exists == "1")
+        {
+            /// Appending goes through a positional INSERT ... SELECT *, so the
+            /// bound columns must line up with the table's. A mismatch is the
+            /// spec's "table exists with an incompatible schema" case, which
+            /// callers expect as ALREADY_EXISTS rather than an engine error.
+            ArrowSchema bound_schema;
+            std::memset(&bound_schema, 0, sizeof(bound_schema));
+            if (impl->bound_stream.get_schema(&impl->bound_stream, &bound_schema) == 0 && bound_schema.release)
+            {
+                std::string bound_names = "[";
+                for (int64_t i = 0; i < bound_schema.n_children; ++i)
+                    bound_names += std::string(i ? "," : "")
+                        + quoteStringLiteral(bound_schema.children[i]->name ? bound_schema.children[i]->name : "");
+                bound_names += "]";
+                bound_schema.release(&bound_schema);
+
+                const std::string db_literal = impl->ingest_db_schema.empty()
+                    ? std::string("currentDatabase()")
+                    : quoteStringLiteral(impl->ingest_db_schema);
+                std::string matches;
+                status = runScalarQuery(
+                    impl->connection,
+                    "SELECT (SELECT groupArray(name) FROM (SELECT name FROM system.columns WHERE database = "
+                        + db_literal + " AND table = " + quoteStringLiteral(impl->ingest_table)
+                        + " ORDER BY position)) = " + bound_names,
+                    matches,
+                    error);
+                if (status == ADBC_STATUS_OK && matches != "1")
+                    status = setError(
+                        error,
+                        ADBC_STATUS_ALREADY_EXISTS,
+                        "[chdb] table " + qualified + " already exists with an incompatible schema");
+            }
+        }
+        if (status == ADBC_STATUS_OK)
+            status = runUpdateQuery(
+                impl->connection, exists == "1" ? insert_sql : create_sql, rows_affected, error,
+                /*zero_rows_known_override=*/true);
+    }
+
+    chdb_arrow_unregister_table(*impl->connection->conn, reg_name.c_str());
+    impl->releaseBoundStream();
+    return status;
+}
+
+AdbcStatusCode wireStreamingResult(
+    ConnectionImpl * connection,
+    uint64_t owner_statement,
+    chdb_result * stream_result,
+    ArrowArrayStream * out,
+    AdbcError * error);
+
+/// Executes a query with qmark-style positional parameters bound as Arrow
+/// data. Each `?` is rewritten to a server-side {name:Type} placeholder
+/// (no string interpolation); NULL values become literal NULLs. Multi-row
+/// binds (executemany) run the statement once per row.
+AdbcStatusCode executeBoundInsertBatch(
+    StatementImpl * impl, const std::string & insert_head, int64_t * rows_affected, AdbcError * error)
+{
+    const std::string reg_name = "adbc_ingest_" + std::to_string(ingest_name_counter.fetch_add(1));
+    if (chdb_arrow_scan(
+            *impl->connection->conn, reg_name.c_str(), reinterpret_cast<chdb_arrow_stream>(&impl->bound_stream))
+        != CHDBSuccess)
+    {
+        impl->releaseBoundStream();
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to register bound Arrow stream");
+    }
+    AdbcStatusCode status = runUpdateQuery(
+        impl->connection, insert_head + " SELECT * FROM arrowstream(" + reg_name + ")", rows_affected, error);
+    chdb_arrow_unregister_table(*impl->connection->conn, reg_name.c_str());
+    impl->releaseBoundStream();
+    return status;
+}
+
+AdbcStatusCode executeBoundQuery(
+    StatementImpl * impl, ArrowArrayStream * out, int64_t * rows_affected, AdbcError * error)
+{
+    /// Fast path: a plain INSERT ... VALUES (?, ...) with update semantics
+    /// streams all bound rows through one INSERT ... SELECT — the same
+    /// engine channel as bulk ingestion — instead of one parse/execute per
+    /// row. Anything else falls through to the per-row path below.
+    if (!out)
+    {
+        std::string insert_head;
+        size_t shape_arity = 0;
+        if (matchPlainInsertShape(impl->query, insert_head, shape_arity))
+        {
+            ArrowSchema bound_schema;
+            std::memset(&bound_schema, 0, sizeof(bound_schema));
+            if (impl->bound_stream.get_schema(&impl->bound_stream, &bound_schema) == 0 && bound_schema.release)
+            {
+                const auto n_cols = static_cast<size_t>(bound_schema.n_children);
+                /// The bound stream is registered as a named table, so every
+                /// column needs a distinct non-empty name; otherwise fall back
+                /// to the per-row path, which never materializes columns.
+                std::vector<std::string> names;
+                names.reserve(n_cols);
+                bool names_usable = true;
+                for (size_t i = 0; i < n_cols && names_usable; ++i)
+                {
+                    const char * cname = bound_schema.children[i]->name;
+                    if (!cname || !*cname)
+                        names_usable = false;
+                    else
+                        names.emplace_back(cname);
+                }
+                std::sort(names.begin(), names.end());
+                names_usable = names_usable && std::adjacent_find(names.begin(), names.end()) == names.end();
+                bound_schema.release(&bound_schema);
+                if (n_cols == shape_arity && names_usable)
+                    return executeBoundInsertBatch(impl, insert_head, rows_affected, error);
+            }
+        }
+    }
+
+    auto reader = arrow::ImportRecordBatchReader(&impl->bound_stream);
+    impl->has_bound_stream = false;
+    std::memset(&impl->bound_stream, 0, sizeof(impl->bound_stream));
+    if (!reader.ok())
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] " + reader.status().ToString());
+
+    auto table_result = reader.ValueUnsafe()->ToTable();
+    if (!table_result.ok())
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] " + table_result.status().ToString());
+    auto combined = table_result.ValueUnsafe()->CombineChunks();
+    if (!combined.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + combined.status().ToString());
+    auto table = combined.ValueUnsafe();
+
+    const std::string & sql = impl->query;
+    const auto positions = findPlaceholders(sql);
+    if (static_cast<int>(positions.size()) != table->num_columns())
+        return setError(
+            error,
+            ADBC_STATUS_INVALID_ARGUMENT,
+            "[chdb] query has " + std::to_string(positions.size()) + " '?' placeholders but "
+                + std::to_string(table->num_columns()) + " parameter columns are bound");
+    if (table->num_rows() == 0)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] bound parameter data has no rows");
+    /// Multiple bound rows with a result set: the statement runs once per
+    /// row and the per-execution results are concatenated into one stream.
+    const bool concat_rows = out && table->num_rows() > 1;
+    std::shared_ptr<arrow::Schema> concat_schema;
+    std::vector<std::shared_ptr<arrow::RecordBatch>> concat_batches;
+
+    std::vector<std::string> ch_types(static_cast<size_t>(table->num_columns()));
+    for (int col = 0; col < table->num_columns(); ++col)
+    {
+        AdbcStatusCode status = clickhouseTypeFor(table->field(col)->type(), ch_types[static_cast<size_t>(col)], error);
+        if (status != ADBC_STATUS_OK)
+            return status;
+        /// When executions are concatenated, a column with NULLs binds as
+        /// Nullable with the engine's \N value on the null rows — a literal
+        /// NULL would type that execution's column as Nothing and break the
+        /// concatenated stream's schema.
+        if (concat_rows && table->column(col)->null_count() > 0)
+            ch_types[static_cast<size_t>(col)] = "Nullable(" + ch_types[static_cast<size_t>(col)] + ")";
+    }
+
+    int64_t written_total = 0;
+    bool any_written = false;
+    /// For INSERTs a per-row count of zero is a known result, not "not
+    /// applicable" — same distinction runUpdateQuery makes.
+    const bool is_insert = statementIsInsert(sql);
+    for (int64_t row = 0; row < table->num_rows(); ++row)
+    {
+        /// Assemble the rewritten query plus name/value pairs for this row.
+        std::string rewritten;
+        std::vector<std::string> names;
+        std::vector<std::string> values;
+        size_t prev = 0;
+        for (size_t p = 0; p < positions.size(); ++p)
+        {
+            rewritten.append(sql, prev, positions[p] - prev);
+            prev = positions[p] + 1;
+
+            auto scalar = table->column(static_cast<int>(p))->chunk(0)->GetScalar(row);
+            if (!scalar.ok())
+                return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + scalar.status().ToString());
+            if (!scalar.ValueUnsafe()->is_valid && !concat_rows)
+            {
+                rewritten += "NULL";
+                continue;
+            }
+            const std::string name = "__adbc_p" + std::to_string(p);
+            rewritten += "{" + name + ":" + ch_types[p] + "}";
+            names.push_back(name);
+            values.push_back(scalar.ValueUnsafe()->is_valid ? scalarToParamString(scalar.ValueUnsafe()) : "\\N");
+        }
+        rewritten.append(sql, prev, sql.size() - prev);
+
+        std::vector<const char *> name_ptrs;
+        std::vector<size_t> name_lens;
+        std::vector<const char *> value_ptrs;
+        std::vector<size_t> value_lens;
+        for (size_t p = 0; p < names.size(); ++p)
+        {
+            name_ptrs.push_back(names[p].c_str());
+            name_lens.push_back(names[p].size());
+            value_ptrs.push_back(values[p].c_str());
+            value_lens.push_back(values[p].size());
+        }
+
+        if (concat_rows)
+        {
+            chdb_result * result = chdb_query_with_params_n(
+                *impl->connection->conn,
+                rewritten.c_str(),
+                rewritten.size(),
+                "ArrowStream",
+                11,
+                name_ptrs.data(),
+                name_lens.data(),
+                value_ptrs.data(),
+                value_lens.data(),
+                names.size());
+            AdbcStatusCode status = ipcResultToBatches(result, concat_schema, concat_batches, error);
+            if (status != ADBC_STATUS_OK)
+                return status;
+            continue;
+        }
+
+        if (out)
+        {
+            /// Parameterized SELECT: server-side binding through the
+            /// streaming Arrow path, same adapter as the plain path.
+            chdb_result * stream_result = chdb_stream_query_arrow_with_params_n(
+                *impl->connection->conn,
+                rewritten.c_str(),
+                rewritten.size(),
+                nullptr,
+                name_ptrs.data(),
+                name_lens.data(),
+                value_ptrs.data(),
+                value_lens.data(),
+                names.size());
+            if (!stream_result)
+                return setError(error, ADBC_STATUS_INTERNAL, "[chdb] streaming init returned no handle");
+            if (const char * err = chdb_result_error(stream_result))
+            {
+                std::string message(err);
+                chdb_destroy_query_result(stream_result);
+                if (message.find(CHDB::kErrorStreamingNotSupportedPrefix) == std::string::npos)
+                    return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + message);
+                /// Statement the engine refuses to stream (rejected before
+                /// executing): run it materialized over the IPC format.
+                chdb_result * result = chdb_query_with_params_n(
+                    *impl->connection->conn,
+                    rewritten.c_str(),
+                    rewritten.size(),
+                    "ArrowStream",
+                    11,
+                    name_ptrs.data(),
+                    name_lens.data(),
+                    value_ptrs.data(),
+                    value_lens.data(),
+                    names.size());
+                return exportIpcResult(result, out, error);
+            }
+            return wireStreamingResult(impl->connection, /*owner_statement=*/impl->id, stream_result, out, error);
+        }
+
+        chdb_result * result = chdb_query_with_params_n(
+            *impl->connection->conn,
+            rewritten.c_str(),
+            rewritten.size(),
+            "Null",
+            4,
+            name_ptrs.data(),
+            name_lens.data(),
+            value_ptrs.data(),
+            value_lens.data(),
+            names.size());
+
+        int64_t row_written = -1;
+        AdbcStatusCode status = consumeResult(result, &row_written, error, is_insert);
+        if (status != ADBC_STATUS_OK)
+            return status;
+        if (row_written >= 0)
+        {
+            written_total += row_written;
+            any_written = true;
+        }
+    }
+    if (concat_rows)
+    {
+        if (!concat_schema)
+            concat_schema = arrow::schema(arrow::FieldVector{});
+        auto reader_result = arrow::RecordBatchReader::Make(std::move(concat_batches), concat_schema);
+        if (!reader_result.ok())
+            return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + reader_result.status().ToString());
+        auto export_status = arrow::ExportRecordBatchReader(reader_result.ValueUnsafe(), out);
+        if (!export_status.ok())
+            return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + export_status.ToString());
+    }
+    if (rows_affected)
+        *rows_affected = any_written ? written_total : -1;
+    return ADBC_STATUS_OK;
+}
+
+/// Pulls the next batch out of the engine. Returns 0 and a released *out on
+/// end-of-stream, per the Arrow C stream contract.
+int streamingGetNextImpl(StreamingResultState & state, ArrowArray * out)
+{
+    std::lock_guard guard(state.mutex);
+    if (state.invalidated)
+        return EIO; /// last_error carries the reason
+    if (state.has_pending)
+    {
+        *out = state.pending;
+        std::memset(&state.pending, 0, sizeof(state.pending));
+        state.has_pending = false;
+        return 0;
+    }
+    if (state.exhausted)
+    {
+        out->release = nullptr;
+        return 0;
+    }
+
+    ArrowArrayStream one_batch;
+    std::memset(&one_batch, 0, sizeof(one_batch));
+    if (chdb_stream_fetch_arrow(
+            state.conn, state.stream_result, reinterpret_cast<chdb_arrow_stream>(&one_batch))
+        != CHDBSuccess)
+    {
+        const char * err = chdb_result_error(state.stream_result);
+        state.last_error = err ? err : "chdb_stream_fetch_arrow failed";
+        return EIO;
+    }
+    int rc = one_batch.get_next(&one_batch, out);
+    if (one_batch.release)
+        one_batch.release(&one_batch);
+    if (rc != 0)
+    {
+        state.last_error = "failed to read batch from stream";
+        return rc;
+    }
+    if (!out->release)
+        state.exhausted = true;
+    return 0;
+}
+
+/// Materialized fallback for statements the engine refuses to stream (DDL):
+/// a missing result header means "executed fine, no result set" — hand
+/// DB-API consumers an empty zero-column stream.
+AdbcStatusCode executeMaterializedSelect(
+    StatementImpl * impl, ArrowArrayStream * out, int64_t * rows_affected, AdbcError * error)
+{
+    chdb_result * result = chdb_query_arrow_n(
+        *impl->connection->conn,
+        impl->query.c_str(),
+        impl->query.size(),
+        reinterpret_cast<chdb_arrow_stream>(out),
+        nullptr);
+    if (result)
+    {
+        const char * err = chdb_result_error(result);
+        if (err && std::strcmp(err, CHDB::kErrorMissingResultHeader) == 0)
+        {
+            chdb_destroy_query_result(result);
+            auto schema = arrow::schema(arrow::FieldVector{});
+            auto batch = arrow::RecordBatch::Make(schema, 0, std::vector<std::shared_ptr<arrow::Array>>{});
+            return exportBatch(schema, batch, out, error);
+        }
+    }
+    return consumeResult(result, rows_affected, error, statementIsInsert(impl->query));
+}
+
+/// Takes ownership of a freshly initialized streaming query handle and wires
+/// the adapter into the caller's ArrowArrayStream. Shared by the plain and
+/// parameterized execution paths.
+AdbcStatusCode wireStreamingResult(
+    ConnectionImpl * connection,
+    uint64_t owner_statement,
+    chdb_result * stream_result,
+    ArrowArrayStream * out,
+    AdbcError * error)
+{
+    chdb_connection conn = *connection->conn;
+    auto state = std::make_unique<StreamingResultState>();
+    state->owner = connection;
+    state->owner_statement = owner_statement;
+    state->conn = conn;
+    state->stream_result = stream_result;
+
+    /// Fetch the first batch eagerly: it drives statements without a result
+    /// set to completion and tells us whether there is a result schema.
+    ArrowArrayStream first;
+    std::memset(&first, 0, sizeof(first));
+    if (chdb_stream_fetch_arrow(conn, stream_result, reinterpret_cast<chdb_arrow_stream>(&first))
+        != CHDBSuccess)
+    {
+        const char * err = chdb_result_error(stream_result);
+        return setError(
+            error, ADBC_STATUS_INTERNAL, std::string("[chdb] ") + (err ? err : "first fetch failed"));
+    }
+
+    ArrowSchema schema_c;
+    std::memset(&schema_c, 0, sizeof(schema_c));
+    if (first.get_schema(&first, &schema_c) != 0 || !schema_c.release)
+    {
+        /// Healthy streams always have a schema (no-result statements are
+        /// rejected at init). Fail loudly; `state` cancels the engine stream
+        /// on destruction so the connection recovers.
+        if (first.release)
+            first.release(&first);
+        return setError(
+            error,
+            ADBC_STATUS_INTERNAL,
+            "[chdb] streaming query was accepted but produced no result schema — "
+            "engine streaming state is inconsistent");
+    }
+    auto imported = arrow::ImportSchema(&schema_c);
+    if (!imported.ok())
+    {
+        if (first.release)
+            first.release(&first);
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + imported.status().ToString());
+    }
+    state->schema = imported.ValueUnsafe();
+
+    int rc = first.get_next(&first, &state->pending);
+    if (first.release)
+        first.release(&first);
+    if (rc != 0)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to read first batch");
+    if (state->pending.release)
+        state->has_pending = true;
+    else
+        state->exhausted = true; /// empty result — schema-only stream
+
+    out->private_data = state.release();
+    out->get_schema = [](ArrowArrayStream * self, ArrowSchema * schema_out) -> int
+    {
+        auto * s = static_cast<StreamingResultState *>(self->private_data);
+        auto status = arrow::ExportSchema(*s->schema, schema_out);
+        if (!status.ok())
+        {
+            s->last_error = status.ToString();
+            return EIO;
+        }
+        return 0;
+    };
+    out->get_next = [](ArrowArrayStream * self, ArrowArray * array_out) -> int
+    {
+        auto * s = static_cast<StreamingResultState *>(self->private_data);
+        return streamingGetNextImpl(*s, array_out);
+    };
+    out->get_last_error = [](ArrowArrayStream * self) -> const char *
+    {
+        auto * s = static_cast<StreamingResultState *>(self->private_data);
+        if (!s)
+            return nullptr;
+        /// Locked: the invalidation thread writes last_error concurrently.
+        std::lock_guard guard(s->mutex);
+        return s->last_error.empty() ? nullptr : s->last_error.c_str();
+    };
+    out->release = [](ArrowArrayStream * self)
+    {
+        delete static_cast<StreamingResultState *>(self->private_data);
+        self->private_data = nullptr;
+        self->release = nullptr;
+    };
+
+    /// Register as the connection's outstanding stream; exhausted
+    /// (schema-only) streams have nothing left in the engine to invalidate.
+    auto * registered = static_cast<StreamingResultState *>(out->private_data);
+    if (!registered->exhausted)
+    {
+        std::lock_guard reg(connection->stream_mutex);
+        connection->active_stream = registered;
+    }
+    else
+    {
+        /// Unregistered, so connection close would never clear these: the
+        /// stream must not point back at a connection that may be released
+        /// before it, and the completed engine handle can be dropped now.
+        registered->owner = nullptr;
+        chdb_destroy_query_result(registered->stream_result);
+        registered->stream_result = nullptr;
+    }
+    return ADBC_STATUS_OK;
+}
+
+/// Executes a (non-parameterized) query through the streaming Arrow path.
+AdbcStatusCode executeStreamingSelect(
+    StatementImpl * impl, ArrowArrayStream * out, int64_t * rows_affected, AdbcError * error)
+{
+    chdb_connection conn = *impl->connection->conn;
+    chdb_result * stream_result
+        = chdb_stream_query_arrow_n(conn, impl->query.c_str(), impl->query.size(), nullptr);
+    if (!stream_result)
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] streaming init returned no handle");
+    if (const char * err = chdb_result_error(stream_result))
+    {
+        std::string message(err);
+        chdb_destroy_query_result(stream_result);
+        /// The engine rejects non-SELECT statements on the streaming path
+        /// before executing them, so falling back re-executes nothing.
+        if (message.find(CHDB::kErrorStreamingNotSupportedPrefix) != std::string::npos)
+            return executeMaterializedSelect(impl, out, rows_affected, error);
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + message);
+    }
+    return wireStreamingResult(impl->connection, /*owner_statement=*/impl->id, stream_result, out, error);
+}
+
+AdbcStatusCode chdbStatementExecuteQuery(
+    AdbcStatement * statement, ArrowArrayStream * out, int64_t * rows_affected, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    if (!impl->connection || !impl->connection->conn)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (rows_affected)
+        *rows_affected = -1;
+
+    std::lock_guard lock(impl->connection->mutex);
+    /// This statement's own prior stream is invalidated (spec-required); a
+    /// live stream from a DIFFERENT statement makes this Execute fail with
+    /// INVALID_STATE instead of silently killing the other reader.
+    if (AdbcStatusCode s
+        = reclaimActiveStream(impl->connection, /*owner_for_reuse=*/impl->id, kStreamInvalidatedBySuccessor, error);
+        s != ADBC_STATUS_OK)
+        return s;
+
+    if (!impl->ingest_table.empty())
+    {
+        if (out)
+            return setError(
+                error,
+                ADBC_STATUS_INVALID_ARGUMENT,
+                "[chdb] bulk ingestion returns no result set; use ExecuteUpdate semantics (out must be null)");
+        return executeIngest(impl, rows_affected, error);
+    }
+
+    if (!impl->has_query)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] no query set (SetSqlQuery)");
+    if (impl->has_bound_stream)
+        return executeBoundQuery(impl, out, rows_affected, error);
+
+    if (!out)
+        return runUpdateQuery(impl->connection, impl->query, rows_affected, error);
+
+    /// INSERT produces no result set: run it as an update — keeping the real
+    /// row count — and hand consumers the empty stream they expect, instead
+    /// of bouncing off the streaming path's rejection.
+    if (statementIsInsert(impl->query))
+    {
+        AdbcStatusCode status = runUpdateQuery(impl->connection, impl->query, rows_affected, error);
+        if (status != ADBC_STATUS_OK)
+            return status;
+        auto schema = arrow::schema(arrow::FieldVector{});
+        auto batch = arrow::RecordBatch::Make(schema, 0, std::vector<std::shared_ptr<arrow::Array>>{});
+        return exportBatch(schema, batch, out, error);
+    }
+
+    return executeStreamingSelect(impl, out, rows_affected, error);
+}
+
+AdbcStatusCode chdbStatementExecutePartitions(
+    AdbcStatement *, ArrowSchema *, AdbcPartitions *, int64_t *, AdbcError * error)
+{
+    return notImplemented(error, "StatementExecutePartitions");
+}
+
+AdbcStatusCode chdbStatementGetParameterSchema(
+    AdbcStatement * statement, ArrowSchema * schema, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    if (!impl->has_query)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] no query set (SetSqlQuery)");
+    if (!schema)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] schema is null");
+
+    /// Placeholder types are resolved from the bound Arrow data at execute
+    /// time, so the parameter schema only conveys the count.
+    const auto positions = findPlaceholders(impl->query);
+    arrow::FieldVector fields;
+    fields.reserve(positions.size());
+    for (size_t i = 0; i < positions.size(); ++i)
+        fields.push_back(arrow::field(std::to_string(i), arrow::null()));
+    auto status = arrow::ExportSchema(*arrow::schema(fields), schema);
+    if (!status.ok())
+        return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + status.ToString());
+    return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode chdbStatementSetSubstraitPlan(
+    AdbcStatement *, const uint8_t *, size_t, AdbcError * error)
+{
+    return notImplemented(error, "StatementSetSubstraitPlan");
+}
+
+/// ---------------------------------------------------------------------
+/// Driver init
+/// ---------------------------------------------------------------------
+
+AdbcStatusCode chdbDriverRelease(AdbcDriver * driver, AdbcError * error)
+{
+    if (!driver)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] driver is null");
+    driver->private_data = nullptr;
+    return ADBC_STATUS_OK;
+}
+
+} // anonymous namespace
+
+extern "C" CHDB_EXPORT AdbcStatusCode chdb_adbc_init(int version, void * raw_driver, AdbcError * error);
+
+extern "C" AdbcStatusCode chdb_adbc_init(int version, void * raw_driver, AdbcError * error)
+{
+    if (version != ADBC_VERSION_1_0_0 && version != ADBC_VERSION_1_1_0)
+        return setError(
+            error,
+            ADBC_STATUS_NOT_IMPLEMENTED,
+            "[chdb] only ADBC 1.0.0 / 1.1.0 are supported (got " + std::to_string(version) + ")");
+    if (!raw_driver)
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, "[chdb] driver is null");
+
+    auto * driver = static_cast<AdbcDriver *>(raw_driver);
+    std::memset(driver, 0, version == ADBC_VERSION_1_0_0 ? ADBC_DRIVER_1_0_0_SIZE : ADBC_DRIVER_1_1_0_SIZE);
+
+    driver->release = chdbDriverRelease;
+
+    driver->DatabaseNew = chdbDatabaseNew;
+    driver->DatabaseSetOption = chdbDatabaseSetOption;
+    driver->DatabaseInit = chdbDatabaseInit;
+    driver->DatabaseRelease = chdbDatabaseRelease;
+
+    driver->ConnectionNew = chdbConnectionNew;
+    driver->ConnectionSetOption = chdbConnectionSetOption;
+    driver->ConnectionInit = chdbConnectionInit;
+    driver->ConnectionRelease = chdbConnectionRelease;
+    driver->ConnectionCommit = chdbConnectionCommit;
+    driver->ConnectionRollback = chdbConnectionRollback;
+    driver->ConnectionGetInfo = chdbConnectionGetInfo;
+    driver->ConnectionGetObjects = chdbConnectionGetObjects;
+    driver->ConnectionGetTableSchema = chdbConnectionGetTableSchema;
+    driver->ConnectionGetTableTypes = chdbConnectionGetTableTypes;
+    driver->ConnectionReadPartition = chdbConnectionReadPartition;
+
+    driver->StatementNew = chdbStatementNew;
+    driver->StatementRelease = chdbStatementRelease;
+    driver->StatementSetSqlQuery = chdbStatementSetSqlQuery;
+    driver->StatementSetOption = chdbStatementSetOption;
+    driver->StatementPrepare = chdbStatementPrepare;
+    driver->StatementBind = chdbStatementBind;
+    driver->StatementBindStream = chdbStatementBindStream;
+    driver->StatementExecuteQuery = chdbStatementExecuteQuery;
+    driver->StatementExecutePartitions = chdbStatementExecutePartitions;
+    driver->StatementGetParameterSchema = chdbStatementGetParameterSchema;
+    driver->StatementSetSubstraitPlan = chdbStatementSetSubstraitPlan;
+
+    /// ADBC 1.1.0 additions beyond these stay zeroed: the driver manager
+    /// backfills unset entries with NOT_IMPLEMENTED stubs.
+    if (version == ADBC_VERSION_1_1_0)
+        driver->ConnectionGetOption = chdbConnectionGetOption;
+
+    return ADBC_STATUS_OK;
+}
+
+/// Default entrypoint name probed by driver managers when none is given, so
+/// `connect(driver=<libchdb path>)` works without an explicit entrypoint.
+extern "C" CHDB_EXPORT AdbcStatusCode AdbcDriverInit(int version, void * raw_driver, AdbcError * error)
+{
+    return chdb_adbc_init(version, raw_driver, error);
+}

--- a/programs/local/chdb-arrow-output.cpp
+++ b/programs/local/chdb-arrow-output.cpp
@@ -223,7 +223,7 @@ chdb_result * runMaterializedArrowQuery(
 
     auto * chunk_result = static_cast<CHDB::ChunkQueryResult *>(query_result.get());
     if (!chunk_result->header)
-        return makeErrorResult("Missing result header for Arrow output");
+        return makeErrorResult(CHDB::kErrorMissingResultHeader);
 
     const auto & header_columns = chunk_result->header->getColumnsWithTypeAndName();
 
@@ -354,7 +354,88 @@ chdb_result * chdb_stream_query_arrow_n(
         auto * client = static_cast<DB::ChdbClient *>(connection->server);
         auto query_result = client->executeStreamingInit(
             query, query_len,
-            CHUNK_COLLECT_FORMAT_NAME, std::strlen(CHUNK_COLLECT_FORMAT_NAME));
+            CHUNK_COLLECT_FORMAT_NAME, std::strlen(CHUNK_COLLECT_FORMAT_NAME),
+            /*dataframe_over_chunks=*/false);
+        if (!query_result)
+            return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Streaming init failed"));
+
+        if (query_result->getType() != CHDB::QueryResultType::RESULT_TYPE_STREAMING)
+            return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Unexpected non-streaming result for Arrow streaming"));
+
+        auto state = std::make_shared<ArrowStreamingState>();
+        if (options)
+            state->options = *options;
+        else
+            state->options = chdb_arrow_options{0, 0, 1};
+
+        auto * stream_result = static_cast<CHDB::StreamQueryResult *>(query_result.get());
+        stream_result->private_data = std::static_pointer_cast<void>(state);
+
+        return reinterpret_cast<chdb_result *>(query_result.release());
+    }
+    catch (const Exception & e)
+    {
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult(getExceptionMessage(e, false)));
+    }
+    catch (const std::exception & e)
+    {
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult(e.what()));
+    }
+    catch (...)
+    {
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult(DB::getCurrentExceptionMessage(true)));
+    }
+}
+
+chdb_result * chdb_stream_query_arrow_with_params(
+    chdb_connection conn, const char * query,
+    const chdb_arrow_options * options,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count)
+{
+    return chdb_stream_query_arrow_with_params_n(
+        conn,
+        query,
+        query ? std::strlen(query) : 0,
+        options,
+        param_names,
+        /*param_name_lens=*/nullptr,
+        param_values,
+        /*param_value_lens=*/nullptr,
+        param_count);
+}
+
+chdb_result * chdb_stream_query_arrow_with_params_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    const chdb_arrow_options * options,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count)
+{
+    if (!conn)
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Unexpected null connection"));
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Invalid or closed connection"));
+
+    try
+    {
+        auto * client = static_cast<DB::ChdbClient *>(connection->server);
+        /// Parameters only need to be present while the statement is parsed
+        /// during init — the engine captures the values then (same contract
+        /// as chdb_stream_query_with_params).
+        const auto params
+            = CHDB::buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
+        CHDB::CApiQueryParameterGuard guard(client, params);
+
+        auto query_result = client->executeStreamingInit(
+            query, query_len,
+            CHUNK_COLLECT_FORMAT_NAME, std::strlen(CHUNK_COLLECT_FORMAT_NAME),
+            /*dataframe_over_chunks=*/false);
         if (!query_result)
             return reinterpret_cast<chdb_result *>(new CHDB::StreamQueryResult("Streaming init failed"));
 
@@ -418,10 +499,17 @@ chdb_state chdb_stream_fetch_arrow(
 
         auto iter_result = client->executeStreamingIterate(stream, false);
         if (!iter_result)
+        {
+            stream->setError("Streaming iterate returned no result");
             return CHDBError;
+        }
 
         if (!iter_result->getError().empty())
+        {
+            /// Surface via chdb_result_error(stream_result).
+            stream->setError(iter_result->getError());
             return CHDBError;
+        }
 
         if (iter_result->getType() != CHDB::QueryResultType::RESULT_TYPE_CHUNK)
         {
@@ -437,6 +525,20 @@ chdb_state chdb_stream_fetch_arrow(
         auto * chunk_iter = static_cast<CHDB::ChunkQueryResult *>(iter_result.get());
         if (!chunk_iter->header || chunk_iter->chunks.empty())
         {
+            /// Zero-row results reach EOS before the converter initializes;
+            /// derive the schema from a zero-row probe chunk (mirrors the
+            /// materialized empty-result path) so column metadata survives.
+            if (chunk_iter->header && !state->header_initialized)
+            {
+                const auto & src_header = chunk_iter->header->getColumnsWithTypeAndName();
+                MutableColumns probe_cols;
+                probe_cols.reserve(src_header.size());
+                for (const auto & h : src_header)
+                    probe_cols.emplace_back(h.type->createColumn());
+                std::vector<Chunk> probe;
+                probe.emplace_back(std::move(probe_cols), 0);
+                ensureConverterInitialized(*state, src_header, &probe.front());
+            }
             auto priv = std::make_unique<OneBatchPrivate>();
             priv->schema = state->schema;
             initOneBatchStream(raw_out, std::move(priv));

--- a/programs/local/chdb-internal.h
+++ b/programs/local/chdb-internal.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <arrow/c/abi.h>
 
+#include <Core/Names.h>
+
 namespace DB
 {
     class ChdbClient;
@@ -28,4 +30,39 @@ const std::string & chdb_result_error_string(chdb_result * result);
 const std::string & chdb_streaming_result_error_string(chdb_streaming_result * result);
 
 void chdb_destroy_arrow_stream(ArrowArrayStream * arrow_stream);
+
+/// Sentinel error texts shared by producers and consumers so fallback
+/// detection can't drift with a reword.
+/// Producer: chdb-arrow-output.cpp (statement yields no result header).
+inline constexpr const char * kErrorMissingResultHeader = "Missing result header for Arrow output";
+/// Producer: ClientBase.cpp, which keeps its literal (upstream-diff file).
+inline constexpr const char * kErrorStreamingNotSupportedPrefix = "Streaming query is not supported";
+
+/// Build a NameToNameMap from parallel C-ABI arrays of parameter names and values.
+/// On duplicate names the last value wins (NameToNameMap == std::unordered_map).
+/// Shared by every *_with_params C entry point (chdb.cpp, chdb-arrow-output.cpp).
+DB::NameToNameMap buildParameterMap(
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/// RAII guard mirroring the Python binding's QueryParameterGuard (see LocalChdb.cpp): sets named
+/// parameters on the client for the duration of one query, then unconditionally clears them.
+/// This matches Python `chdb.query(..., params=...)` semantics — including for streaming, where
+/// parameters only need to be present during the streaming init (the engine captures values then).
+class CApiQueryParameterGuard
+{
+public:
+    CApiQueryParameterGuard(DB::ChdbClient * client_, const DB::NameToNameMap & params);
+    ~CApiQueryParameterGuard();
+
+    CApiQueryParameterGuard(const CApiQueryParameterGuard &) = delete;
+    CApiQueryParameterGuard & operator=(const CApiQueryParameterGuard &) = delete;
+
+private:
+    DB::ChdbClient * client = nullptr;
+    bool applied = false;
+};
 }

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -52,6 +52,10 @@ extern "C"
     extern chdb_result * chdb_stream_query_arrow(chdb_connection, const char *, const chdb_arrow_options *);
     extern chdb_result * chdb_stream_query_arrow_n(chdb_connection, const char *, size_t, const chdb_arrow_options *);
     extern chdb_state chdb_stream_fetch_arrow(chdb_connection, chdb_result *, chdb_arrow_stream);
+    /// ADBC entrypoint (chdb-adbc.cpp). Anchor declaration with erased pointer
+    /// types — C linkage, address-only use; real signature is in adbc/adbc.h.
+    /// Return type matches AdbcStatusCode (uint8_t) without pulling in adbc.h.
+    extern unsigned char chdb_adbc_init(int, void *, void *);
 }
 
 /// Force-link references: chdb-arrow.cpp.o and chdb-arrow-output.cpp.o each
@@ -65,7 +69,8 @@ extern "C"
     reinterpret_cast<void*>(chdb_query_arrow_n),
     reinterpret_cast<void*>(chdb_stream_query_arrow),
     reinterpret_cast<void*>(chdb_stream_query_arrow_n),
-    reinterpret_cast<void*>(chdb_stream_fetch_arrow)
+    reinterpret_cast<void*>(chdb_stream_fetch_arrow),
+    reinterpret_cast<void*>(chdb_adbc_init)
 };
 #endif
 
@@ -631,11 +636,10 @@ chdb_result * chdb_stream_query_n(chdb_connection conn, const char * query, size
     }
 }
 
-namespace
+namespace CHDB
 {
 
-/// Build a NameToNameMap from parallel C-ABI arrays of parameter names and values.
-/// On duplicate names the last value wins (NameToNameMap == std::unordered_map).
+/// See chdb-internal.h — shared by every *_with_params C entry point.
 DB::NameToNameMap buildParameterMap(
     const char * const * param_names,
     const size_t * param_name_lens,
@@ -666,37 +670,23 @@ DB::NameToNameMap buildParameterMap(
     return params;
 }
 
-/// RAII guard mirroring the Python binding's QueryParameterGuard (see LocalChdb.cpp): sets named
-/// parameters on the client for the duration of one query, then unconditionally clears them.
-/// This matches Python `chdb.query(..., params=...)` semantics — including for streaming, where
-/// parameters only need to be present during executeStreamingInit (the engine captures values then).
-class CApiQueryParameterGuard
+CApiQueryParameterGuard::CApiQueryParameterGuard(DB::ChdbClient * client_, const DB::NameToNameMap & params)
+    : client(client_)
 {
-public:
-    CApiQueryParameterGuard(DB::ChdbClient * client_, const DB::NameToNameMap & params) : client(client_)
+    if (client && !params.empty())
     {
-        if (client && !params.empty())
-        {
-            client->setQueryParameters(params);
-            applied = true;
-        }
+        client->setQueryParameters(params);
+        applied = true;
     }
+}
 
-    ~CApiQueryParameterGuard()
-    {
-        if (client && applied)
-            client->clearQueryParameters();
-    }
+CApiQueryParameterGuard::~CApiQueryParameterGuard()
+{
+    if (client && applied)
+        client->clearQueryParameters();
+}
 
-    CApiQueryParameterGuard(const CApiQueryParameterGuard &) = delete;
-    CApiQueryParameterGuard & operator=(const CApiQueryParameterGuard &) = delete;
-
-private:
-    DB::ChdbClient * client = nullptr;
-    bool applied = false;
-};
-
-} // anonymous namespace
+} // namespace CHDB
 
 chdb_result * chdb_query_with_params(
     chdb_connection conn,
@@ -747,8 +737,8 @@ chdb_result * chdb_query_with_params_n(
     try
     {
         auto * client = static_cast<DB::ChdbClient *>(connection->server);
-        const auto params = buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
-        CApiQueryParameterGuard guard(client, params);
+        const auto params = CHDB::buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
+        CHDB::CApiQueryParameterGuard guard(client, params);
 
         auto query_result = client->executeMaterializedQuery(query, query_len, format, format_len);
         return reinterpret_cast<chdb_result *>(query_result.release());
@@ -814,8 +804,8 @@ chdb_result * chdb_stream_query_with_params_n(
     try
     {
         auto * client = static_cast<DB::ChdbClient *>(connection->server);
-        const auto params = buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
-        CApiQueryParameterGuard guard(client, params);
+        const auto params = CHDB::buildParameterMap(param_names, param_name_lens, param_values, param_value_lens, param_count);
+        CHDB::CApiQueryParameterGuard guard(client, params);
 
         auto query_result = client->executeStreamingInit(query, query_len, format, format_len);
         if (!query_result)

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -661,6 +661,31 @@ CHDB_EXPORT chdb_result * chdb_stream_query_arrow_n(
     const chdb_arrow_options * options);
 
 /**
+ * chdb_stream_query_arrow() with server-side {name:Type} parameter binding
+ * (chdb_query_with_params semantics, no SQL interpolation). Parameters are
+ * bound before streaming init and cleared once it returns; fetch, cancel
+ * and destroy work exactly like chdb_stream_query_arrow().
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow_with_params(
+    chdb_connection conn, const char * query,
+    const chdb_arrow_options * options,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Binary-safe variant of chdb_stream_query_arrow_with_params.
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow_with_params_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    const chdb_arrow_options * options,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
  * Pulls the next record batch from a streaming Arrow query into the
  * caller-allocated out_batch (a single-batch ArrowArrayStream). When the
  * stream is exhausted out_batch->get_next() will return a released array

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1225,6 +1225,8 @@ bool ClientBase::processTextAsSingleQuery(const String & full_query)
     else
     {
         streaming_query_context->is_streaming_query = false;
+        /// Prefix matched by chdb-adbc.cpp (kErrorStreamingNotSupportedPrefix
+        /// in chdb-internal.h) — keep in sync when rewording.
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Streaming query is not supported for query: {}", full_query);
     }
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -101,6 +101,10 @@ struct StreamingQueryContext
     void * streaming_result = nullptr;
     bool is_streaming_query = true;
     ThreadGroupPtr thread_group = nullptr;
+    /// What chunk-collect streaming iterate returns: a pandas DataFrame
+    /// (Python default) or raw chunks (the Arrow/ADBC path). Per-stream so
+    /// concurrent streams on one client can differ.
+    bool dataframe_over_chunks = true;
 
     StreamingQueryContext() = default;
 };

--- a/tests/benchmarks/bench_adbc_fetch.py
+++ b/tests/benchmarks/bench_adbc_fetch.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Result-set transfer throughput through the ADBC driver, DuckDB-ADBC style
+(duckdb.org/2023/08/04/adbc): fetch `SELECT *` over a lineitem-shaped table,
+same libchdb build for every transport.
+
+  adbc-stream   streamed Arrow C Data Interface (the driver's path)
+  capi-arrow    chdb_query_arrow via ctypes, materialized
+  capi-csv      CSV serialization baseline (understates a real text
+                consumer's cost: no field parsing included)
+
+Usage: CHDB_LIB_PATH=./libchdb.so python tests/benchmarks/bench_adbc_fetch.py
+"""
+
+import ctypes
+import os
+import statistics
+import time
+
+import pyarrow as pa
+import adbc_driver_manager.dbapi as dbapi
+
+LIB = os.environ.get("CHDB_LIB_PATH", "./libchdb.so")
+N_ROWS = 5_000_000
+WARMUP = 1
+REPEATS = 3
+
+SETUP = f"""
+CREATE TABLE lineitem ENGINE = MergeTree() ORDER BY l_orderkey AS
+SELECT
+    number                        AS l_orderkey,
+    toFloat64(number % 50 + 1)    AS l_quantity,
+    toFloat64(number % 100000) / 100 AS l_extendedprice,
+    toFloat64(number % 10) / 100  AS l_discount,
+    toDate('1994-01-01') + number % 2500 AS l_shipdate,
+    concat('comment_', toString(number % 1000)) AS l_comment
+FROM numbers({N_ROWS})
+"""
+
+QUERY = "SELECT * FROM lineitem"
+
+
+class ArrowArrayStream(ctypes.Structure):
+    _fields_ = [
+        ("get_schema", ctypes.c_void_p),
+        ("get_next", ctypes.c_void_p),
+        ("get_last_error", ctypes.c_void_p),
+        ("release", ctypes.c_void_p),
+        ("private_data", ctypes.c_void_p),
+    ]
+
+
+def bench(fn, *args):
+    for _ in range(WARMUP):
+        fn(*args)
+    times = []
+    for _ in range(REPEATS):
+        t0 = time.perf_counter()
+        rows = fn(*args)
+        times.append(time.perf_counter() - t0)
+        assert rows == N_ROWS, f"row mismatch: {rows}"
+    return statistics.median(times)
+
+
+def main():
+    conn = dbapi.connect(
+        driver=LIB, entrypoint="chdb_adbc_init", autocommit=True
+    )
+    cur = conn.cursor()
+    cur.execute(SETUP)
+
+    # --- adbc-stream ---
+    def adbc_stream():
+        cur.execute(QUERY)
+        return sum(b.num_rows for b in cur.fetch_record_batch())
+
+    # --- capi paths share the ADBC connection's engine via a second handle ---
+    lib = ctypes.CDLL(LIB)
+    lib.chdb_connect.restype = ctypes.c_void_p
+    lib.chdb_connect.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+    lib.chdb_query.restype = ctypes.c_void_p
+    lib.chdb_query.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib.chdb_query_arrow.restype = ctypes.c_void_p
+    lib.chdb_query_arrow.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_void_p
+    ]
+    lib.chdb_result_error.restype = ctypes.c_char_p
+    lib.chdb_result_error.argtypes = [ctypes.c_void_p]
+    lib.chdb_result_length.restype = ctypes.c_size_t
+    lib.chdb_result_length.argtypes = [ctypes.c_void_p]
+    lib.chdb_result_buffer.restype = ctypes.POINTER(ctypes.c_char)
+    lib.chdb_result_buffer.argtypes = [ctypes.c_void_p]
+    lib.chdb_destroy_query_result.restype = None
+    lib.chdb_destroy_query_result.argtypes = [ctypes.c_void_p]
+
+    argv = (ctypes.c_char_p * 1)(b"clickhouse")
+    conn_pp = lib.chdb_connect(1, argv)
+    capi_conn = ctypes.c_void_p.from_address(conn_pp).value
+
+    def capi_arrow():
+        stream = ArrowArrayStream()
+        res = lib.chdb_query_arrow(
+            capi_conn, QUERY.encode(), ctypes.byref(stream), None
+        )
+        err = lib.chdb_result_error(res)
+        assert not err, err
+        reader = pa.RecordBatchReader._import_from_c(ctypes.addressof(stream))
+        rows = sum(b.num_rows for b in reader)
+        lib.chdb_destroy_query_result(res)
+        return rows
+
+    def capi_csv():
+        res = lib.chdb_query(capi_conn, QUERY.encode(), b"CSV")
+        err = lib.chdb_result_error(res)
+        assert not err, err
+        n = lib.chdb_result_length(res)
+        buf = ctypes.string_at(lib.chdb_result_buffer(res), n)
+        rows = buf.count(b"\n")
+        lib.chdb_destroy_query_result(res)
+        return rows
+
+    results = {}
+    for name, fn in [
+        ("adbc-stream", adbc_stream),
+        ("capi-arrow", capi_arrow),
+        ("capi-csv", capi_csv),
+    ]:
+        secs = bench(fn)
+        results[name] = secs
+        print(f"{name:14s} {secs:7.3f} s   {N_ROWS / secs / 1e6:6.1f} M rows/s")
+
+    base = results["capi-csv"]
+    for name in ("adbc-stream", "capi-arrow"):
+        print(f"{name} vs csv: {base / results[name]:.1f}x faster")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adbc_driver.py
+++ b/tests/test_adbc_driver.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""ADBC driver tests: load the driver through the standard driver manager
+(driver=<path>, entrypoint="chdb_adbc_init") — the exact path any external
+consumer uses. Works against libchdb.so or the Python module's _chdb.abi3.so;
+CHDB_LIB_PATH overrides discovery. Skips when dependencies are missing."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+try:
+    import pyarrow as pa
+    from adbc_driver_manager import dbapi as adbc_dbapi
+except ImportError:  # pragma: no cover - optional test dependency
+    pa = None
+    adbc_dbapi = None
+
+
+def _candidate_libchdb_paths():
+    if os.environ.get("CHDB_LIB_PATH"):
+        yield os.environ["CHDB_LIB_PATH"]
+    here = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(here)
+    names = ["libchdb.so", "libchdb.dylib"]
+    yield from (os.path.join(project_root, n) for n in names)
+    yield from (os.path.join(project_root, "buildlib", n) for n in names)
+    on_path = shutil.which("libchdb.so")
+    if on_path:
+        yield on_path
+    # Installed chdb package (wheel CI): the module doubles as the driver.
+    try:
+        import importlib.util as _ilu
+
+        _spec = _ilu.find_spec("chdb")
+        if _spec and _spec.origin:
+            yield os.path.join(os.path.dirname(_spec.origin), "_chdb.abi3.so")
+    except (ImportError, ValueError):
+        pass
+
+
+def _find_libchdb_path():
+    for path in _candidate_libchdb_paths():
+        if os.path.exists(path):
+            return path
+    return None
+
+
+_LIBCHDB_PATH = _find_libchdb_path()
+
+# The Python module doubles as the driver, but its pybind runtime must be
+# initialized by a normal import before the ADBC entrypoint is used — the
+# same order the locator package uses (import _chdb, then _chdb.__file__).
+if _LIBCHDB_PATH and _LIBCHDB_PATH.endswith(".abi3.so"):
+    import importlib.util
+
+    _spec = importlib.util.spec_from_file_location("_chdb", _LIBCHDB_PATH)
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+
+
+def _has_adbc_entrypoint(path):
+    if path is None or adbc_dbapi is None:
+        return False
+    try:
+        conn = adbc_dbapi.connect(
+            driver=path, entrypoint="chdb_adbc_init", autocommit=True
+        )
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+_SKIP_REASON = (
+    "adbc_driver_manager/pyarrow not installed"
+    if adbc_dbapi is None
+    else "libchdb with chdb_adbc_init not found"
+)
+_ENABLED = _has_adbc_entrypoint(_LIBCHDB_PATH)
+
+
+def _connect(path=":memory:"):
+    # autocommit=True matches the driver's transaction model (autocommit-only)
+    # and avoids the DB-API compliance warning from the default connect path.
+    return adbc_dbapi.connect(
+        driver=_LIBCHDB_PATH,
+        entrypoint="chdb_adbc_init",
+        db_kwargs={"path": path},
+        autocommit=True,
+    )
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcQuery(unittest.TestCase):
+    def test_select_arrow_result(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT number AS n, toString(number) AS s FROM numbers(5)"
+            )
+            table = cur.fetch_arrow_table()
+        self.assertEqual(table.num_rows, 5)
+        self.assertEqual(table.column_names, ["n", "s"])
+        self.assertEqual(table.column("n").to_pylist(), [0, 1, 2, 3, 4])
+        self.assertEqual(table.column("s").to_pylist(), ["0", "1", "2", "3", "4"])
+
+    def test_empty_stream_outlives_connection(self):
+        # A schema-only (empty) streaming result must stay safe to read and
+        # release after the statement, connection, and database are closed —
+        # it detaches from the connection at wire-up.
+        from adbc_driver_manager import AdbcConnection, AdbcDatabase, AdbcStatement
+
+        db = AdbcDatabase(driver=_LIBCHDB_PATH, entrypoint="chdb_adbc_init")
+        conn = AdbcConnection(db)
+        stmt = AdbcStatement(conn)
+        stmt.set_sql_query("SELECT 1 AS x WHERE 0")
+        handle, _ = stmt.execute_query()
+        reader = pa.RecordBatchReader._import_from_c(handle.address)
+        stmt.close()
+        conn.close()
+        db.close()
+        self.assertEqual(reader.read_all().num_rows, 0)
+        del reader
+
+    def test_connect_without_entrypoint(self):
+        # AdbcDriverInit (the default name driver managers probe) is exported
+        # as an alias, so the entrypoint argument is optional.
+        conn = adbc_dbapi.connect(
+            driver=_LIBCHDB_PATH, db_kwargs={"path": ":memory:"}, autocommit=True
+        )
+        with conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            self.assertEqual(cur.fetchone()[0], 1)
+
+    def test_fetchone_via_dbapi(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT 21 * 2 AS answer")
+            row = cur.fetchone()
+        self.assertEqual(row[0], 42)
+
+    def test_large_result_streams_in_batches(self):
+        # ExecuteQuery goes through the streaming Arrow path: a large result
+        # arrives as multiple record batches instead of one materialized blob.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT number FROM numbers(1000000)")
+            reader = cur.fetch_record_batch()
+            batches = list(reader)
+        self.assertGreater(len(batches), 1)
+        self.assertEqual(sum(b.num_rows for b in batches), 1000000)
+
+    def test_empty_select_preserves_schema(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT number AS n, toString(number) AS s "
+                "FROM numbers(10) WHERE number < 0"
+            )
+            tbl = cur.fetch_arrow_table()
+        self.assertEqual(tbl.num_rows, 0)
+        self.assertEqual(tbl.column_names, ["n", "s"])
+
+    def test_different_statement_rejected_while_stream_open(self):
+        # ADBC concurrency: chDB runs one statement at a time and cannot buffer
+        # a live stream, so a DIFFERENT statement's execute is rejected (not a
+        # silent invalidation of the open reader). The first reader stays valid.
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn:
+            cur1 = conn.cursor()
+            cur1.execute("SELECT number FROM numbers(1000000)")
+            r1 = iter(cur1.fetch_record_batch())
+            b0 = next(r1)  # partially consumed, stream still live
+
+            cur2 = conn.cursor()
+            with self.assertRaises(Exception) as ctx:
+                cur2.execute("SELECT number + 5000000 FROM numbers(1000000)")
+            self.assertEqual(ctx.exception.status_code, AdbcStatusCode.INVALID_STATE)
+
+            total1 = b0.num_rows + sum(b.num_rows for b in r1)  # r1 reads to the end
+            self.assertEqual(total1, 1000000)
+            cur1.close()
+            cur2.close()
+
+    def test_same_statement_reexecute_invalidates_own_stream(self):
+        # The spec REQUIRES a statement's next execute to invalidate its own
+        # prior result. Re-executing the same cursor works; the old reader
+        # fails with a clear message.
+        with _connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT number FROM numbers(1000000)")
+            r1 = iter(cur.fetch_record_batch())
+            next(r1)
+
+            cur.execute("SELECT 42")  # same statement reused — allowed, no error
+            self.assertEqual(cur.fetchone()[0], 42)
+
+            # The old reader is now dead; the exact message depends on which
+            # layer closes it (driver invalidation vs the dbapi cursor's own
+            # result teardown), so just require that reading it fails.
+            with self.assertRaises(Exception):
+                for _ in r1:
+                    pass
+            cur.close()
+
+    def test_metadata_call_rejected_while_stream_open(self):
+        # A metadata call is not a statement reuse, so an open live stream
+        # makes it fail with INVALID_STATE rather than being silently killed.
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT number FROM numbers(1000000)")
+            reader = iter(cur.fetch_record_batch())
+            b0 = next(reader)
+
+            with self.assertRaises(Exception) as ctx:
+                conn.adbc_get_objects(depth="db_schemas").read_all()
+            self.assertEqual(ctx.exception.status_code, AdbcStatusCode.INVALID_STATE)
+
+            total = b0.num_rows + sum(b.num_rows for b in reader)  # stream untouched
+            self.assertEqual(total, 1000000)
+            cur.close()
+
+    def test_abandoned_stream_leaves_connection_usable(self):
+        with _connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT number FROM numbers(1000000)")
+            reader = iter(cur.fetch_record_batch())
+            next(reader)
+            del reader  # abandon mid-stream: release() cancels the query
+            cur.execute("SELECT 7")
+            self.assertEqual(cur.fetchone()[0], 7)
+            cur.close()
+
+    def test_error_reports_message(self):
+        with _connect() as conn, conn.cursor() as cur:
+            with self.assertRaises(Exception) as ctx:
+                cur.execute("SELECT * FROM this_table_does_not_exist_42")
+            self.assertIn("this_table_does_not_exist_42", str(ctx.exception))
+
+    def test_execute_update_ddl_and_insert(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("CREATE DATABASE IF NOT EXISTS adbc_t")
+            cur.execute(
+                "CREATE TABLE adbc_t.upd (x Int64) ENGINE = MergeTree() ORDER BY x"
+            )
+            cur.execute("INSERT INTO adbc_t.upd SELECT number FROM numbers(10)")
+            cur.execute("SELECT count() FROM adbc_t.upd")
+            self.assertEqual(cur.fetchone()[0], 10)
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcIngest(unittest.TestCase):
+    def _table(self, n=6, offset=0):
+        return pa.table(
+            {
+                "id": pa.array(range(offset, offset + n), pa.int64()),
+                "name": pa.array([f"row{i}" for i in range(offset, offset + n)]),
+            }
+        )
+
+    def test_ingest_create_and_append(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ingest_ca", self._table(6), mode="create")
+            cur.execute("SELECT count() FROM ingest_ca")
+            self.assertEqual(cur.fetchone()[0], 6)
+
+            cur.adbc_ingest("ingest_ca", self._table(4, offset=6), mode="append")
+            cur.execute("SELECT count(), max(id) FROM ingest_ca")
+            self.assertEqual(cur.fetchone(), (10, 9))
+
+    def test_ingest_replace(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ingest_rep", self._table(6), mode="create")
+            cur.adbc_ingest("ingest_rep", self._table(2), mode="replace")
+            cur.execute("SELECT count() FROM ingest_rep")
+            self.assertEqual(cur.fetchone()[0], 2)
+
+    def test_ingest_create_append(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ingest_capp", self._table(3), mode="create_append")
+            cur.adbc_ingest("ingest_capp", self._table(3), mode="create_append")
+            cur.execute("SELECT count() FROM ingest_capp")
+            self.assertEqual(cur.fetchone()[0], 6)
+
+    def test_ingest_create_existing_fails(self):
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ingest_dup", self._table(1), mode="create")
+            with self.assertRaises(Exception) as ctx:
+                cur.adbc_ingest("ingest_dup", self._table(1), mode="create")
+        self.assertEqual(ctx.exception.status_code, AdbcStatusCode.ALREADY_EXISTS)
+
+    def test_ingest_create_append_schema_mismatch(self):
+        from adbc_driver_manager import AdbcStatusCode
+
+        mismatched = pa.table({"id": [1], "extra": ["x"]})
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ingest_mismatch", self._table(2), mode="create_append")
+            with self.assertRaises(Exception) as ctx:
+                cur.adbc_ingest("ingest_mismatch", mismatched, mode="create_append")
+        self.assertEqual(ctx.exception.status_code, AdbcStatusCode.ALREADY_EXISTS)
+
+    def test_ingest_target_db_schema(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("CREATE DATABASE IF NOT EXISTS ingest_tgt")
+            cur.adbc_ingest(
+                "in_schema", self._table(3), mode="create",
+                db_schema_name="ingest_tgt",
+            )
+            cur.execute("SELECT count() FROM ingest_tgt.in_schema")
+            self.assertEqual(cur.fetchone()[0], 3)
+
+    def test_ingest_maps_field_nullability(self):
+        t = pa.table(
+            {"nn": pa.array([1, 2], pa.int64()), "nu": pa.array([1, None], pa.int64())},
+            schema=pa.schema(
+                [pa.field("nn", pa.int64(), nullable=False),
+                 pa.field("nu", pa.int64(), nullable=True)]
+            ),
+        )
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ing_null", t, mode="create")
+            cur.execute(
+                "SELECT name, type FROM system.columns "
+                "WHERE table = 'ing_null' AND database = currentDatabase() ORDER BY name"
+            )
+            self.assertEqual(
+                cur.fetchall(), [("nn", "Int64"), ("nu", "Nullable(Int64)")]
+            )
+
+    def test_ingest_roundtrip_values(self):
+        table = self._table(5)
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_ingest("ingest_rt", table, mode="create")
+            cur.execute("SELECT id, name FROM ingest_rt ORDER BY id")
+            got = cur.fetch_arrow_table()
+        self.assertEqual(got.column("id").to_pylist(), table.column("id").to_pylist())
+        self.assertEqual(
+            got.column("name").to_pylist(), table.column("name").to_pylist()
+        )
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcParameters(unittest.TestCase):
+    def test_positional_select(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT ? + 1 AS v, upper(?) AS s", (41, "abc"))
+            self.assertEqual(cur.fetchone(), (42, "ABC"))
+
+    def test_param_types_roundtrip(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT ? AS f, ? AS b, toTypeName(?) AS t",
+                (2.5, True, 7),
+            )
+            row = cur.fetchone()
+        self.assertEqual(row[0], 2.5)
+        self.assertEqual(row[1], True)
+        self.assertEqual(row[2], "Int64")
+
+    def test_null_param(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT isNull(?) AS n", (None,))
+            self.assertEqual(cur.fetchone()[0], 1)
+
+    def test_placeholder_in_literal_not_bound(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT '?q' AS lit, ? AS v", (5,))
+            self.assertEqual(cur.fetchone(), ("?q", 5))
+
+    def test_executemany_insert(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE param_many (id Int64, name String) "
+                "ENGINE = MergeTree() ORDER BY id"
+            )
+            cur.executemany(
+                "INSERT INTO param_many VALUES (?, ?)",
+                [(1, "a"), (2, "b"), (3, "c")],
+            )
+            cur.execute("SELECT count(), sum(id) FROM param_many")
+            self.assertEqual(cur.fetchone(), (3, 6))
+
+    def test_multi_row_bind_concatenates_result_sets(self):
+        # Binding several parameter rows to a result-returning statement runs
+        # it once per row and concatenates the per-execution results.
+        params = pa.RecordBatch.from_pydict({"0": pa.array([1, 2, 3, 4], pa.int64())})
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_statement.set_sql_query("SELECT 1 + ? AS v")
+            cur.adbc_statement.bind(params)
+            handle, _ = cur.adbc_statement.execute_query()
+            result = pa.RecordBatchReader._import_from_c(handle.address).read_all()
+        self.assertEqual(result.column("v").to_pylist(), [2, 3, 4, 5])
+
+    def test_param_injection_is_inert(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT ? AS s", ("'; DROP TABLE x; --",))
+            self.assertEqual(cur.fetchone()[0], "'; DROP TABLE x; --")
+
+    def test_param_string_control_chars_roundtrip(self):
+        # Parameter values travel as escaped text: tab/newline would end the
+        # value mid-parse and a bare backslash-N would read as NULL.
+        cases = ["tab\there", "new\nline", "cr\rhere", "back\\slash", "\\N", "mix\t\\N\nend"]
+        with _connect() as conn, conn.cursor() as cur:
+            for v in cases:
+                cur.execute("SELECT ? AS s", (v,))
+                self.assertEqual(cur.fetchone()[0], v)
+
+    def test_multi_row_bind_null_and_backslash_n_distinct(self):
+        # In concatenated executions a real NULL and the literal string
+        # backslash-N must stay distinguishable.
+        params = pa.RecordBatch.from_pydict(
+            {"0": pa.array(["\\N", None, "x\ty"], pa.string())}
+        )
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_statement.set_sql_query("SELECT ? AS s")
+            cur.adbc_statement.bind(params)
+            handle, _ = cur.adbc_statement.execute_query()
+            result = pa.RecordBatchReader._import_from_c(handle.address).read_all()
+        self.assertEqual(result.column("s").to_pylist(), ["\\N", None, "x\ty"])
+
+    def test_param_temporal_and_decimal(self):
+        import datetime
+        import decimal
+
+        d = datetime.date(2024, 5, 17)
+        dt = datetime.datetime(2024, 5, 17, 12, 34, 56, 789000)
+        dec = decimal.Decimal("12345.67")
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT ? AS d, ? AS dt, ? AS dec", (d, dt, dec))
+            row = cur.fetchone()
+        self.assertEqual(row[0], d)
+        # DateTime64 carries the server timezone; the wall-clock value of a
+        # naive datetime parameter is preserved.
+        self.assertEqual(row[1].replace(tzinfo=None), dt)
+        self.assertEqual(row[2], dec)
+
+    def test_param_binary_is_binary_safe(self):
+        blob = b"\x00\x01\xff"
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT hex(?) AS h, length(?) AS l", (blob, blob))
+            row = cur.fetchone()
+        self.assertEqual(row[0], "0001FF")
+        self.assertEqual(row[1], 3)
+
+    def test_param_int64_boundaries(self):
+        lo, hi = -(2**63), 2**63 - 1
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT ? AS lo, ? AS hi", (lo, hi))
+            self.assertEqual(cur.fetchone(), (lo, hi))
+
+    def test_param_unicode(self):
+        s = "中文 🚀 '; -- $tag$"
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT ? AS s", (s,))
+            self.assertEqual(cur.fetchone()[0], s)
+
+    def test_executemany_mixed_types_with_nulls(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE param_mixed (id Int64, v Nullable(Float64)) "
+                "ENGINE = MergeTree() ORDER BY id"
+            )
+            cur.executemany(
+                "INSERT INTO param_mixed VALUES (?, ?)",
+                [(1, 1.5), (2, None), (3, 2.5)],
+            )
+            cur.execute(
+                "SELECT count(), sum(v), countIf(v IS NULL) FROM param_mixed"
+            )
+            self.assertEqual(cur.fetchone(), (3, 4.0, 1))
+
+    def test_parameterized_large_result_streams(self):
+        # Parameterized SELECTs go through the streaming Arrow path too:
+        # a large result arrives as multiple record batches.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT number + ? FROM numbers(1000000)", (1,))
+            reader = cur.fetch_record_batch()
+            batches = list(reader)
+        self.assertGreater(len(batches), 1)
+        self.assertEqual(sum(b.num_rows for b in batches), 1000000)
+
+    def test_rowcount_distinguishes_zero_from_unknown(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("CREATE TABLE rc (x Int64) ENGINE = Memory")
+            self.assertEqual(cur.rowcount, -1)  # DDL: not applicable
+            cur.execute("INSERT INTO rc SELECT number FROM numbers(5)")
+            self.assertEqual(cur.rowcount, 5)
+            cur.execute("INSERT INTO rc SELECT number FROM numbers(9) WHERE 0")
+            self.assertEqual(cur.rowcount, 0)   # a known zero, not unknown
+            cur.executemany("INSERT INTO rc VALUES (?)", [(7,), (8,)])
+            self.assertEqual(cur.rowcount, 2)
+
+    def test_executemany_fallback_zero_rows_is_known(self):
+        # INSERT ... SELECT ? WHERE 0 is not the plain-VALUES shape, so it
+        # takes the per-row fallback; every execution writes zero rows and
+        # the total must be a known 0, not "unknown" (-1).
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("CREATE TABLE rc_zero (x Int64) ENGINE = Memory")
+            cur.executemany(
+                "INSERT INTO rc_zero SELECT ? WHERE 0", [(1,), (2,), (3,)]
+            )
+            self.assertEqual(cur.rowcount, 0)
+            cur.execute("SELECT count() FROM rc_zero")
+            self.assertEqual(cur.fetchone()[0], 0)
+
+    def test_heredoc_string_with_question_mark(self):
+        # Heredoc strings are tokenized by the engine lexer: a `?` inside
+        # one is literal text, not a placeholder.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT $$a?b$$ AS s, ? AS v", (5,))
+            self.assertEqual(cur.fetchone(), ("a?b", 5))
+
+    def test_executemany_large_batch(self):
+        # The plain INSERT ... VALUES (?, ...) shape streams all bound rows
+        # through one statement.
+        rows = [(i, float(i) / 2) for i in range(5000)]
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE many_fast (id Int64, v Float64) "
+                "ENGINE = MergeTree() ORDER BY id"
+            )
+            cur.executemany("INSERT INTO many_fast (id, v) VALUES (?, ?)", rows)
+            cur.execute("SELECT count(), sum(id) FROM many_fast")
+            self.assertEqual(cur.fetchone(), (5000, sum(r[0] for r in rows)))
+
+    def test_executemany_expression_falls_back(self):
+        # A constant mixed into VALUES doesn't match the fast-path shape;
+        # the per-row path must produce the same result.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE many_slow (id Int64, tag Int64) "
+                "ENGINE = MergeTree() ORDER BY id"
+            )
+            cur.executemany(
+                "INSERT INTO many_slow VALUES (?, 7)", [(1,), (2,), (3,)]
+            )
+            cur.execute("SELECT count(), sum(tag) FROM many_slow")
+            self.assertEqual(cur.fetchone(), (3, 21))
+
+    def test_param_count_mismatch(self):
+        with _connect() as conn, conn.cursor() as cur:
+            with self.assertRaises(Exception) as ctx:
+                cur.execute("SELECT ? + ?", (1,))
+            self.assertIn("placeholder", str(ctx.exception))
+
+
+def _expected_get_objects_schema():
+    """The GetObjects result schema mandated by the ADBC spec, transcribed
+    independently from the C++ definition so a typo in either side fails
+    the equality assertion (adbc.h 'Connection Metadata' section)."""
+    usage = pa.struct(
+        [
+            pa.field("fk_catalog", pa.utf8()),
+            pa.field("fk_db_schema", pa.utf8()),
+            pa.field("fk_table", pa.utf8(), nullable=False),
+            pa.field("fk_column_name", pa.utf8(), nullable=False),
+        ]
+    )
+    constraint = pa.struct(
+        [
+            pa.field("constraint_name", pa.utf8()),
+            pa.field("constraint_type", pa.utf8(), nullable=False),
+            pa.field("constraint_column_names", pa.list_(pa.utf8()), nullable=False),
+            pa.field("constraint_column_usage", pa.list_(usage)),
+        ]
+    )
+    column = pa.struct(
+        [
+            pa.field("column_name", pa.utf8(), nullable=False),
+            pa.field("ordinal_position", pa.int32()),
+            pa.field("remarks", pa.utf8()),
+            pa.field("xdbc_data_type", pa.int16()),
+            pa.field("xdbc_type_name", pa.utf8()),
+            pa.field("xdbc_column_size", pa.int32()),
+            pa.field("xdbc_decimal_digits", pa.int16()),
+            pa.field("xdbc_num_prec_radix", pa.int16()),
+            pa.field("xdbc_nullable", pa.int16()),
+            pa.field("xdbc_column_def", pa.utf8()),
+            pa.field("xdbc_sql_data_type", pa.int16()),
+            pa.field("xdbc_datetime_sub", pa.int16()),
+            pa.field("xdbc_char_octet_length", pa.int32()),
+            pa.field("xdbc_is_nullable", pa.utf8()),
+            pa.field("xdbc_scope_catalog", pa.utf8()),
+            pa.field("xdbc_scope_schema", pa.utf8()),
+            pa.field("xdbc_scope_table", pa.utf8()),
+            pa.field("xdbc_is_autoincrement", pa.bool_()),
+            pa.field("xdbc_is_generatedcolumn", pa.bool_()),
+        ]
+    )
+    table = pa.struct(
+        [
+            pa.field("table_name", pa.utf8(), nullable=False),
+            pa.field("table_type", pa.utf8(), nullable=False),
+            pa.field("table_columns", pa.list_(column)),
+            pa.field("table_constraints", pa.list_(constraint)),
+        ]
+    )
+    db_schema = pa.struct(
+        [
+            pa.field("db_schema_name", pa.utf8()),
+            pa.field("db_schema_tables", pa.list_(table)),
+        ]
+    )
+    return pa.schema(
+        [
+            pa.field("catalog_name", pa.utf8()),
+            pa.field("catalog_db_schemas", pa.list_(db_schema)),
+        ]
+    )
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcGetObjects(unittest.TestCase):
+    def _objects(self, conn, **kwargs):
+        return conn.adbc_get_objects(**kwargs).read_all().to_pylist()
+
+    def test_schema_matches_spec(self):
+        with _connect() as conn:
+            got = conn.adbc_get_objects(depth="all").read_all().schema
+        self.assertEqual(got, _expected_get_objects_schema())
+
+    def test_depth_all_finds_table_and_columns(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE obj_probe (a Int64, b String) "
+                "ENGINE = MergeTree() ORDER BY a"
+            )
+            catalogs = self._objects(conn, depth="all")
+        self.assertEqual(len(catalogs), 1)
+        schemas = {s["db_schema_name"]: s for s in catalogs[0]["catalog_db_schemas"]}
+        self.assertIn("default", schemas)
+        self.assertIn("system", schemas)
+        tables = {t["table_name"]: t for t in schemas["default"]["db_schema_tables"]}
+        self.assertIn("obj_probe", tables)
+        self.assertEqual(tables["obj_probe"]["table_type"], "BASE TABLE")
+        columns = {
+            c["column_name"]: c for c in tables["obj_probe"]["table_columns"]
+        }
+        self.assertEqual(set(columns), {"a", "b"})
+        self.assertEqual(columns["a"]["ordinal_position"], 1)
+        self.assertEqual(columns["a"]["xdbc_type_name"], "Int64")
+
+    def test_empty_db_schema_filter_matches_nothing(self):
+        # Spec: an empty string selects objects *without* a database schema;
+        # every table here has one, so the catalog row carries no schemas.
+        with _connect() as conn:
+            catalogs = conn.adbc_get_objects(
+                depth="all", db_schema_filter=""
+            ).read_all().to_pylist()
+        self.assertEqual(len(catalogs), 1)
+        self.assertEqual(catalogs[0]["catalog_db_schemas"], [])
+
+    def test_nonmatching_catalog_filter_yields_zero_rows(self):
+        with _connect() as conn:
+            table = conn.adbc_get_objects(
+                depth="all", catalog_filter="no_such_catalog"
+            ).read_all()
+        self.assertEqual(table.num_rows, 0)
+
+    def test_depth_db_schemas_has_null_tables(self):
+        with _connect() as conn:
+            catalogs = self._objects(conn, depth="db_schemas")
+        schemas = catalogs[0]["catalog_db_schemas"]
+        self.assertTrue(len(schemas) >= 1)
+        self.assertIsNone(schemas[0]["db_schema_tables"])
+
+    def test_table_name_filter(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE filter_me (x Int64) ENGINE = MergeTree() ORDER BY x"
+            )
+            catalogs = self._objects(
+                conn, depth="all", table_name_filter="filter_%"
+            )
+        schemas = {s["db_schema_name"]: s for s in catalogs[0]["catalog_db_schemas"]}
+        names = [t["table_name"] for t in schemas["default"]["db_schema_tables"]]
+        self.assertEqual(names, ["filter_me"])
+
+    def test_view_table_type(self):
+        # Note: the table-type *filter* (GetObjects' table_type argument) is
+        # implemented in the driver but cannot be exercised from Python —
+        # adbc_driver_manager's bindings pass NULL for it ("TODO: support
+        # table_types" in _lib.pyx). Assert the classification instead.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE view_base (x Int64) ENGINE = MergeTree() ORDER BY x"
+            )
+            cur.execute("CREATE VIEW view_probe AS SELECT * FROM view_base")
+            catalogs = self._objects(conn, depth="all")
+        schemas = {s["db_schema_name"]: s for s in catalogs[0]["catalog_db_schemas"]}
+        tables = {t["table_name"]: t for t in schemas["default"]["db_schema_tables"]}
+        self.assertEqual(tables["view_probe"]["table_type"], "VIEW")
+        self.assertEqual(tables["view_base"]["table_type"], "BASE TABLE")
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcMetadata(unittest.TestCase):
+    def test_get_info(self):
+        with _connect() as conn:
+            info = conn.adbc_get_info()
+        self.assertEqual(info["vendor_name"], "ClickHouse")
+        self.assertEqual(info["driver_name"], "ADBC chDB Driver")
+        self.assertTrue(info["vendor_version"])
+        # driver_version is semver-shaped (at most three components), unlike
+        # the four-component vendor_version.
+        self.assertRegex(info["driver_version"], r"^\d+(\.\d+){0,2}$")
+        self.assertRegex(info["driver_arrow_version"], r"^v\d+")
+        # Capability-probe fields for upper layers. The driver manager maps
+        # some codes to friendly names and leaves others as the numeric code
+        # (3 = VENDOR_SQL, 4 = VENDOR_SUBSTRAIT).
+        self.assertRegex(info["vendor_arrow_version"], r"^v\d+")
+        self.assertIs(info[3], True)
+        self.assertIs(info[4], False)
+
+    def test_current_db_schema_option(self):
+        with _connect() as conn:
+            self.assertEqual(conn.adbc_current_db_schema, "default")
+
+    def test_get_table_schema_missing_table_is_not_found(self):
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn:
+            with self.assertRaises(Exception) as ctx:
+                conn.adbc_get_table_schema("definitely_missing_table")
+        self.assertEqual(ctx.exception.status_code, AdbcStatusCode.NOT_FOUND)
+
+    def test_get_table_schema(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE schema_probe (a Int64, b String) "
+                "ENGINE = MergeTree() ORDER BY a"
+            )
+            schema = conn.adbc_get_table_schema("schema_probe")
+        self.assertEqual(schema.names, ["a", "b"])
+        self.assertEqual(schema.field("a").type, pa.int64())
+
+    def test_get_table_types(self):
+        with _connect() as conn:
+            types = conn.adbc_get_table_types()
+        self.assertIn("BASE TABLE", types)
+
+    def test_autocommit_only(self):
+        with _connect() as conn:
+            # dbapi defaults to autocommit for this driver setup; explicit
+            # commit on the raw connection must report INVALID_STATE.
+            with self.assertRaises(Exception):
+                conn.adbc_connection.commit()
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcUri(unittest.TestCase):
+    def _connect_uri(self, uri):
+        return adbc_dbapi.connect(
+            driver=_LIBCHDB_PATH,
+            entrypoint="chdb_adbc_init",
+            db_kwargs={"uri": uri},
+            autocommit=True,
+        )
+
+    def _roundtrip(self, uri, expect_dir):
+        with self._connect_uri(uri) as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            self.assertEqual(cur.fetchone()[0], 1)
+        self.assertTrue(os.path.isdir(expect_dir), expect_dir)
+
+    def test_file_uri_forms(self):
+        base = tempfile.mkdtemp(prefix="chdb_uri_")
+        try:
+            self._roundtrip(f"file:{base}/u1", f"{base}/u1")
+            self._roundtrip(f"file://{base}/u2", f"{base}/u2")
+            self._roundtrip(f"file://localhost{base}/u3", f"{base}/u3")
+            self._roundtrip(f"file:{base}/my%20db", f"{base}/my db")
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+
+    def test_non_file_scheme_rejected(self):
+        with self.assertRaises(Exception) as ctx:
+            self._connect_uri("http://example.com/db")
+        self.assertIn("scheme", str(ctx.exception).lower())
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcPersistence(unittest.TestCase):
+    def test_on_disk_path_roundtrip(self):
+        # Engine state is process-global with one storage path; this test
+        # exercises connect/reconnect against the same on-disk path.
+        tmp = tempfile.mkdtemp(prefix="chdb_adbc_")
+        try:
+            with _connect(tmp) as conn, conn.cursor() as cur:
+                cur.adbc_ingest(
+                    "persisted",
+                    pa.table({"v": pa.array([1, 2, 3], pa.int64())}),
+                    mode="create",
+                )
+            with _connect(tmp) as conn, conn.cursor() as cur:
+                cur.execute("SELECT sum(v) FROM persisted")
+                self.assertEqual(cur.fetchone()[0], 6)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_arrow_c_data_output.py
+++ b/tests/test_arrow_c_data_output.py
@@ -91,6 +91,15 @@ def _bind(lib):
     lib.chdb_result_error.argtypes = [ctypes.c_void_p]
     lib.chdb_result_error.restype = ctypes.c_char_p
 
+    # Streaming parameter-binding variant; absent when running against an older lib.
+    if hasattr(lib, "chdb_stream_query_arrow_with_params"):
+        lib.chdb_stream_query_arrow_with_params.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_char_p),
+            ctypes.c_size_t,
+        ]
+        lib.chdb_stream_query_arrow_with_params.restype = ctypes.c_void_p
+
 
 LIBCHDB = None
 if _LIBCHDB_PATH is not None:
@@ -218,6 +227,60 @@ class TestArrowCDataOutput(unittest.TestCase):
             LIBCHDB.chdb_destroy_query_result(stream_result)
 
         self.assertEqual(total_rows, 1000)
+
+    def test_streaming_with_params_value_roundtrip(self):
+        if not hasattr(LIBCHDB, "chdb_stream_query_arrow_with_params"):
+            self.skipTest("libchdb lacks chdb_stream_query_arrow_with_params")
+        sql = "SELECT number + {off:Int64} AS v FROM numbers({n:UInt64})"
+        params = {"off": "100", "n": "1000"}
+        names = (ctypes.c_char_p * len(params))(*[k.encode() for k in params])
+        values = (ctypes.c_char_p * len(params))(*[v.encode() for v in params.values()])
+        stream_result = LIBCHDB.chdb_stream_query_arrow_with_params(
+            self.conn, sql.encode("utf-8"), None, names, values, len(params))
+        err = LIBCHDB.chdb_result_error(stream_result)
+        if err:
+            LIBCHDB.chdb_destroy_query_result(stream_result)
+            self.fail(err.decode())
+
+        try:
+            total_rows = 0
+            first_value = None
+            for _ in range(2048):
+                batch = ArrowArrayStream()
+                state = LIBCHDB.chdb_stream_fetch_arrow(
+                    self.conn, stream_result, ctypes.byref(batch))
+                if state != 0:
+                    break
+                reader = pa.RecordBatchReader._import_from_c(ctypes.addressof(batch))
+                tbl = reader.read_all()
+                if tbl.num_rows == 0:
+                    break
+                if first_value is None:
+                    first_value = tbl.column("v")[0].as_py()
+                total_rows += tbl.num_rows
+        finally:
+            LIBCHDB.chdb_destroy_query_result(stream_result)
+
+        self.assertEqual(total_rows, 1000)
+        self.assertEqual(first_value, 100)
+
+    def test_streaming_with_params_missing_substitution_errors(self):
+        if not hasattr(LIBCHDB, "chdb_stream_query_arrow_with_params"):
+            self.skipTest("libchdb lacks chdb_stream_query_arrow_with_params")
+        stream_result = LIBCHDB.chdb_stream_query_arrow_with_params(
+            self.conn, b"SELECT {x:Int64} AS v", None, None, None, 0)
+        try:
+            err = LIBCHDB.chdb_result_error(stream_result)
+            # Substitution errors may surface at init or on first fetch.
+            if not err:
+                batch = ArrowArrayStream()
+                state = LIBCHDB.chdb_stream_fetch_arrow(
+                    self.conn, stream_result, ctypes.byref(batch))
+                err = LIBCHDB.chdb_result_error(stream_result)
+                self.assertTrue(state != 0 or err)
+            self.assertIsNotNone(err)
+        finally:
+            LIBCHDB.chdb_destroy_query_result(stream_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #122 — libchdb exports `chdb_adbc_init`, making the library itself
loadable as an ADBC driver by the standard driver managers: one C-ABI
implementation, usable from Python, Go, R, Rust and C#.

```python
import adbc_driver_manager.dbapi as dbapi

conn = dbapi.connect(driver="/path/to/libchdb.so",
                     entrypoint="chdb_adbc_init",
                     db_kwargs={"path": ":memory:"})
cur = conn.cursor()
cur.execute("SELECT ? + 1", (41,))
tbl = cur.fetch_arrow_table()               # streamed Arrow C Data Interface
cur.adbc_ingest("t", tbl, mode="create")    # bulk ingestion
```

## Mapping onto the C API

| ADBC | chdb-core C API |
|---|---|
| `StatementExecuteQuery` (result set) | `chdb_stream_query_arrow{,_n}` + `chdb_stream_fetch_arrow`, wrapped into one continuous `ArrowArrayStream` — large results never materialize in full |
| `StatementExecuteQuery` with parameters | `chdb_stream_query_arrow_with_params{,_n}` — **new API in this PR**, completing the four streaming-Arrow variants per the `_with_params` convention (#73) |
| `StatementExecuteQuery` (update/DDL, `out == NULL`) | `chdb_query_n` + `Null` format; `rows_affected` from `chdb_result_rows_written` |
| `adbc_ingest` (all four modes) | `chdb_arrow_scan` + `CREATE TABLE … AS SELECT` / `INSERT … SELECT FROM arrowstream(…)` |
| `GetObjects` / `GetTableSchema` | SQL over `system.databases/tables/columns`; `SELECT * FROM t WHERE 0` |
| `GetInfo` / `GetTableTypes` | spec result sets built with arrow C++ |
| `Commit` / `Rollback` | `INVALID_STATE` (autocommit-only) |

This driver implements the core subset of ADBC 1.1: the optional 1.1
extensions (cancel, statistics, typed get/set options) report
`NOT_IMPLEMENTED` through the standard negotiation.

Defined semantics worth calling out:
- one statement at a time per connection: any new operation cancels and
  invalidates an outstanding streamed result with a clear error — probing
  showed the engine otherwise lets a new statement silently displace the old
  stream, poisoning both. Independent concurrent readers work over separate
  connections (session state is per-connection)
- `executemany` on the plain `INSERT ... VALUES (?, ...)` shape streams all
  bound rows through one statement (20k rows: 85s per-row → 9ms); other
  statements execute per row
- the `uri` option accepts file-scheme forms (`file:name`, `file:/abs`,
  `file:///abs`, `file://localhost/abs`) with percent-decoding
- ingest `replace` is a single-statement swap; the old table stays intact on
  failure
- statements the engine refuses to stream (DDL) fall back to materialized
  execution; no-result statements surface as an empty zero-column stream
- one storage path per process: a second `AdbcDatabase` with a different path
  fails at `ConnectionInit`

The driver also compiles into the Python module (`chdb_adbc_init` allowlisted
in `pychdb_export*`), so the wheel doubles as the driver at zero size cost —
`pip install chdb` will be all a Python ADBC user needs once the locator
package lands.

## Commits (by module)

1. `capi` — streaming-Arrow groundwork: the new `_with_params` entry points,
   shared parameter helpers, per-caller DataFrame-vs-chunks streaming mode
   (streaming iterate used to hard-wire results into pandas in Python builds,
   starving non-Python consumers), zero-row schema fix, iterate error
   propagation, arrowstream registration in Python builds, shared sentinel
   error texts, force-link anchor
2. `adbc` — the driver itself + vendored `adbc.h` (apache-arrow-adbc-23)
3. `tests` — 37 end-to-end cases through the standard `adbc_driver_manager`
   (params types, all ingest modes, GetObjects with a golden-schema assertion,
   stream-invalidation semantics), plus ctypes coverage for the new C API
4. `ci/examples/bench` — ADBC suite enabled in wheel CI; a pure-C harness
   (dlopen + function table — what Go/R/Rust sit on); a DuckDB-style fetch
   benchmark: adbc-stream 54 M rows/s == raw C-API Arrow (no measurable ADBC
   overhead) vs 28 M rows/s CSV baseline (macOS arm64, 5M rows)

## Verification

Rebased on current main; full suite 1057/1057 green locally (macOS arm64),
ADBC suite green against both libchdb.so and the Python module's
`_chdb.abi3.so`; Linux runs in wheel CI via the added adbc-driver-manager
test dependency.

## Validation

Validated with the [adbc-drivers/validation](https://github.com/adbc-drivers/validation)
suite (the ADBC Driver Foundry's capability-matrix harness): **214 passed, 27
skipped, 0 failed** against `libchdb`. Skips are feature-gated (transactions,
statistics, catalogs) or documented engine limits. The suite runs in all four
wheel CI matrices on Python 3.12; harness and ClickHouse-dialect overrides
live in `tests/validation/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `chdb_adbc_init` from libchdb to enable ADBC driver support
> - Adds [chdb-adbc.cpp](https://github.com/chdb-io/chdb-core/pull/132/files#diff-5b253d3438b0719880878a1150dcfb7b196e77c2276b7a7724d3b848c8c54c49) implementing a full ADBC driver over the existing chdb C API, exposing `chdb_adbc_init` and `AdbcDriverInit` for use with standard ADBC driver managers.
> - Exports the new symbols from libchdb and the Python extension module on both Linux and macOS via updated linker map files.
> - Adds `dataframe_over_chunks` flag to `executeStreamingInit` so the Arrow/ADBC path returns raw chunks instead of Pandas DataFrames.
> - Extends the Arrow streaming C API with `chdb_stream_query_arrow_with_params` and `chdb_stream_query_arrow_with_params_n` for parameterized queries, and fixes schema propagation for empty results in `chdb_stream_fetch_arrow`.
> - CI workflows and functional test scripts now install `adbc-driver-manager==1.8.0` before running tests; new end-to-end tests in [tests/test_adbc_driver.py](https://github.com/chdb-io/chdb-core/pull/132/files#diff-1ffd0fb08b222190955369dab8b91b55bde505df1b53326ec01e2466fd1346a2) cover queries, ingestion, parameter binding, metadata, and persistence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f28238b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

