### PR TITLE
Python UDF: cut per-row overhead and free-threaded GC pressure in the scalar call loop

### DIFF
--- a/programs/local/PythonConversion.cpp
+++ b/programs/local/PythonConversion.cpp
@@ -39,12 +39,11 @@ PythonObjectType GetPythonObjectType(const py::handle & obj)
 	if (obj.is_none())
 		return PythonObjectType::None;
 
-	if (obj.is(import_cache.pandas.NaT()))
-		return PythonObjectType::None;
-
-	if (obj.is(import_cache.pandas.NA()))
-		return PythonObjectType::None;
-
+	/// Exact builtin scalars first, ahead of anything that touches the import
+	/// cache: bool/int/float/str can never be pandas.NaT/NA (still checked
+	/// below, before the datetime family NaT belongs to). On the UDF result
+	/// path this function runs once per row, and the cache-item lookups are
+	/// pure overhead for the overwhelmingly common scalar results.
 	if (py::isinstance<py::bool_>(obj))
 		return PythonObjectType::Bool;
 
@@ -53,6 +52,15 @@ PythonObjectType GetPythonObjectType(const py::handle & obj)
 
 	if (py::isinstance<py::float_>(obj))
 		return PythonObjectType::Float;
+
+	if (py::isinstance<py::str>(obj))
+		return PythonObjectType::String;
+
+	if (obj.is(import_cache.pandas.NaT()))
+		return PythonObjectType::None;
+
+	if (obj.is(import_cache.pandas.NA()))
+		return PythonObjectType::None;
 
 	if (py::isinstance(obj, import_cache.datetime.datetime()))
 		return PythonObjectType::Datetime;
@@ -74,9 +82,6 @@ PythonObjectType GetPythonObjectType(const py::handle & obj)
 
 	if (py::isinstance(obj, import_cache.decimal.Decimal()))
 		return PythonObjectType::Decimal;
