### PR TITLE
Fix BACKUP/RESTORE to S3 failing in embedded mode

### DIFF
--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -126,6 +126,9 @@ extern const ServerSettingsUInt64 text_index_postings_cache_size;
 extern const ServerSettingsUInt64 text_index_postings_cache_max_entries;
 extern const ServerSettingsDouble text_index_postings_cache_size_ratio;
 extern const ServerSettingsUInt64 io_thread_pool_queue_size;
+extern const ServerSettingsUInt64 backups_io_thread_pool_queue_size;
+extern const ServerSettingsUInt64 max_backups_io_thread_pool_free_size;
+extern const ServerSettingsUInt64 max_backups_io_thread_pool_size;
 extern const ServerSettingsString mark_cache_policy;
 extern const ServerSettingsUInt64 mark_cache_size;
 extern const ServerSettingsDouble mark_cache_size_ratio;
@@ -263,6 +266,11 @@ void EmbeddedServer::initialize(Poco::Util::Application & self)
         server_settings[ServerSetting::max_io_thread_pool_size],
         server_settings[ServerSetting::max_io_thread_pool_free_size],
         server_settings[ServerSetting::io_thread_pool_queue_size]);
+
+    getBackupsIOThreadPool().initialize(
+        server_settings[ServerSetting::max_backups_io_thread_pool_size],
+        server_settings[ServerSetting::max_backups_io_thread_pool_free_size],
+        server_settings[ServerSetting::backups_io_thread_pool_queue_size]);
 
     const size_t active_parts_loading_threads = server_settings[ServerSetting::max_active_parts_loading_thread_pool_size];
     getActivePartsLoadingThreadPool().initialize(


### PR DESCRIPTION
Closes #133

## Problem

`BACKUP`/`RESTORE` to `S3(...)` in embedded mode fails with:

```
Code: 49. DB::Exception: The BackupsIOThreadPool is not initialized. (LOGICAL_ERROR)
```

`EmbeddedServer.cpp` initializes the IO / parts-loading / format-parsing thread pools but not the backups IO pool, which the S3 backup path requires. `programs/server/Server.cpp` does initialize it.

## Fix

Initialize `getBackupsIOThreadPool()` in `EmbeddedServer::initialize()` the same way `Server.cpp` does, next to `getIOThreadPool().initialize(...)`, plus the corresponding `ServerSetting` extern declarations (the snippet in the issue missed these — each translation unit declares the server settings it uses).

## Verification

Reproduced before the fix (exact error above), then verified after rebuilding against a local MinIO:

```python
w = session.Session("/tmp/src")
w.query("CREATE DATABASE mem")
w.query("CREATE TABLE mem.t (n Int64) ENGINE=MergeTree ORDER BY n")
w.query("INSERT INTO mem.t SELECT number FROM numbers(1000)")
w.query("BACKUP DATABASE mem TO S3('http://127.0.0.1:9100/chdb-backups/issue133', 'minioadmin', 'minioadmin')")
w.close()

r = session.Session("/tmp/dst")   # fresh, empty engine
r.query("RESTORE DATABASE mem FROM S3('http://127.0.0.1:9100/chdb-backups/issue133', 'minioadmin', 'minioadmin')")
r.query("SELECT count() FROM mem.t", "CSV")   # 1000
r.query("SELECT sum(n) FROM mem.t", "CSV")    # 499500
```

- `BACKUP` succeeds; backup objects (`.backup` metadata + part data files) confirmed present in the bucket.
- `RESTORE` into a fresh session returns `count() = 1000`, `sum(n) = 499500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BACKUP/RESTORE to S3 failing in embedded mode by initializing the Backups IO thread pool
> In [EmbeddedServer.initialize](https://github.com/chdb-io/chdb-core/pull/134/files#diff-b40e2cd65195a45a5e28818eb8a4abb4f0b06a149aad063577c767414136191b), the Backups IO thread pool was never initialized, causing S3 backup/restore operations to fail in embedded mode. This adds a call to initialize the pool using the `max_backups_io_thread_pool_size`, `max_backups_io_thread_pool_free_size`, and `backups_io_thread_pool_queue_size` server settings, mirroring how the general IO thread pool is set up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4a1933.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->