### PR TITLE
Python(df): fail per-column on pandas ArrowDtype instead of misreading buffers

### DIFF
--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -26,6 +26,7 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
+    extern const int NOT_IMPLEMENTED;
 }
 
 }
@@ -83,6 +84,21 @@ static DataTypePtr inferDataTypeFromPandasColumn(
     ContextPtr & context,
     DataSourceWrapper & wrapper)
 {
+    /// ArrowDtype columns (pandas dtype_backend="pyarrow") keep their values in
+    /// Arrow buffers, not in the numpy layout the scan expects, and are not
+    /// supported yet. They must fail here, per column: treating the whole
+    /// DataFrame as "not a DataFrame" instead dropped it into the legacy
+    /// regex-based schema path, which substring-matched e.g. "int64[pyarrow]"
+    /// as Int64 and returned garbage values without any error.
+    py::handle arrow_dtype = PythonImporter::ImportCache().pandas.ArrowDtype();
+    if (arrow_dtype && !arrow_dtype.is_none() && py::isinstance(col_type, arrow_dtype))
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Column '{}' has pandas ArrowDtype '{}', which is not supported by the Python() table engine. "
+            "Convert it to a NumPy-backed dtype first, e.g. with .astype(...), or pass the data as a pyarrow.Table.",
+            String(py::str(col_name)),
+            String(py::str(col_type)));
+
     auto numpy_type = ConvertNumpyType(col_type);
 
     if (numpy_type.type == NumpyNullableType::CATEGORY)
@@ -200,20 +216,7 @@ bool PandasDataFrame::isPandasDataframe(const py::object & object)
 		return false;
 
 	auto & importer_cache = PythonImporter::ImportCache();
-	bool is_df = py::isinstance(object, importer_cache.pandas.DataFrame());
-
-    if (!is_df)
-        return false;
-
-	auto arrow_dtype = importer_cache.pandas.ArrowDtype();
-	py::list dtypes = object.attr("dtypes");
-	for (auto & dtype : dtypes)
-    {
-		if (py::isinstance(dtype, arrow_dtype))
-			return false;
-	}
-
-	return true;
+	return py::isinstance(object, importer_cache.pandas.DataFrame());
 }
 
 bool PandasDataFrame::isPyArrowBacked(const py::handle & /*object*/)

--- a/tests/test_dataframe_arrow_dtype.py
+++ b/tests/test_dataframe_arrow_dtype.py
@@ -31,12 +31,19 @@ except ImportError:
 class TestDataFrameArrowDtype(unittest.TestCase):
     """ArrowDtype columns fail loudly with an actionable message."""
 
-    def _assert_clear_error(self, df, col_name, dtype_str):
-        with self.assertRaises(Exception) as ctx:
+    def _assert_clear_error(self, df, col_name):  # noqa: F841 -- df referenced by Python(df)
+        # Engine query failures surface as RuntimeError on the connection path
+        # (which chdb.query uses) and as chdb.ChdbError on the stateless buffer
+        # path; anything else (TypeError, ...) would be a binding bug, so keep
+        # the assertion tight.
+        with self.assertRaises((chdb.ChdbError, RuntimeError)) as ctx:
             chdb.query("SELECT * FROM Python(df)", "CSV")
         msg = str(ctx.exception)
         self.assertIn("'%s'" % col_name, msg)
-        self.assertIn(dtype_str, msg)
+        # The C++ side formats the dtype with py::str(col_type), i.e. exactly
+        # str(df[col].dtype); derive the expectation so the test does not
+        # depend on per-version ArrowDtype reprs.
+        self.assertIn(str(df[col_name].dtype), msg)
         # The old whole-DataFrame rejection produced this misleading error.
         self.assertNotIn("not found in the Python environment", msg)
 
@@ -44,7 +51,7 @@ class TestDataFrameArrowDtype(unittest.TestCase):
         df = pd.DataFrame(
             {"a": pd.array([1, 2, None], dtype=pd.ArrowDtype(pa.int64()))}
         )
-        self._assert_clear_error(df, "a", "int64[pyarrow]")
+        self._assert_clear_error(df, "a")
 
     def test_int64_arrow_dtype_without_nulls(self):
         # Without nulls the buffers happened to be readable on old versions,
@@ -53,13 +60,13 @@ class TestDataFrameArrowDtype(unittest.TestCase):
         df = pd.DataFrame(
             {"a": pd.array([1, 2, 3], dtype=pd.ArrowDtype(pa.int64()))}
         )