-
-	if (py::isinstance<py::str>(obj))
-		return PythonObjectType::String;
 
 	if (py::isinstance<py::bytearray>(obj))
 		return PythonObjectType::ByteArray;

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -34,7 +34,7 @@ py::handle PythonImportCacheItem::operator()(bool load) {
 	// initializer has published `object`, so an acquire read here makes the
 	// plain read of `object` well-defined and gives steady-state accesses a
 	// lock-free fast path that skips the hierarchy rebuild below.
-	if (loaded.load(std::memory_order_acquire))
+	if (IsPublished())
 		return object;
 #endif
 	std::stack<PythonImportCacheItem *> hierarchy;
@@ -143,9 +143,9 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 	// visible (a throwing initializer leaves it false, so retry semantics
 	// are unchanged).
 	if (!load)
-		return loaded.load(std::memory_order_acquire) ? object : py::handle(nullptr);
+		return IsPublished() ? object : py::handle(nullptr);
 
-	if (!loaded.load(std::memory_order_acquire))
+	if (!IsPublished())
 	{
 		py::gil_scoped_release detach_while_waiting;
 		std::call_once(load_flag, [&]() {

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -29,12 +29,14 @@ py::handle PythonImportCacheItem::operator()(bool load) {
 	// attribute access.
 	if (IsLoaded())
 		return object;
+#else
+	// Free-threaded: `loaded` is set (release) only after the call_once
+	// initializer has published `object`, so an acquire read here makes the
+	// plain read of `object` well-defined and gives steady-state accesses a
+	// lock-free fast path that skips the hierarchy rebuild below.
+	if (loaded.load(std::memory_order_acquire))
+		return object;
 #endif
-	// Free-threaded: no unsynchronized pre-check on `object`. Reading `object`
-	// concurrently with the call_once initializer's write is a C++ data race.
-	// std::call_once already provides the necessary happens-before — every
-	// passive call_once on the same flag synchronizes with the completion of
-	// the initializer, so the post-call_once read of `object` is well-defined.
 	std::stack<PythonImportCacheItem *> hierarchy;
 
 	PythonImportCacheItem * item = this;
@@ -122,18 +124,36 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 		LoadAttribute(cache, source);
 	return object;
 #else
-	// Free-threaded: no GIL to serialize callers, so use std::call_once. The
-	// initializer's write to `object` happens-before every passive call_once on
-	// the same flag, so the post-call_once read below is well-defined.
+	// Free-threaded: no GIL to serialize callers, so use std::call_once for the
+	// one-shot initialization — but the wait must happen DETACHED. LoadModule()
+	// runs the import machinery (Python code: allocations, safepoints), and an
+	// allocation-triggered GC on any thread issues a stop-the-world that only
+	// completes once every attached thread parks at a safepoint. A thread
+	// blocked on the once_flag futex while attached never reaches a safepoint,
+	// so the stop-the-world never completes, the winner parks forever at the
+	// next safepoint inside the import, and the flag is never released — a
+	// process-wide deadlock (issue #131: cold process, first parallel UDF
+	// query). Detaching the waiters lets the stop-the-world drain, the winner's
+	// import finish, and everyone proceed.
+	//
+	// The initializer's write to `object` happens-before every passive
+	// call_once on the same flag; `loaded` (set after the flag completes)
+	// additionally publishes it to the lock-free fast paths.
 	if (!load)
-		return object;
+		return loaded.load(std::memory_order_acquire) ? object : py::handle(nullptr);
 
-	std::call_once(load_flag, [&]() {
-		if (is_module)
-			LoadModule(cache);
-		else
-			LoadAttribute(cache, source);
-	});
+	if (!loaded.load(std::memory_order_acquire))
+	{
+		py::gil_scoped_release detach_while_waiting;
+		std::call_once(load_flag, [&]() {
+			py::gil_scoped_acquire attach_for_import;
+			if (is_module)
+				LoadModule(cache);
+			else
+				LoadAttribute(cache, source);
+		});
+		loaded.store(true, std::memory_order_release);
+	}
 
 	return object;
 #endif

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -137,8 +137,11 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 	// import finish, and everyone proceed.
 	//
 	// The initializer's write to `object` happens-before every passive
-	// call_once on the same flag; `loaded` (set after the flag completes)
-	// additionally publishes it to the lock-free fast paths.
+	// call_once on the same flag; `loaded`, released at the end of the
+	// initializer itself, additionally publishes it to the lock-free fast
+	// paths with no window between the load completing and the flag being
+	// visible (a throwing initializer leaves it false, so retry semantics
+	// are unchanged).
 	if (!load)
 		return loaded.load(std::memory_order_acquire) ? object : py::handle(nullptr);
 
@@ -151,8 +154,8 @@ py::handle PythonImportCacheItem::Load(PythonImportCache & cache, py::handle sou
 				LoadModule(cache);
 			else
 				LoadAttribute(cache, source);
+			loaded.store(true, std::memory_order_release);
 		});
-		loaded.store(true, std::memory_order_release);
 	}
 
 	return object;

--- a/programs/local/PythonImportCacheItem.h
+++ b/programs/local/PythonImportCacheItem.h
@@ -3,6 +3,7 @@
 #include "PybindWrapper.h"
 
 #include <base/types.h>
+#include <atomic>
 #include <mutex>
 
 namespace CHDB {
@@ -54,6 +55,10 @@ private:
 	PythonImportCacheItem * parent;
 	py::handle object;
 	std::once_flag load_flag;
+	/// Free-threaded builds only: set (release) after the call_once initializer
+	/// has published `object`, giving steady-state accesses a lock-free fast
+	/// path that skips the hierarchy rebuild and the call_once entirely.
+	std::atomic<bool> loaded{false};
 };
 
 } // namespace CHDB

--- a/programs/local/PythonImportCacheItem.h
+++ b/programs/local/PythonImportCacheItem.h
@@ -48,6 +48,15 @@ private:
 	void LoadAttribute(PythonImportCache & cache, py::handle source);
 	void LoadModule(PythonImportCache & cache);
 
+	/// Free-threaded builds: true once the call_once initializer has published
+	/// `object` (acquire; pairs with the release store at the end of the
+	/// initializer). The single fast-path predicate shared by operator() and
+	/// Load(), so the two cannot drift apart.
+	bool IsPublished() const
+	{
+		return loaded.load(std::memory_order_acquire);
+	}
+
 private:
 	String name;
 	bool is_module;

--- a/programs/local/PythonScalarUDF.cpp
+++ b/programs/local/PythonScalarUDF.cpp
@@ -4,6 +4,8 @@
 #include "FieldToPython.h"
 
 #include "PyDateTimeHelper.h"
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -438,8 +440,126 @@ namespace
 
 void insertPythonObjectToColumn(
     DB::IColumn & column,
-    const DB::DataTypePtr & type,
+    const DB::DataTypePtr & actual_type,
     const py::handle & value);
+
+/// Loop-invariant per-argument state, computed once per block. The generic
+/// convertColumnValueForUDF() re-derives all of it on every row (Const/Nullable
+/// unwrapping, removeNullable, expected-type checks, dtype dispatch through a
+/// Field), which profiles as several percent of a UDF-heavy query.
+struct UDFArgSpec
+{
+    const DB::IColumn * column = nullptr;        /// original column (null checks)
+    const DB::IColumn * value_column = nullptr;  /// Const/Nullable unwrapped
+    DB::DataTypePtr type;                        /// original (possibly Nullable) type
+    DB::DataTypePtr declared_type;               /// UDF-declared arg type, if any
+    DB::TypeIndex type_id = DB::TypeIndex::Nothing;
+    bool is_const = false;
+    bool is_bool = false;
+    bool cast_to_float = false;                  /// declared arg type is Float32/64
+    bool fast = false;                           /// convertArgFast handles this type
+};
+
+UDFArgSpec makeUDFArgSpec(const DB::ColumnWithTypeAndName & arg, const DB::DataTypePtr & declared_type)
+{
+    UDFArgSpec spec;
+    spec.column = arg.column.get();
+    spec.type = arg.type;
+    spec.declared_type = declared_type;
+
+    const DB::IColumn * col = arg.column.get();
+    if (const auto * col_const = typeid_cast<const DB::ColumnConst *>(col))
+    {
+        spec.is_const = true;
+        col = &col_const->getDataColumn();
+    }
+    if (const auto * col_nullable = typeid_cast<const DB::ColumnNullable *>(col))
+        col = &col_nullable->getNestedColumn();
+    spec.value_column = col;
+
+    auto actual_type = DB::removeNullable(arg.type);
+    spec.type_id = actual_type->getTypeId();
+    spec.is_bool = DB::isBool(actual_type);
+    if (declared_type)
+    {
+        auto declared_id = DB::removeNullable(declared_type)->getTypeId();
+        spec.cast_to_float = declared_id == DB::TypeIndex::Float32 || declared_id == DB::TypeIndex::Float64;
+    }
+
+    switch (spec.type_id)
+    {
+        case DB::TypeIndex::UInt8:
+        case DB::TypeIndex::UInt16:
+        case DB::TypeIndex::UInt32:
+        case DB::TypeIndex::UInt64:
+        case DB::TypeIndex::Int8:
+        case DB::TypeIndex::Int16:
+        case DB::TypeIndex::Int32:
+        case DB::TypeIndex::Int64:
+        case DB::TypeIndex::Float32:
+        case DB::TypeIndex::Float64:
+        case DB::TypeIndex::BFloat16:
+        case DB::TypeIndex::String:
+        case DB::TypeIndex::FixedString:
+            spec.fast = true;
+            break;
+        default:
+            spec.fast = false;
+    }
+    return spec;
+}
+
+/// Row conversion for the common argument types using one IColumn virtual call
+/// per value instead of a Field round-trip; matches the generic path's results.
+py::object convertArgFast(const UDFArgSpec & spec, size_t input_row)
+{
+    if (spec.column->isNullAt(input_row))
+        return py::none();
+
+    const size_t row = spec.is_const ? 0 : input_row;
+
+    switch (spec.type_id)
+    {
+        case DB::TypeIndex::UInt8:
+            if (spec.is_bool)
+                return py::cast(spec.value_column->getBool(row));
+            [[fallthrough]];
+        case DB::TypeIndex::UInt16:
+        case DB::TypeIndex::UInt32:
+        case DB::TypeIndex::UInt64:
+        {
+            UInt64 value = spec.value_column->getUInt(row);
+            if (spec.cast_to_float)
+                return py::reinterpret_steal<py::object>(PyFloat_FromDouble(static_cast<double>(value)));
+            return py::reinterpret_steal<py::object>(PyLong_FromUnsignedLongLong(value));
+        }
+        case DB::TypeIndex::Int8:
+        case DB::TypeIndex::Int16:
+        case DB::TypeIndex::Int32:
+        case DB::TypeIndex::Int64:
+        {
+            Int64 value = spec.value_column->getInt(row);
+            if (spec.cast_to_float)
+                return py::reinterpret_steal<py::object>(PyFloat_FromDouble(static_cast<double>(value)));
+            return py::reinterpret_steal<py::object>(PyLong_FromLongLong(value));
+        }
+        case DB::TypeIndex::Float32:
+        case DB::TypeIndex::Float64:
+        case DB::TypeIndex::BFloat16:
+            return py::reinterpret_steal<py::object>(PyFloat_FromDouble(spec.value_column->getFloat64(row)));
+        case DB::TypeIndex::String:
+        case DB::TypeIndex::FixedString:
+        {
+            auto ref = spec.value_column->getDataAt(row);
+            PyObject * str = PyUnicode_FromStringAndSize(ref.data(), static_cast<Py_ssize_t>(ref.size()));
+            if (!str)
+                throw py::error_already_set();
+            return py::reinterpret_steal<py::object>(str);
+        }
+        default:
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "convertArgFast called for unsupported type id");
+    }
+}
 
 void handleFloat(
     DB::IColumn & column,
@@ -752,10 +872,9 @@ void handleNull(DB::IColumn & column)
 
 void insertPythonObjectToColumn(
     DB::IColumn & column,
-    const DB::DataTypePtr & type,
+    const DB::DataTypePtr & actual_type,
     const py::handle & value)
 {
-    DB::DataTypePtr actual_type = DB::removeNullable(type);
     auto object_type = GetPythonObjectType(value);
 
     switch (object_type)
@@ -832,14 +951,37 @@ DB::ColumnPtr PythonScalarUDF::executeImpl(
     auto result_column = result_type->createColumn();
     result_column->reserve(input_rows_count);
 
+    const size_t argc = arguments.size();
+
+    /// Hoist every loop invariant out of the per-row path: type unwrapping,
+    /// dispatch flags and the Nullable peel of the return type.
+    std::vector<UDFArgSpec> specs;
+    specs.reserve(argc);
+    for (size_t i = 0; i < argc; ++i)
+        specs.push_back(makeUDFArgSpec(arguments[i], (i < arg_types.size() && arg_types[i]) ? arg_types[i] : nullptr));
+
+    const DB::DataTypePtr result_actual_type = DB::removeNullable(return_type);
+
+#ifdef CHDB_FREE_THREADING
+    /// One reused vectorcall frame instead of a fresh py::tuple per row: the
+    /// tuple is a GC-tracked allocation, and at millions of rows per second
+    /// across many threads it dominates the free-threaded GC trigger rate
+    /// (every young collection is a stop-the-world). Slot 0 stays reserved for
+    /// PY_VECTORCALL_ARGUMENTS_OFFSET; row_args owns the references.
+    /// (PyObject_Vectorcall is not part of the 3.9 stable ABI, so the abi3
+    /// build below keeps a per-row tuple and calls through the limited API.)
+    std::vector<PyObject *> argv(argc + 1, nullptr);
+#endif
+    std::vector<py::object> row_args(argc);
+
     for (size_t row = 0; row < input_rows_count; ++row)
     {
         if (null_handling == NullHandling::SKIP)
         {
             bool has_null_arg = false;
-            for (const auto & arg : arguments)
+            for (const auto & spec : specs)
             {
-                if (arg.column->isNullAt(row))
+                if (spec.column->isNullAt(row))
                 {
                     has_null_arg = true;
                     break;
@@ -854,21 +996,31 @@ DB::ColumnPtr PythonScalarUDF::executeImpl(
             }
         }
 
-        py::tuple py_args(arguments.size());
-        for (size_t i = 0; i < arguments.size(); ++i)
+        for (size_t i = 0; i < argc; ++i)
         {
-            const auto & col = arguments[i];
-            DB::DataTypePtr expected = (i < arg_types.size() && arg_types[i]) ? arg_types[i] : nullptr;
-            py_args[i] = convertColumnValueForUDF(*col.column, col.type, row, expected);
+            const auto & spec = specs[i];
+            row_args[i] = spec.fast
+                ? convertArgFast(spec, row)
+                : convertColumnValueForUDF(*spec.column, spec.type, row, spec.declared_type);
         }
 
-        py::object py_result;
-        try
+#ifdef CHDB_FREE_THREADING
+        for (size_t i = 0; i < argc; ++i)
+            argv[i + 1] = row_args[i].ptr();
+
+        PyObject * raw_result = PyObject_Vectorcall(
+            func.ptr(), argv.data() + 1, argc | PY_VECTORCALL_ARGUMENTS_OFFSET, nullptr);
+#else
+        py::tuple py_args(argc);
+        for (size_t i = 0; i < argc; ++i)
+            py_args[i] = row_args[i];
+
+        PyObject * raw_result = PyObject_CallObject(func.ptr(), py_args.ptr());
+#endif
+
+        if (!raw_result)
         {
-            py_result = func(*py_args);
-        }
-        catch (py::error_already_set & e)
-        {
+            py::error_already_set e;
             if (exception_handling == ExceptionHandling::PROPAGATE)
             {
 #if USE_JEMALLOC
@@ -883,7 +1035,8 @@ DB::ColumnPtr PythonScalarUDF::executeImpl(
             continue;
         }
 
-        insertPythonObjectToColumn(*result_column, return_type, py_result);
+        py::object py_result = py::reinterpret_steal<py::object>(raw_result);
+        insertPythonObjectToColumn(*result_column, result_actual_type, py_result);
     }
 
     return result_column;

--- a/programs/local/PythonUDFRegistry.cpp
+++ b/programs/local/PythonUDFRegistry.cpp
@@ -36,6 +36,15 @@ void PythonUDFRegistry::registerUDF(
 {
     py::gil_assert();
 
+    {
+        /// Fail fast on duplicate names before paying the Python signature
+        /// inspection below; the authoritative re-check still happens under
+        /// the unique lock. No Python runs while this lock is held.
+        std::shared_lock read_lock(mutex);
+        if (udfs.contains(name))
+            throw DB::Exception(DB::ErrorCodes::FUNCTION_ALREADY_EXISTS, "Python UDF '{}' is already registered", name);
+    }
+
     /// Build the UDF (initSignature runs Python: inspect.signature) BEFORE
     /// taking the registry lock. On free-threaded builds, running Python while
     /// holding a lock that other attached threads may block on is the same

--- a/programs/local/PythonUDFRegistry.cpp
+++ b/programs/local/PythonUDFRegistry.cpp
@@ -36,13 +36,20 @@ void PythonUDFRegistry::registerUDF(
 {
     py::gil_assert();
 
+    /// Build the UDF (initSignature runs Python: inspect.signature) BEFORE
+    /// taking the registry lock. On free-threaded builds, running Python while
+    /// holding a lock that other attached threads may block on is the same
+    /// stop-the-world deadlock class as issue #131: the blocked waiters never
+    /// reach a safepoint, so a GC stop-the-world issued during the signature
+    /// inspection could never complete.
+    auto udf = std::make_shared<PythonScalarUDF>(name, std::move(func), std::move(return_type), null_handling, exception_handling);
+    udf->initSignature(arg_types_hint);
+
     std::unique_lock lock(mutex);
 
     if (udfs.contains(name))
         throw DB::Exception(DB::ErrorCodes::FUNCTION_ALREADY_EXISTS, "Python UDF '{}' is already registered", name);
 
-    auto udf = std::make_shared<PythonScalarUDF>(name, std::move(func), std::move(return_type), null_handling, exception_handling);
-    udf->initSignature(arg_types_hint);
     udfs[name] = std::move(udf);
 }
 

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -28,13 +28,31 @@ import sys
 import textwrap
 import unittest
 
-ROWS = 4_000_000
-TIMEOUT_SECONDS = 180
+# The deadlock races the FIRST lazy import-cache load, in the first rows each
+# worker processes — total row volume adds nothing to the repro (a regressed
+# build hangs forever at any size and still trips the timeout). What DOES
+# matter is how many threads actually execute the UDF concurrently, and that
+# is the number of data blocks: with the default max_block_size (65409) a
+# small row count degenerates to a single block, i.e. a single racing thread
+# and no deadlock window at all. So the block size is pinned small to keep a
+# full 32-way race (100k rows / 1k = 100 blocks) while the total work stays
+# tiny — the original 4M rows were CPU-bound past the 180s budget on the FT
+# CI runner (per-row Python UDF × oversubscribed threads × collect storm),
+# misreporting plain slowness as the deadlock.
+ROWS = 100_000
+MAX_BLOCK_SIZE = 1_000
+# The race is probabilistic: on a pre-fix build one cold start hangs in ~3 of
+# 4 attempts (the import can win the race against the first stop-the-world).
+# Several independent cold processes push the per-test catch rate past 98%,
+# while a healthy build pays well under a second per attempt.
+ATTEMPTS = 3
+TIMEOUT_SECONDS = 60
 
 CHILD_SCRIPT = textwrap.dedent(
     f"""
     import gc
     import threading
+    import time
 
     import chdb
     from chdb.sqltypes import INT64
@@ -43,23 +61,29 @@ CHILD_SCRIPT = textwrap.dedent(
     def fadd(a, b):
         return (a * 31 + b) % 97
 
-    stop = False
+    stop = threading.Event()
 
     def collector():
         # Continuous stop-the-world requests, covering the cold lazy-import
         # window of the first parallel query.
-        while not stop:
+        while not stop.is_set():
             gc.collect()
 
     thread = threading.Thread(target=collector, daemon=True)
     thread.start()
+    time.sleep(0.05)  # make sure the storm is already running when the query starts
 
-    result = chdb.query(
-        "SELECT sum(fadd(toInt64(number), 1)) FROM numbers_mt({ROWS}) "
-        "SETTINGS max_threads=32"
-    )
-    stop = True
-    thread.join(timeout=5)
+    try:
+        result = chdb.query(
+            "SELECT sum(fadd(toInt64(number), 1)) FROM numbers_mt({ROWS}) "
+            "SETTINGS max_threads=32, max_block_size={MAX_BLOCK_SIZE}"
+        )
+    finally:
+        # Always stop the collector: a spinning gc.collect() thread during
+        # interpreter finalization can stall the child and turn an ordinary
+        # query error into a bogus deadlock timeout.
+        stop.set()
+        thread.join(timeout=5)
     print("RESULT:" + str(result).strip(), flush=True)
     """
 )
@@ -67,36 +91,38 @@ CHILD_SCRIPT = textwrap.dedent(
 
 class TestFTImportCacheColdStart(unittest.TestCase):
     def test_cold_parallel_udf_survives_gc_stop_the_world_storm(self):
-        try:
-            proc = subprocess.run(
-                [sys.executable, "-c", CHILD_SCRIPT],
-                capture_output=True,
-                text=True,
-                timeout=TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired as e:
-            stderr = (e.stderr or b"")
-            if isinstance(stderr, bytes):
-                stderr = stderr.decode("utf-8", "replace")
-            self.fail(
-                "cold parallel UDF query did not finish within "
-                f"{TIMEOUT_SECONDS}s — the import-cache stop-the-world "
-                "deadlock (issue #131) is back. Child stderr:\n" + stderr[-2000:]
-            )
-
-        self.assertEqual(
-            proc.returncode,
-            0,
-            "child process failed:\n" + (proc.stderr or "")[-2000:],
-        )
-
         # fadd is deterministic: sum((i * 31 + 1) % 97 for i in range(ROWS)),
         # computed via the period-97 structure of the sequence.
         period = [(i * 31 + 1) % 97 for i in range(97)]
         full, rest = divmod(ROWS, 97)
         expected = sum(period) * full + sum(period[:rest])
 
-        self.assertIn(f"RESULT:{expected}", proc.stdout)
+        for attempt in range(ATTEMPTS):
+            try:
+                proc = subprocess.run(
+                    [sys.executable, "-c", CHILD_SCRIPT],
+                    capture_output=True,
+                    text=True,
+                    timeout=TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired as e:
+                stderr = (e.stderr or b"")
+                if isinstance(stderr, bytes):
+                    stderr = stderr.decode("utf-8", "replace")
+                self.fail(
+                    f"cold parallel UDF query (attempt {attempt + 1}/{ATTEMPTS}) "
+                    f"did not finish within {TIMEOUT_SECONDS}s — the import-cache "
+                    "stop-the-world deadlock (issue #131) is back. "
+                    "Child stderr:\n" + stderr[-2000:]
+                )
+
+            self.assertEqual(
+                proc.returncode,
+                0,
+                f"child process failed (attempt {attempt + 1}):\n"
+                + (proc.stderr or "")[-2000:],
+            )
+            self.assertIn(f"RESULT:{expected}", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -47,6 +47,14 @@ MAX_BLOCK_SIZE = 1_000
 # while a healthy build pays well under a second per attempt.
 ATTEMPTS = 3
 TIMEOUT_SECONDS = 60
+# The storm only needs to cover the cold-import window at query start: once
+# the deadlock forms it self-sustains (the collector itself is then stuck
+# inside gc.collect(), waiting on a stop-the-world that can never finish), so
+# bounding the storm loses no detection power. Left unbounded, it throttled
+# the whole healthy run instead: with pandas installed (as on CI) the lazy
+# import loads the real package, the heap grows, every gc.collect() costs
+# tens of milliseconds, and the run took >130s even on a 16-core box.
+STORM_SECONDS = 10
 
 CHILD_SCRIPT = textwrap.dedent(
     f"""
@@ -62,11 +70,13 @@ CHILD_SCRIPT = textwrap.dedent(
         return (a * 31 + b) % 97
 
     stop = threading.Event()
+    storm_deadline = time.monotonic() + {STORM_SECONDS}
 
     def collector():
         # Continuous stop-the-world requests, covering the cold lazy-import
-        # window of the first parallel query.
-        while not stop.is_set():
+        # window of the first parallel query; time-boxed so a healthy run is
+        # not throttled end-to-end (a formed deadlock self-sustains anyway).
+        while not stop.is_set() and time.monotonic() < storm_deadline:
             gc.collect()
 
     thread = threading.Thread(target=collector, daemon=True)

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression test for the free-threading cold-start UDF deadlock (issue #131).
+
+On free-threaded builds, the lazy import-cache load ran inside std::call_once
+with the waiting threads blocked on the once_flag futex while still attached.
+An attached thread parked on a futex never reaches a safepoint, so a GC
+stop-the-world issued while the call_once winner runs the import can never
+complete: the winner parks forever inside the import machinery, the flag is
+never released, and the first parallel UDF query of a cold process hangs.
+
+The deadlock needs a stop-the-world to land inside the few-millisecond import
+window, so the test forces it: a spammer thread issues gc.collect()
+continuously while the cold query runs. Before the fix this hangs 5/5 on a
+16-core box; with the fix it completes with the correct result.
+
+Two properties matter for CI:
+- the query must run in a fresh subprocess (the import cache is per-process;
+  any earlier query in this process would warm it and mask the bug), and
+- a regression must FAIL the test instead of hanging the suite, hence the
+  subprocess timeout.
+
+On stock (GIL) builds the scenario cannot deadlock; the test then simply
+asserts the query result, at negligible cost.
+"""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+ROWS = 4_000_000
+TIMEOUT_SECONDS = 180
+
+CHILD_SCRIPT = textwrap.dedent(
+    f"""
+    import gc
+    import threading
+
+    import chdb
+    from chdb.sqltypes import INT64
+
+    @chdb.func([INT64, INT64], INT64)
+    def fadd(a, b):
+        return (a * 31 + b) % 97
+
+    stop = False
+
+    def collector():
+        # Continuous stop-the-world requests, covering the cold lazy-import
+        # window of the first parallel query.
+        while not stop:
+            gc.collect()
+
+    thread = threading.Thread(target=collector, daemon=True)
+    thread.start()
+
+    result = chdb.query(
+        "SELECT sum(fadd(toInt64(number), 1)) FROM numbers_mt({ROWS}) "
+        "SETTINGS max_threads=32"
+    )
+    stop = True
+    thread.join(timeout=5)
+    print("RESULT:" + str(result).strip(), flush=True)
+    """
+)
+
+
+class TestFTImportCacheColdStart(unittest.TestCase):
+    def test_cold_parallel_udf_survives_gc_stop_the_world_storm(self):
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", CHILD_SCRIPT],
+                capture_output=True,
+                text=True,
+                timeout=TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as e:
+            stderr = (e.stderr or b"")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", "replace")
+            self.fail(
+                "cold parallel UDF query did not finish within "
+                f"{TIMEOUT_SECONDS}s — the import-cache stop-the-world "
+                "deadlock (issue #131) is back. Child stderr:\n" + stderr[-2000:]
+            )
+
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "child process failed:\n" + (proc.stderr or "")[-2000:],
+        )
+
+        # fadd is deterministic: sum((i * 31 + 1) % 97 for i in range(ROWS)),
+        # computed via the period-97 structure of the sequence.
+        period = [(i * 31 + 1) % 97 for i in range(97)]
+        full, rest = divmod(ROWS, 97)
+        expected = sum(period) * full + sum(period[:rest])
+
+        self.assertIn(f"RESULT:{expected}", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -46,7 +46,13 @@ MAX_BLOCK_SIZE = 1_000
 # Several independent cold processes push the per-test catch rate past 98%,
 # while a healthy build pays well under a second per attempt.
 ATTEMPTS = 3
-TIMEOUT_SECONDS = 60
+# With the storm time-boxed below, a healthy attempt is structurally bounded
+# (~10-20s even with pandas loaded), so the timeout's only job is detecting an
+# infinite hang and it is deliberately generous: ~28x the measured healthy
+# attempt, absorbing even pathological slowness spikes. A real regression
+# still fails fast — the first hanging attempt trips it, so the worst-case
+# CI cost of a regression is a single timeout, not ATTEMPTS times it.
+TIMEOUT_SECONDS = 300
 # The storm only needs to cover the cold-import window at query start: once
 # the deadlock forms it self-sustains (the collector itself is then stuck
 # inside gc.collect(), waiting on a stop-the-world that can never finish), so

--- a/tests/test_ft_import_cache_cold_start.py
+++ b/tests/test_ft_import_cache_cold_start.py
@@ -64,16 +64,28 @@ STORM_SECONDS = 10
 
 CHILD_SCRIPT = textwrap.dedent(
     f"""
+    import faulthandler
     import gc
+    import sys
     import threading
     import time
 
     import chdb
     from chdb.sqltypes import INT64
 
+    # Which chdb actually got imported — surfaces cwd/PYTHONPATH shadowing
+    # mixups in the failure diagnostics instead of leaving them to archaeology.
+    print("CHDB:" + chdb.__file__, file=sys.stderr, flush=True)
+
     @chdb.func([INT64, INT64], INT64)
     def fadd(a, b):
         return (a * 31 + b) % 97
+
+    # Black box for hang diagnosis: if this child ever wedges, dump every
+    # thread's stack to stderr periodically; the parent surfaces stderr in the
+    # timeout failure message, telling a stuck stop-the-world (collector still
+    # inside gc.collect) apart from mere slowness. No-op on healthy runs.
+    faulthandler.dump_traceback_later(45, repeat=True)
 
     stop = threading.Event()
     storm_deadline = time.monotonic() + {STORM_SECONDS}
@@ -100,6 +112,7 @@ CHILD_SCRIPT = textwrap.dedent(
         # query error into a bogus deadlock timeout.
         stop.set()
         thread.join(timeout=5)
+        faulthandler.cancel_dump_traceback_later()
     print("RESULT:" + str(result).strip(), flush=True)
     """
 )
@@ -129,7 +142,7 @@ class TestFTImportCacheColdStart(unittest.TestCase):
                     f"cold parallel UDF query (attempt {attempt + 1}/{ATTEMPTS}) "
                     f"did not finish within {TIMEOUT_SECONDS}s — the import-cache "
                     "stop-the-world deadlock (issue #131) is back. "
-                    "Child stderr:\n" + stderr[-2000:]
+                    "Child stderr:\n" + stderr[-6000:]
                 )
 
             self.assertEqual(


### PR DESCRIPTION
Fixes #128

Stacked on #141 (includes its commit; will rebase to a single commit once that merges).

## Root cause (profiled)

`perf` on the UDF loop showed the per-row costs: ~15% jemalloc churn + `_Py_Dealloc`/`dec_ref`, 3.6% `removeNullable`, 1.9% `isExpectedFloat`, 1.9% `std::deque` growth from import-cache hierarchy rebuilds, plus pybind11's unpacking-call tuple traffic.

- `executeImpl` re-derived loop invariants on every row (Const/Nullable unwrapping, `removeNullable`, expected-type checks, dtype dispatch through a `Field`) and built a fresh **gc-tracked `py::tuple` per row**.
- On free-threaded builds that tuple dominates the GC trigger rate, and every young collection is a stop-the-world across all query threads — the more threads, the higher the allocation rate, the more STW pauses: that is the negative scaling at high `max_threads`.
- `GetPythonObjectType` checked `pandas.NaT`/`NA` (import-cache lookups) before the builtin scalars, adding per-result-row overhead.

## Fix

- hoist per-argument state into a per-block `UDFArgSpec`; convert the common argument types (ints, floats, bool, strings) with one `IColumn` virtual call instead of a `Field` round-trip (other types keep the generic path)
- free-threaded: call the UDF via `PyObject_Vectorcall` with a reused argument frame — no per-row tuple; abi3: `PyObject_Vectorcall` is not in the 3.9 stable ABI, so keep the tuple but call `PyObject_CallObject` directly, skipping pybind11's unpacking collector
- check exact builtin scalars (bool/int/float/str) before the import-cache lookups in `GetPythonObjectType`; `NaT`/`NA` stay ahead of the datetime family they belong to
- hoist `removeNullable(return_type)` out of the per-row result insert

## Numbers

`fadd((a*31+b)%97)` over 4M rows (`numbers_mt`), 16-core x86_64, best of 3:

| build | threads | before | after |
|---|---:|---:|---:|
| free-threaded 3.14.0t | 1 | 3.37 s | **0.72 s** |
| free-threaded 3.14.0t | 8 | 1.60 s | **0.15 s** |
| free-threaded 3.14.0t | 32 | 1.27 s | **0.17 s** |
| stock 3.14 abi3 | 1 | 2.31 s | **0.83 s** |
| stock 3.14 abi3 | 8–32 | ~2.36 s | ~0.85 s (flat under the GIL, as before) |

FT single-thread goes from ~1.5× slower than stock to slightly faster, thread scaling holds to the core count with no degradation past 8 threads, and the stock build gets a ~2.8× single-thread win from the same hoisting.

## Verification

`test_func_udf.py` / `test_func_udf_types.py` pass on both builds (minus the pre-existing wide-int gaps of the lite engine variant used locally); dataframe object-scan probes over the reordered `GetPythonObjectType` show no behavior change; the #131 stop-the-world storm repro still passes 5/5.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut per-row overhead and fix GC deadlock in Python scalar UDF execution
> - Hoists loop-invariant work (arg specs, result type) out of the per-row path in `PythonScalarUDF::executeImpl` and adds a `convertArgFast` path that converts common argument types directly via `IColumn` getters instead of `Field` round-trips.
> - On free-threaded builds, switches to `PyObject_Vectorcall` with a reused argv frame to eliminate per-row tuple allocations.
> - Reorders type checks in `GetPythonObjectType` to prioritize exact builtin scalars (`bool`, `int`, `float`, `str`) before any import-cache lookups, reducing cache pressure on the hot UDF result path.
> - Adds a lock-free fast path in `PythonImportCacheItem::operator()` for free-threaded builds using an atomic `loaded` flag, and reworks `Load` to release the GIL while waiting on `std::call_once` to prevent a process-wide deadlock during GC stop-the-world.
> - Risk: callers with `load=false` on free-threaded builds now receive a null handle until the import cache item is fully published.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85814e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->