### PR TITLE
FT: detach while waiting on import-cache call_once to fix the cold-start UDF deadlock

### DIFF
--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -34,7 +34,7 @@ py::handle PythonImportCacheItem::operator()(bool load) {
 	// initializer has published `object`, so an acquire read here makes the
 	// plain read of `object` well-defined and gives steady-state accesses a
 	// lock-free fast path that skips the hierarchy rebuild below.
-	if (loaded.load(std::memory_order_acquire))
+	if (IsPublished())
 		return object;
 #endif
 	std::stack<PythonImportCacheItem *> hierarchy;
@@ -143,9 +143,9 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 	// visible (a throwing initializer leaves it false, so retry semantics
 	// are unchanged).
 	if (!load)
-		return loaded.load(std::memory_order_acquire) ? object : py::handle(nullptr);
+		return IsPublished() ? object : py::handle(nullptr);
 
-	if (!loaded.load(std::memory_order_acquire))
+	if (!IsPublished())
 	{
 		py::gil_scoped_release detach_while_waiting;
 		std::call_once(load_flag, [&]() {

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -29,12 +29,14 @@ py::handle PythonImportCacheItem::operator()(bool load) {
 	// attribute access.
 	if (IsLoaded())
 		return object;
+#else
+	// Free-threaded: `loaded` is set (release) only after the call_once
+	// initializer has published `object`, so an acquire read here makes the
+	// plain read of `object` well-defined and gives steady-state accesses a
+	// lock-free fast path that skips the hierarchy rebuild below.
+	if (loaded.load(std::memory_order_acquire))
+		return object;
 #endif
-	// Free-threaded: no unsynchronized pre-check on `object`. Reading `object`
-	// concurrently with the call_once initializer's write is a C++ data race.
-	// std::call_once already provides the necessary happens-before — every
-	// passive call_once on the same flag synchronizes with the completion of
-	// the initializer, so the post-call_once read of `object` is well-defined.
 	std::stack<PythonImportCacheItem *> hierarchy;
 
 	PythonImportCacheItem * item = this;
@@ -122,18 +124,36 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 		LoadAttribute(cache, source);
 	return object;
 #else
-	// Free-threaded: no GIL to serialize callers, so use std::call_once. The
-	// initializer's write to `object` happens-before every passive call_once on
-	// the same flag, so the post-call_once read below is well-defined.
+	// Free-threaded: no GIL to serialize callers, so use std::call_once for the
+	// one-shot initialization — but the wait must happen DETACHED. LoadModule()
+	// runs the import machinery (Python code: allocations, safepoints), and an
+	// allocation-triggered GC on any thread issues a stop-the-world that only
+	// completes once every attached thread parks at a safepoint. A thread
+	// blocked on the once_flag futex while attached never reaches a safepoint,
+	// so the stop-the-world never completes, the winner parks forever at the
+	// next safepoint inside the import, and the flag is never released — a
+	// process-wide deadlock (issue #131: cold process, first parallel UDF
+	// query). Detaching the waiters lets the stop-the-world drain, the winner's
+	// import finish, and everyone proceed.
+	//
+	// The initializer's write to `object` happens-before every passive
+	// call_once on the same flag; `loaded` (set after the flag completes)
+	// additionally publishes it to the lock-free fast paths.
 	if (!load)
-		return object;
+		return loaded.load(std::memory_order_acquire) ? object : py::handle(nullptr);
 
-	std::call_once(load_flag, [&]() {
-		if (is_module)
-			LoadModule(cache);
-		else
-			LoadAttribute(cache, source);
-	});
+	if (!loaded.load(std::memory_order_acquire))
+	{
+		py::gil_scoped_release detach_while_waiting;
+		std::call_once(load_flag, [&]() {
+			py::gil_scoped_acquire attach_for_import;
+			if (is_module)
+				LoadModule(cache);
+			else
+				LoadAttribute(cache, source);
+		});
+		loaded.store(true, std::memory_order_release);
+	}
 
 	return object;
 #endif

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -137,8 +137,11 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 	// import finish, and everyone proceed.
 	//
 	// The initializer's write to `object` happens-before every passive
-	// call_once on the same flag; `loaded` (set after the flag completes)
-	// additionally publishes it to the lock-free fast paths.
+	// call_once on the same flag; `loaded`, released at the end of the
+	// initializer itself, additionally publishes it to the lock-free fast
+	// paths with no window between the load completing and the flag being
+	// visible (a throwing initializer leaves it false, so retry semantics
+	// are unchanged).
 	if (!load)
 		return loaded.load(std::memory_order_acquire) ? object : py::handle(nullptr);
 
@@ -151,8 +154,8 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 				LoadModule(cache);
 			else
 				LoadAttribute(cache, source);
+			loaded.store(true, std::memory_order_release);
 		});
-		loaded.store(true, std::memory_order_release);
 	}
 
 	return object;

--- a/programs/local/PythonImportCacheItem.h
+++ b/programs/local/PythonImportCacheItem.h
@@ -3,6 +3,7 @@
 #include "PybindWrapper.h"
 
 #include <base/types.h>
+#include <atomic>
 #include <mutex>
 
 namespace CHDB {
@@ -54,6 +55,10 @@ private:
 	PythonImportCacheItem * parent;
 	py::handle object;
 	std::once_flag load_flag;
+	/// Free-threaded builds only: set (release) after the call_once initializer
+	/// has published `object`, giving steady-state accesses a lock-free fast
+	/// path that skips the hierarchy rebuild and the call_once entirely.
+	std::atomic<bool> loaded{false};
 };
 
 } // namespace CHDB

--- a/programs/local/PythonImportCacheItem.h
+++ b/programs/local/PythonImportCacheItem.h
@@ -48,6 +48,15 @@ private:
 	void LoadAttribute(PythonImportCache & cache, py::handle source);
 	void LoadModule(PythonImportCache & cache);
 
+	/// Free-threaded builds: true once the call_once initializer has published
+	/// `object` (acquire; pairs with the release store at the end of the
+	/// initializer). The single fast-path predicate shared by operator() and
+	/// Load(), so the two cannot drift apart.
+	bool IsPublished() const
+	{
+		return loaded.load(std::memory_order_acquire);
+	}
+
 private:
 	String name;
 	bool is_module;

--- a/programs/local/PythonUDFRegistry.cpp
+++ b/programs/local/PythonUDFRegistry.cpp
@@ -36,6 +36,15 @@ void PythonUDFRegistry::registerUDF(
 {
     py::gil_assert();
 
+    {
+        /// Fail fast on duplicate names before paying the Python signature
+        /// inspection below; the authoritative re-check still happens under
+        /// the unique lock. No Python runs while this lock is held.
+        std::shared_lock read_lock(mutex);
+        if (udfs.contains(name))
+            throw DB::Exception(DB::ErrorCodes::FUNCTION_ALREADY_EXISTS, "Python UDF '{}' is already registered", name);
+    }
+
     /// Build the UDF (initSignature runs Python: inspect.signature) BEFORE
     /// taking the registry lock. On free-threaded builds, running Python while
     /// holding a lock that other attached threads may block on is the same

--- a/programs/local/PythonUDFRegistry.cpp
+++ b/programs/local/PythonUDFRegistry.cpp
@@ -36,13 +36,20 @@ void PythonUDFRegistry::registerUDF(
 {
     py::gil_assert();
 
+    /// Build the UDF (initSignature runs Python: inspect.signature) BEFORE
+    /// taking the registry lock. On free-threaded builds, running Python while
+    /// holding a lock that other attached threads may block on is the same
+    /// stop-the-world deadlock class as issue #131: the blocked waiters never
+    /// reach a safepoint, so a GC stop-the-world issued during the signature
+    /// inspection could never complete.
+    auto udf = std::make_shared<PythonScalarUDF>(name, std::move(func), std::move(return_type), null_handling, exception_handling);
+    udf->initSignature(arg_types_hint);
+
     std::unique_lock lock(mutex);
 
     if (udfs.contains(name))
         throw DB::Exception(DB::ErrorCodes::FUNCTION_ALREADY_EXISTS, "Python UDF '{}' is already registered", name);
 
-    auto udf = std::make_shared<PythonScalarUDF>(name, std::move(func), std::move(return_type), null_handling, exception_handling);
-    udf->initSignature(arg_types_hint);
     udfs[name] = std::move(udf);
 }
 

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -28,13 +28,31 @@ import sys
 import textwrap
 import unittest
 
-ROWS = 4_000_000
-TIMEOUT_SECONDS = 180
+# The deadlock races the FIRST lazy import-cache load, in the first rows each
+# worker processes — total row volume adds nothing to the repro (a regressed
+# build hangs forever at any size and still trips the timeout). What DOES
+# matter is how many threads actually execute the UDF concurrently, and that
+# is the number of data blocks: with the default max_block_size (65409) a
+# small row count degenerates to a single block, i.e. a single racing thread
+# and no deadlock window at all. So the block size is pinned small to keep a
+# full 32-way race (100k rows / 1k = 100 blocks) while the total work stays
+# tiny — the original 4M rows were CPU-bound past the 180s budget on the FT
+# CI runner (per-row Python UDF × oversubscribed threads × collect storm),
+# misreporting plain slowness as the deadlock.
+ROWS = 100_000
+MAX_BLOCK_SIZE = 1_000
+# The race is probabilistic: on a pre-fix build one cold start hangs in ~3 of
+# 4 attempts (the import can win the race against the first stop-the-world).
+# Several independent cold processes push the per-test catch rate past 98%,
+# while a healthy build pays well under a second per attempt.
+ATTEMPTS = 3
+TIMEOUT_SECONDS = 60
 
 CHILD_SCRIPT = textwrap.dedent(
     f"""
     import gc
     import threading
+    import time
 
     import chdb
     from chdb.sqltypes import INT64
@@ -43,23 +61,29 @@ CHILD_SCRIPT = textwrap.dedent(
     def fadd(a, b):
         return (a * 31 + b) % 97
 
-    stop = False
+    stop = threading.Event()
 
     def collector():
         # Continuous stop-the-world requests, covering the cold lazy-import
         # window of the first parallel query.
-        while not stop:
+        while not stop.is_set():
             gc.collect()
 
     thread = threading.Thread(target=collector, daemon=True)
     thread.start()
+    time.sleep(0.05)  # make sure the storm is already running when the query starts
 
-    result = chdb.query(
-        "SELECT sum(fadd(toInt64(number), 1)) FROM numbers_mt({ROWS}) "
-        "SETTINGS max_threads=32"
-    )
-    stop = True
-    thread.join(timeout=5)
+    try:
+        result = chdb.query(
+            "SELECT sum(fadd(toInt64(number), 1)) FROM numbers_mt({ROWS}) "
+            "SETTINGS max_threads=32, max_block_size={MAX_BLOCK_SIZE}"
+        )
+    finally:
+        # Always stop the collector: a spinning gc.collect() thread during
+        # interpreter finalization can stall the child and turn an ordinary
+        # query error into a bogus deadlock timeout.
+        stop.set()
+        thread.join(timeout=5)
     print("RESULT:" + str(result).strip(), flush=True)
     """
 )
@@ -67,36 +91,38 @@ CHILD_SCRIPT = textwrap.dedent(
 
 class TestFTImportCacheColdStart(unittest.TestCase):
     def test_cold_parallel_udf_survives_gc_stop_the_world_storm(self):
-        try:
-            proc = subprocess.run(
-                [sys.executable, "-c", CHILD_SCRIPT],
-                capture_output=True,
-                text=True,
-                timeout=TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired as e:
-            stderr = (e.stderr or b"")
-            if isinstance(stderr, bytes):
-                stderr = stderr.decode("utf-8", "replace")
-            self.fail(
-                "cold parallel UDF query did not finish within "
-                f"{TIMEOUT_SECONDS}s — the import-cache stop-the-world "
-                "deadlock (issue #131) is back. Child stderr:\n" + stderr[-2000:]
-            )
-
-        self.assertEqual(
-            proc.returncode,
-            0,
-            "child process failed:\n" + (proc.stderr or "")[-2000:],
-        )
-
         # fadd is deterministic: sum((i * 31 + 1) % 97 for i in range(ROWS)),
         # computed via the period-97 structure of the sequence.
         period = [(i * 31 + 1) % 97 for i in range(97)]
         full, rest = divmod(ROWS, 97)
         expected = sum(period) * full + sum(period[:rest])
 
-        self.assertIn(f"RESULT:{expected}", proc.stdout)
+        for attempt in range(ATTEMPTS):
+            try:
+                proc = subprocess.run(
+                    [sys.executable, "-c", CHILD_SCRIPT],
+                    capture_output=True,
+                    text=True,
+                    timeout=TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired as e:
+                stderr = (e.stderr or b"")
+                if isinstance(stderr, bytes):
+                    stderr = stderr.decode("utf-8", "replace")
+                self.fail(
+                    f"cold parallel UDF query (attempt {attempt + 1}/{ATTEMPTS}) "
+                    f"did not finish within {TIMEOUT_SECONDS}s — the import-cache "
+                    "stop-the-world deadlock (issue #131) is back. "
+                    "Child stderr:\n" + stderr[-2000:]
+                )
+
+            self.assertEqual(
+                proc.returncode,
+                0,
+                f"child process failed (attempt {attempt + 1}):\n"
+                + (proc.stderr or "")[-2000:],
+            )
+            self.assertIn(f"RESULT:{expected}", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -47,6 +47,14 @@ MAX_BLOCK_SIZE = 1_000
 # while a healthy build pays well under a second per attempt.
 ATTEMPTS = 3
 TIMEOUT_SECONDS = 60
+# The storm only needs to cover the cold-import window at query start: once
+# the deadlock forms it self-sustains (the collector itself is then stuck
+# inside gc.collect(), waiting on a stop-the-world that can never finish), so
+# bounding the storm loses no detection power. Left unbounded, it throttled
+# the whole healthy run instead: with pandas installed (as on CI) the lazy
+# import loads the real package, the heap grows, every gc.collect() costs
+# tens of milliseconds, and the run took >130s even on a 16-core box.
+STORM_SECONDS = 10
 
 CHILD_SCRIPT = textwrap.dedent(
     f"""
@@ -62,11 +70,13 @@ CHILD_SCRIPT = textwrap.dedent(
         return (a * 31 + b) % 97
 
     stop = threading.Event()
+    storm_deadline = time.monotonic() + {STORM_SECONDS}
 
     def collector():
         # Continuous stop-the-world requests, covering the cold lazy-import
-        # window of the first parallel query.
-        while not stop.is_set():
+        # window of the first parallel query; time-boxed so a healthy run is
+        # not throttled end-to-end (a formed deadlock self-sustains anyway).
+        while not stop.is_set() and time.monotonic() < storm_deadline:
             gc.collect()
 
     thread = threading.Thread(target=collector, daemon=True)

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression test for the free-threading cold-start UDF deadlock (issue #131).
+
+On free-threaded builds, the lazy import-cache load ran inside std::call_once
+with the waiting threads blocked on the once_flag futex while still attached.
+An attached thread parked on a futex never reaches a safepoint, so a GC
+stop-the-world issued while the call_once winner runs the import can never
+complete: the winner parks forever inside the import machinery, the flag is
+never released, and the first parallel UDF query of a cold process hangs.
+
+The deadlock needs a stop-the-world to land inside the few-millisecond import
+window, so the test forces it: a spammer thread issues gc.collect()
+continuously while the cold query runs. Before the fix this hangs 5/5 on a
+16-core box; with the fix it completes with the correct result.
+
+Two properties matter for CI:
+- the query must run in a fresh subprocess (the import cache is per-process;
+  any earlier query in this process would warm it and mask the bug), and
+- a regression must FAIL the test instead of hanging the suite, hence the
+  subprocess timeout.
+
+On stock (GIL) builds the scenario cannot deadlock; the test then simply
+asserts the query result, at negligible cost.
+"""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+ROWS = 4_000_000
+TIMEOUT_SECONDS = 180
+
+CHILD_SCRIPT = textwrap.dedent(
+    f"""
+    import gc
+    import threading
+
+    import chdb
+    from chdb.sqltypes import INT64
+
+    @chdb.func([INT64, INT64], INT64)
+    def fadd(a, b):
+        return (a * 31 + b) % 97
+
+    stop = False
+
+    def collector():
+        # Continuous stop-the-world requests, covering the cold lazy-import
+        # window of the first parallel query.
+        while not stop:
+            gc.collect()
+
+    thread = threading.Thread(target=collector, daemon=True)
+    thread.start()
+
+    result = chdb.query(
+        "SELECT sum(fadd(toInt64(number), 1)) FROM numbers_mt({ROWS}) "
+        "SETTINGS max_threads=32"
+    )
+    stop = True
+    thread.join(timeout=5)
+    print("RESULT:" + str(result).strip(), flush=True)
+    """
+)
+
+
+class TestFTImportCacheColdStart(unittest.TestCase):
+    def test_cold_parallel_udf_survives_gc_stop_the_world_storm(self):
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", CHILD_SCRIPT],
+                capture_output=True,
+                text=True,
+                timeout=TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as e:
+            stderr = (e.stderr or b"")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", "replace")
+            self.fail(
+                "cold parallel UDF query did not finish within "
+                f"{TIMEOUT_SECONDS}s — the import-cache stop-the-world "
+                "deadlock (issue #131) is back. Child stderr:\n" + stderr[-2000:]
+            )
+
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "child process failed:\n" + (proc.stderr or "")[-2000:],
+        )
+
+        # fadd is deterministic: sum((i * 31 + 1) % 97 for i in range(ROWS)),
+        # computed via the period-97 structure of the sequence.
+        period = [(i * 31 + 1) % 97 for i in range(97)]
+        full, rest = divmod(ROWS, 97)
+        expected = sum(period) * full + sum(period[:rest])
+
+        self.assertIn(f"RESULT:{expected}", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -46,7 +46,13 @@ MAX_BLOCK_SIZE = 1_000
 # Several independent cold processes push the per-test catch rate past 98%,
 # while a healthy build pays well under a second per attempt.
 ATTEMPTS = 3
-TIMEOUT_SECONDS = 60
+# With the storm time-boxed below, a healthy attempt is structurally bounded
+# (~10-20s even with pandas loaded), so the timeout's only job is detecting an
+# infinite hang and it is deliberately generous: ~28x the measured healthy
+# attempt, absorbing even pathological slowness spikes. A real regression
+# still fails fast — the first hanging attempt trips it, so the worst-case
+# CI cost of a regression is a single timeout, not ATTEMPTS times it.
+TIMEOUT_SECONDS = 300
 # The storm only needs to cover the cold-import window at query start: once
 # the deadlock forms it self-sustains (the collector itself is then stuck
 # inside gc.collect(), waiting on a stop-the-world that can never finish), so

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -64,16 +64,28 @@ STORM_SECONDS = 10
 
 CHILD_SCRIPT = textwrap.dedent(
     f"""
+    import faulthandler
     import gc
+    import sys
     import threading
     import time
 
     import chdb
     from chdb.sqltypes import INT64
 
+    # Which chdb actually got imported — surfaces cwd/PYTHONPATH shadowing
+    # mixups in the failure diagnostics instead of leaving them to archaeology.
+    print("CHDB:" + chdb.__file__, file=sys.stderr, flush=True)
+
     @chdb.func([INT64, INT64], INT64)
     def fadd(a, b):
         return (a * 31 + b) % 97
+
+    # Black box for hang diagnosis: if this child ever wedges, dump every
+    # thread's stack to stderr periodically; the parent surfaces stderr in the
+    # timeout failure message, telling a stuck stop-the-world (collector still
+    # inside gc.collect) apart from mere slowness. No-op on healthy runs.
+    faulthandler.dump_traceback_later(45, repeat=True)
 
     stop = threading.Event()
     storm_deadline = time.monotonic() + {STORM_SECONDS}
@@ -100,6 +112,7 @@ CHILD_SCRIPT = textwrap.dedent(
         # query error into a bogus deadlock timeout.
         stop.set()
         thread.join(timeout=5)
+        faulthandler.cancel_dump_traceback_later()
     print("RESULT:" + str(result).strip(), flush=True)
     """
 )
@@ -129,7 +142,7 @@ class TestFTImportCacheColdStart(unittest.TestCase):
                     f"cold parallel UDF query (attempt {attempt + 1}/{ATTEMPTS}) "
                     f"did not finish within {TIMEOUT_SECONDS}s — the import-cache "
                     "stop-the-world deadlock (issue #131) is back. "
-                    "Child stderr:\n" + stderr[-2000:]
+                    "Child stderr:\n" + stderr[-6000:]
                 )
 
             self.assertEqual(


### PR DESCRIPTION
Fixes #131

## Root cause

On free-threaded builds the lazy `PythonImportCacheItem` load runs inside `std::call_once`, and the losing threads park on the once_flag futex **while attached**. An attached thread blocked in C code never reaches a safepoint, so a stop-the-world issued meanwhile (e.g. an allocation-triggered GC on any worker) can never complete; the call_once winner then parks forever at the next safepoint inside the import machinery, and the flag is never released — a process-wide deadlock.

That is exactly the cold-process `max_threads=32` UDF hang: the first parallel query races all fresh engine threads into the first lazy item load (`GetPythonObjectType` touches `pandas.NaT`/`NA` on the per-row result path), which is also why a small single-threaded warmup query masks it, and why the stock GIL build is immune (waiters there queue on the GIL, never on the flag). The reported stacks — workers in `_PySemaphore_Wait` / futex waits — match.

## Fix

- Waiters detach (`py::gil_scoped_release`) before entering `call_once`; the winner re-attaches inside the initializer. A pending stop-the-world can now drain while the import runs.
- New atomic `loaded` flag (set after the initializer completes) gives steady-state accesses a lock-free fast path — no hierarchy rebuild, no call_once — on the per-row paths.
- Same-class hardening: `PythonUDFRegistry::registerUDF` now runs `initSignature` (`inspect.signature`, i.e. Python) before taking the registry mutex instead of while holding it.

## Verification

The hang wasn't timing-reachable on this 16-core box with plain runs (24 cold starts at 32/64/128 threads all passed), so the stop-the-world race was forced directly: a `gc.collect()` spammer thread racing the cold parallel UDF query.

- before: **5/5 runs hang** (killed at 60s), thread dump shows QueryPipelineEx workers in `sem_wait`/futex — matching the issue report
- after: **5/5 runs complete** with correct results; plain cold32/warm runs and the 1–32 thread scaling benchmark unchanged

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cold-start UDF deadlock by releasing GIL while waiting on import-cache `call_once`
> - In free-threaded builds, `PythonImportCacheItem::Load` previously held the GIL while blocking on `std::call_once`, causing a process-wide deadlock when a concurrent GC stop-the-world was triggered during the first lazy import.
> - Fixes this by releasing the GIL (`py::gil_scoped_release`) before waiting on `call_once` and reacquiring it (`py::gil_scoped_acquire`) only for the actual import inside the once initializer.
> - Adds a lock-free fast path in `PythonImportCacheItem::operator()`: once the item is published (via a release-store to an atomic `loaded` flag), subsequent accesses return the cached handle without entering `call_once`.
> - `PythonUDFRegistry::registerUDF` now checks for duplicate UDF names under a shared lock before running any Python, and constructs the UDF object before acquiring the exclusive registry lock.
> - Adds a regression test in [`test_ft_import_cache_cold_start.py`](https://github.com/chdb-io/chdb-core/pull/141/files#diff-a0120fad57f24f91d2bc6d74c39760425f1a2af590e853875bf0442d923aba78) that runs parallel UDF queries with a concurrent `gc.collect()` storm in a subprocess to catch the deadlock.
> - Behavioral Change: with `load=false`, `PythonImportCacheItem::Load` now returns `nullptr` until the object is published rather than always proceeding to import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a322c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->