-        self._assert_clear_error(df, "a", "int64[pyarrow]")
+        self._assert_clear_error(df, "a")
 
     def test_bool_arrow_dtype(self):
         df = pd.DataFrame(
             {"b": pd.array([True, False], dtype=pd.ArrowDtype(pa.bool_()))}
         )
-        self._assert_clear_error(df, "b", "bool[pyarrow]")
+        self._assert_clear_error(df, "b")
 
     def test_timestamp_arrow_dtype(self):
         df = pd.DataFrame(
@@ -70,7 +77,7 @@ class TestDataFrameArrowDtype(unittest.TestCase):
                 )
             }
         )
-        self._assert_clear_error(df, "t", "timestamp[us][pyarrow]")
+        self._assert_clear_error(df, "t")
 
     def test_string_arrow_dtype(self):
         df = pd.DataFrame(
@@ -80,7 +87,7 @@ class TestDataFrameArrowDtype(unittest.TestCase):
                 )
             }
         )
-        self._assert_clear_error(df, "s", "large_string[pyarrow]")
+        self._assert_clear_error(df, "s")
 
     def test_mixed_frame_names_offending_column(self):
         df = pd.DataFrame(
@@ -89,7 +96,7 @@ class TestDataFrameArrowDtype(unittest.TestCase):
                 "bad": pd.array([1, 2, None], dtype=pd.ArrowDtype(pa.int64())),
             }
         )
