### PR TITLE
Apply query-level SETTINGS to streaming query output format

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3276,6 +3276,17 @@ bool ClientBase::processStreamingQuery(void * streaming_result_, bool is_cancele
 
         resetOutputFormat();
 
+        /// The query-level SETTINGS clause (e.g. date_time_output_format = 'iso')
+        /// was applied to client_context in processParsedSingleQuery, but its
+        /// SCOPE_EXIT rolled the settings back before this deferred fetch runs.
+        /// Re-apply it from the stored AST so initOutputFormat() (which builds the
+        /// output format from getFormatSettings(client_context)) formats the result
+        /// as requested, then restore to avoid leaking into later statements on
+        /// this connection. Mirrors the streaming-insert path in ChdbClient.
+        Settings old_settings = client_context->getSettingsRef();
+        SCOPE_EXIT_SAFE({ client_context->setSettings(old_settings); });
+        InterpreterSetQuery::applySettingsFromQuery(streaming_query_context->parsed_query, client_context);
+
         receiveResult(streaming_query_context->parsed_query, is_canceled);
 
         resetOutputFormat();

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3284,12 +3284,29 @@ bool ClientBase::processStreamingQuery(void * streaming_result_, bool is_cancele
         /// as requested, then restore to avoid leaking into later statements on
         /// this connection. Mirrors the streaming-insert path in ChdbClient.
         Settings old_settings = client_context->getSettingsRef();
-        SCOPE_EXIT_SAFE({ client_context->setSettings(old_settings); });
+        SCOPE_EXIT_SAFE({
+            try
+            {
+                /// Park ParallelFormatting threads before restoring settings:
+                /// they can read settings from the context, which would race
+                /// with setSettings (mirrors processParsedSingleQuery). This
+                /// must run before setSettings even when receiveResult threw,
+                /// so it lives in the scope-exit rather than after receiveResult.
+                resetOutputFormat();
+            }
+            catch (...)
+            {
+                if (!have_error)
+                {
+                    client_exception = std::make_unique<Exception>(getCurrentExceptionMessageAndPattern(print_stack_trace), getCurrentExceptionCode());
+                    have_error = true;
+                }
+            }
+            client_context->setSettings(old_settings);
+        });
         InterpreterSetQuery::applySettingsFromQuery(streaming_query_context->parsed_query, client_context);
 
         receiveResult(streaming_query_context->parsed_query, is_canceled);
-
-        resetOutputFormat();
     }
     catch (...)
     {

--- a/tests/test_c_api_stream_query.py
+++ b/tests/test_c_api_stream_query.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Regression test for the C ABI streaming-query surface (Issue #143).
+
+Reproduces chdb-io/chdb-core#143: a query-level ``SETTINGS`` clause
+(e.g. ``date_time_output_format='iso'``) must be applied to the CLIENT-SIDE
+output format of a STREAMING query issued via ``chdb_stream_query`` +
+``chdb_stream_fetch_result``, exactly as it already is for a materialized
+``chdb_query``. Before the fix the streaming path rolled the query settings
+back to defaults before the output format was created at fetch time, so a
+``DateTime64`` was emitted as ``2025-12-19 13:52:04.496187`` instead of the
+ISO form ``2025-12-19T13:52:04.496187Z``.
+
+Loads libchdb.so / libchdb.dylib directly via ctypes (those binaries export
+the C ABI; the Python wheel's ``_chdb.abi3.so`` only exports
+``PyInit__chdb``). When no standalone library is found (e.g. running against
+an installed wheel without the source tree) the whole suite is skipped.
+"""
+
+import ctypes
+import os
+import platform
+import unittest
+
+
+def _find_libchdb():
+    """Locate libchdb.so / libchdb.dylib. Returns the path or None."""
+    candidates = []
+    if os.environ.get("CHDB_LIB_PATH"):
+        candidates.append(os.environ["CHDB_LIB_PATH"])
+
+    # tests/ -> repo root -> buildlib/
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    lib_name = "libchdb.dylib" if platform.system() == "Darwin" else "libchdb.so"
+    candidates.append(os.path.join(repo_root, "buildlib", lib_name))
+
+    for path in candidates:
+        if path and os.path.isfile(path):
+            return path
+    return None
+
+
+_LIB_PATH = _find_libchdb()
+
+
+@unittest.skipIf(
+    _LIB_PATH is None,
+    "libchdb.so/dylib not found; build chdb-core or set CHDB_LIB_PATH to run",
+)
+class TestCApiStreamQuery(unittest.TestCase):
+    """Verify the C-ABI streaming-query entry points honor query SETTINGS."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.lib = ctypes.CDLL(_LIB_PATH)
+
+        cls.lib.chdb_connect.restype = ctypes.c_void_p
+        cls.lib.chdb_connect.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+        cls.lib.chdb_close_conn.restype = None
+        cls.lib.chdb_close_conn.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+
+        # Materialized query (control).
+        cls.lib.chdb_query.restype = ctypes.c_void_p
+        cls.lib.chdb_query.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+
+        # Streaming query: init + fetch loop.
+        cls.lib.chdb_stream_query.restype = ctypes.c_void_p
+        cls.lib.chdb_stream_query.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+        cls.lib.chdb_stream_fetch_result.restype = ctypes.c_void_p
+        cls.lib.chdb_stream_fetch_result.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        cls.lib.chdb_stream_cancel_query.restype = None
+        cls.lib.chdb_stream_cancel_query.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        # Result accessors.
+        cls.lib.chdb_result_buffer.restype = ctypes.POINTER(ctypes.c_char)
+        cls.lib.chdb_result_buffer.argtypes = [ctypes.c_void_p]
+        cls.lib.chdb_result_length.restype = ctypes.c_size_t
+        cls.lib.chdb_result_length.argtypes = [ctypes.c_void_p]
+        cls.lib.chdb_result_error.restype = ctypes.c_char_p
+        cls.lib.chdb_result_error.argtypes = [ctypes.c_void_p]
+        cls.lib.chdb_destroy_query_result.restype = None
+        cls.lib.chdb_destroy_query_result.argtypes = [ctypes.c_void_p]
+
+        # Memory-only connection: chdb.state.connect(":memory:") collapses to
+        # argv = ["clickhouse"] (no --path), so do the same here.
+        argv = (ctypes.c_char_p * 1)(b"clickhouse")
+        cls.conn_ptr = cls.lib.chdb_connect(1, argv)
+        if not cls.conn_ptr:
+            raise RuntimeError("chdb_connect returned NULL")
+        # chdb_connect returns chdb_connection*; deref once to get the
+        # chdb_connection value the query functions expect.
+        cls.conn = ctypes.c_void_p.from_address(cls.conn_ptr).value
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "conn_ptr", None):
+            cls.lib.chdb_close_conn(ctypes.cast(cls.conn_ptr, ctypes.POINTER(ctypes.c_void_p)))
+
+    # ------------------------------------------------------------------ helpers
+
+    def _materialized_text(self, sql, fmt=b"TSV"):
+        result = self.lib.chdb_query(self.conn, sql, fmt)
+        try:
+            err = self.lib.chdb_result_error(result)
+            self.assertIsNone(err, err.decode("utf-8", "replace") if err else None)
+            n = self.lib.chdb_result_length(result)
+            buf = self.lib.chdb_result_buffer(result)
+            return ctypes.string_at(buf, n).decode("utf-8") if buf and n else ""
+        finally:
+            self.lib.chdb_destroy_query_result(result)
+
+    def _stream_text(self, sql, fmt=b"TSV"):
+        stream = self.lib.chdb_stream_query(self.conn, sql, fmt)
+        err = self.lib.chdb_result_error(stream)
+        self.assertIsNone(err, err.decode("utf-8", "replace") if err else None)
+
+        chunks = []
+        try:
+            while True:
+                chunk = self.lib.chdb_stream_fetch_result(self.conn, stream)
+                chunk_err = self.lib.chdb_result_error(chunk)
+                self.assertIsNone(
+                    chunk_err, chunk_err.decode("utf-8", "replace") if chunk_err else None
+                )
+                n = self.lib.chdb_result_length(chunk)
+                if n == 0:
+                    self.lib.chdb_destroy_query_result(chunk)
+                    break
+                buf = self.lib.chdb_result_buffer(chunk)
+                chunks.append(ctypes.string_at(buf, n))
+                self.lib.chdb_destroy_query_result(chunk)
+        finally:
+            self.lib.chdb_stream_cancel_query(self.conn, stream)
+            self.lib.chdb_destroy_query_result(stream)
+
+        return b"".join(chunks).decode("utf-8")
+
+    # -------------------------------------------------------------------- tests
+
+    def test_stream_query_applies_date_time_output_format_iso(self):
+        iso_sql = (
+            b"SELECT toDateTime64('2025-12-19 13:52:04.496187', 6, 'UTC') AS ts "
+            b"SETTINGS date_time_output_format = 'iso'"
+        )
+        # TSV: bare value + trailing newline (no quoting, no header).
+        expected_iso = "2025-12-19T13:52:04.496187Z\n"
+
+        # Control: the materialized path already honors the SETTINGS clause.
+        self.assertEqual(self._materialized_text(iso_sql), expected_iso)
+
+        # The bug: the streaming path must produce the SAME ISO-formatted output.
+        streaming = self._stream_text(iso_sql)
+        # Specific checks first for clearer failure diagnostics, then exact match.
+        self.assertIn("2025-12-19T13:52:04.496187Z", streaming)
+        self.assertNotIn("2025-12-19 13:52:04.496187", streaming)
+        self.assertEqual(streaming, expected_iso)
+
+        # Parity: streaming and materialized must agree exactly.
+        self.assertEqual(streaming, self._materialized_text(iso_sql))
+
+        # Leak guard: a subsequent streaming query with no SETTINGS clause must
+        # fall back to the default (non-ISO) form.
+        default_sql = b"SELECT toDateTime64('2025-12-19 13:52:04.496187', 6, 'UTC') AS ts"
+        self.assertEqual(self._stream_text(default_sql), "2025-12-19 13:52:04.496187\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming_query.py
+++ b/tests/test_streaming_query.py
@@ -76,6 +76,44 @@ class TestStreamingQuery(unittest.TestCase):
                 total_rows += chunk.rows_read()
         self.assertEqual(total_rows, 1073741824)
 
+    def test_streaming_query_applies_date_time_output_format_iso(self):
+        # chdb-core #143: a query-level `SETTINGS date_time_output_format = 'iso'`
+        # must be applied to the CLIENT-SIDE output format of a STREAMING query,
+        # exactly as it already is for a materialized query. Before the fix the
+        # streaming path rolled the query settings back to defaults before the
+        # output format was created at fetch time, so a DateTime64 was emitted in
+        # the default form ("2025-12-19 13:52:04.496187") instead of the ISO form
+        # with a `T` separator and trailing `Z` ("2025-12-19T13:52:04.496187Z").
+        iso_query = (
+            "SELECT toDateTime64('2025-12-19 13:52:04.496187', 6, 'UTC') AS ts "
+            "SETTINGS date_time_output_format = 'iso'"
+        )
+        # CSVWITHNAMES: quoted header line, then the quoted value + trailing newline.
+        expected_iso = '"ts"\n"2025-12-19T13:52:04.496187Z"\n'
+        expected_default = '"ts"\n"2025-12-19 13:52:04.496187"\n'
+
+        # Control: the materialized (non-streaming) path already honors the SETTINGS.
+        materialized = self.sess.query(iso_query, "CSVWITHNAMES").data()
+        self.assertEqual(materialized, expected_iso)
+
+        # The bug: the streaming path must produce the SAME ISO-formatted output.
+        chunks = list(self.sess.send_query(iso_query, "CSVWITHNAMES"))
+        self.assertEqual(len(chunks), 1)
+        streaming = chunks[0].data()
+        self.assertEqual(streaming, expected_iso)
+        self.assertIn("2025-12-19T13:52:04.496187Z", streaming)
+        self.assertNotIn("2025-12-19 13:52:04.496187", streaming)
+
+        # Parity: the streaming and materialized paths must agree exactly.
+        self.assertEqual(streaming, materialized)
+
+        # Guard against setting leakage: a subsequent streaming query with no
+        # SETTINGS clause must fall back to the default (non-ISO) form.
+        default_query = "SELECT toDateTime64('2025-12-19 13:52:04.496187', 6, 'UTC') AS ts"
+        default_chunks = list(self.sess.send_query(default_query, "CSVWITHNAMES"))
+        self.assertEqual(len(default_chunks), 1)
+        self.assertEqual(default_chunks[0].data(), expected_default)
+
     def test_cancel_streaming_query(self):
         self.sess.query("CREATE DATABASE IF NOT EXISTS test")
         self.sess.query("USE test")

--- a/tests/test_streaming_query.py
+++ b/tests/test_streaming_query.py
@@ -100,9 +100,10 @@ class TestStreamingQuery(unittest.TestCase):
         chunks = list(self.sess.send_query(iso_query, "CSVWITHNAMES"))
         self.assertEqual(len(chunks), 1)
         streaming = chunks[0].data()
-        self.assertEqual(streaming, expected_iso)
+        # Specific checks first for clearer failure diagnostics, then exact match.
         self.assertIn("2025-12-19T13:52:04.496187Z", streaming)
         self.assertNotIn("2025-12-19 13:52:04.496187", streaming)
+        self.assertEqual(streaming, expected_iso)
 
         # Parity: the streaming and materialized paths must agree exactly.
         self.assertEqual(streaming, materialized)


### PR DESCRIPTION
Streaming queries dropped their `SETTINGS` clause when formatting output. `SELECT ... SETTINGS date_time_output_format='iso'` returned `2025-12-19 13:52:04.496187` instead of the ISO `2025-12-19T13:52:04.496187Z`; materialized queries were unaffected.

The setting is applied to `client_context` in `processParsedSingleQuery`, but its `SCOPE_EXIT` rolls it back before the streaming query's deferred `receiveResult` runs. The output format is created at fetch time from `getFormatSettings(client_context)`, so the setting was already gone. `processStreamingQuery` now re-applies the settings from the stored AST around `receiveResult` and restores them afterwards (client-side only; mirrors the streaming-insert path).

Test: `test_streaming_query_applies_date_time_output_format_iso` asserts the streaming path matches the materialized path for an ISO-formatted `DateTime64`, plus a setting-leak guard.

Fixes #143


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply query-level SETTINGS to streaming query output format in `ClientBase::processStreamingQuery`
> - Query-level `SETTINGS` clauses (e.g. `date_time_output_format='iso'`) were previously ignored when formatting streaming query results; they are now applied to `client_context` before `receiveResult` runs.
> - `resetOutputFormat` is moved into a `SCOPE_EXIT_SAFE` that also restores the original settings after result retrieval completes or throws, ensuring settings do not leak to subsequent queries.
> - Regression tests are added in [test_streaming_query.py](https://github.com/chdb-io/chdb-core/pull/144/files#diff-ed94b739bcb0ce7eed921792014d6af8cee06752bac3e444aed47a90e103581a) and [test_c_api_stream_query.py](https://github.com/chdb-io/chdb-core/pull/144/files#diff-4363615475e57bfd5134cd04300eeb68870393cc0fa952006f8c68914443c0ad) to verify correct formatting and settings isolation.
> - Behavioral Change: if `resetOutputFormat` throws inside the scope-exit and no prior error was recorded, `client_exception`/`have_error` are now set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0636b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->