-        self._assert_clear_error(df, "bad", "int64[pyarrow]")
+        self._assert_clear_error(df, "bad")
 
     def test_astype_workaround(self):
         df = pd.DataFrame(

--- a/tests/test_dataframe_arrow_dtype.py
+++ b/tests/test_dataframe_arrow_dtype.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Python(df) behavior for pandas ArrowDtype (dtype_backend="pyarrow") columns.
+
+ArrowDtype columns are not supported by the Python() table engine yet.
+chdb-core <= 26.5.0 silently misread their buffers (int64[pyarrow] with nulls
+surfaced float64 bit patterns as integers, bool[pyarrow] surfaced raw bitmap
+bytes), and later revisions rejected the whole DataFrame in isPandasDataframe,
+which surfaced as a misleading "Python object not found in the Python
+environment" error.
+
+A DataFrame containing ArrowDtype columns must still be recognized as a
+DataFrame, and schema inference must fail with a clear per-column error that
+names the offending column and dtype and suggests a workaround.
+"""
+
+import unittest
+
+import pandas as pd
+
+import chdb
+
+try:
+    import pyarrow as pa
+
+    HAS_PYARROW = True
+except ImportError:
+    HAS_PYARROW = False
+
+
+@unittest.skipUnless(HAS_PYARROW, "needs pyarrow")
+class TestDataFrameArrowDtype(unittest.TestCase):
+    """ArrowDtype columns fail loudly with an actionable message."""
+
+    def _assert_clear_error(self, df, col_name, dtype_str):
+        with self.assertRaises(Exception) as ctx:
+            chdb.query("SELECT * FROM Python(df)", "CSV")
+        msg = str(ctx.exception)
+        self.assertIn("'%s'" % col_name, msg)
+        self.assertIn(dtype_str, msg)
+        # The old whole-DataFrame rejection produced this misleading error.
+        self.assertNotIn("not found in the Python environment", msg)
+
+    def test_int64_arrow_dtype_with_nulls(self):
+        df = pd.DataFrame(
+            {"a": pd.array([1, 2, None], dtype=pd.ArrowDtype(pa.int64()))}
+        )
+        self._assert_clear_error(df, "a", "int64[pyarrow]")
+
+    def test_int64_arrow_dtype_without_nulls(self):
+        # Without nulls the buffers happened to be readable on old versions,
+        # which made the corruption data-dependent. Now it must fail the same
+        # way regardless of null presence.
+        df = pd.DataFrame(
+            {"a": pd.array([1, 2, 3], dtype=pd.ArrowDtype(pa.int64()))}
+        )
+        self._assert_clear_error(df, "a", "int64[pyarrow]")
+
+    def test_bool_arrow_dtype(self):
+        df = pd.DataFrame(
+            {"b": pd.array([True, False], dtype=pd.ArrowDtype(pa.bool_()))}
+        )
+        self._assert_clear_error(df, "b", "bool[pyarrow]")
+
+    def test_timestamp_arrow_dtype(self):
+        df = pd.DataFrame(
+            {
+                "t": pd.array(
+                    [pd.Timestamp("2024-01-01")],
+                    dtype=pd.ArrowDtype(pa.timestamp("us")),
+                )
+            }
+        )
+        self._assert_clear_error(df, "t", "timestamp[us][pyarrow]")
+
+    def test_string_arrow_dtype(self):
+        df = pd.DataFrame(
+            {
+                "s": pd.array(
+                    ["x", "中文", None], dtype=pd.ArrowDtype(pa.large_string())
+                )
+            }
+        )
+        self._assert_clear_error(df, "s", "large_string[pyarrow]")
+
+    def test_mixed_frame_names_offending_column(self):
+        df = pd.DataFrame(
+            {
+                "ok_int": [1, 2, 3],
+                "bad": pd.array([1, 2, None], dtype=pd.ArrowDtype(pa.int64())),
+            }
+        )
+        self._assert_clear_error(df, "bad", "int64[pyarrow]")
+
+    def test_astype_workaround(self):
+        df = pd.DataFrame(
+            {"a": pd.array([1, 2, 3], dtype=pd.ArrowDtype(pa.int64()))}
+        )
+        df["a"] = df["a"].astype("int64")
+        res = str(chdb.query("SELECT sum(a) FROM Python(df)", "CSV"))
+        self.assertEqual(res, "6\n")
+
+    def test_pyarrow_table_alternative(self):
+        # The error message suggests passing a pyarrow.Table; verify it works,
+        # including nulls.
+        tbl = pa.table({"a": pa.array([1, 2, None], type=pa.int64())})
+        res = str(
+            chdb.query(
+                "SELECT sum(a) AS s, countIf(a IS NULL) AS n FROM Python(tbl)",
+                "CSV",
+            )
+        )
+        self.assertEqual(res, "3,1\n")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #137

`isPandasDataframe()` rejected any DataFrame containing an ArrowDtype (`dtype_backend="pyarrow"`) column, so those frames fell through to the legacy regex-based schema path, which substring-matches dtype strings: `int64[pyarrow]` matched Int64 and the scan read the float64 ndarray materialized by `to_numpy()` as int64 — garbage values with no error; `large_string[pyarrow]` matched String and the scan hung.

Changes:
- keep ArrowDtype frames on the pandas path (drop the blanket rejection in `isPandasDataframe`, which also removes a per-query scan over `df.dtypes`)
- raise NOT_IMPLEMENTED in `inferDataTypeFromPandasColumn`, naming the offending column and dtype and suggesting `.astype(...)` or `pyarrow.Table` as workarounds:
  ```
  Column 'a' has pandas ArrowDtype 'int64[pyarrow]', which is not supported by the
  Python() table engine. Convert it to a NumPy-backed dtype first, e.g. with
  .astype(...), or pass the data as a pyarrow.Table. (NOT_IMPLEMENTED)
  ```
- `tests/test_dataframe_arrow_dtype.py`: int64 with/without nulls, bool, timestamp, large_string, a mixed frame (error names the offending column), and both suggested workarounds asserted to work

Verified on a local build: 8/8 new tests pass on pandas 3.0.3 and 2.3.3; string / nullable-int / categorical / tz / CoW / output-format probes show no behavior change; the two pre-existing failing suite files fail identically on pure main (A/B checked).

Native ArrowDtype support can come later; this removes the silent corruption now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail per-column with `NOT_IMPLEMENTED` for pandas `ArrowDtype` instead of misreading buffers
> - `inferDataTypeFromPandasColumn` in [PandasDataFrame.cpp](https://github.com/chdb-io/chdb-core/pull/140/files#diff-a8ffa72d6f6751acb3a9bd819ef603ed01cdf902d2f4a92aa566114763d75f56) now detects `ArrowDtype` columns early and throws a `NOT_IMPLEMENTED` exception with a message naming the column and dtype, advising conversion to a NumPy-backed dtype or use of `pyarrow.Table`.
> - `isPandasDataframe` no longer iterates column dtypes to reject `ArrowDtype`; it now only checks whether the object is a `pandas.DataFrame`, so DataFrames with mixed dtypes are accepted and errors surface per-column.
> - Adds [test_dataframe_arrow_dtype.py](https://github.com/chdb-io/chdb-core/pull/140/files#diff-1ff30d775b2ec304c32a8d4b22788e75a848395758f659ea5c4c0547c1f2340e) covering per-column errors across several `ArrowDtype` types, error message content, and both suggested workarounds.
> - Behavioral Change: previously a DataFrame containing any `ArrowDtype` column was rejected entirely; now it is accepted and only the offending column raises an error at read time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c28901.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->