### PR TITLE
Add Arrow PyCapsule interface (__arrow_c_stream__) for query results and Python() table input

### DIFF
--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -112,6 +112,7 @@ class StreamingResult:
         self._exhausted = False
         self._supports_record_batch = supports_record_batch
         self._is_dataframe = is_dataframe
+        self._arrow_c_stream_exported = False
         self._progress_callback = None
         self._cleanup_progress_callback = None
         self._progress_callback_cleaned = False
@@ -300,6 +301,16 @@ class StreamingResult:
                 "Please use format='Arrow' when calling send_query."
             )
         _require_pyarrow("__arrow_c_stream__()")
+        # Single-use: the underlying stream is consumed as the caller reads it.
+        # A second export (or an export after the stream was drained/cancelled)
+        # would otherwise silently hand back a zero-column, zero-row stream, so
+        # reject it with a clear error instead.
+        if self._arrow_c_stream_exported or self._exhausted:
+            raise RuntimeError(
+                "streaming result already consumed; __arrow_c_stream__() is "
+                "single-use. Start a new send_query() to read the data again."
+            )
+        self._arrow_c_stream_exported = True
         return self.record_batch().__arrow_c_stream__(requested_schema)
 
 

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -283,6 +283,25 @@ class StreamingResult:
         chdb_reader = ChdbRecordBatchReader(self, rows_per_batch)
         return pa.RecordBatchReader.from_batches(chdb_reader.schema(), chdb_reader)
 
+    def __arrow_c_stream__(self, requested_schema=None):
+        """
+        Arrow PyCapsule interface: export this streaming result as an
+        ArrowArrayStream capsule so Arrow-native consumers (polars, pyarrow,
+        duckdb, pandas, ...) can ingest it directly, e.g. ``pl.DataFrame(stream)``.
+
+        Requires the streaming query to have been started with arrow format
+        (``send_query(sql, "Arrow")``) and pyarrow to be installed. Like the
+        stream itself, the export is single-use: batches are consumed as the
+        caller reads them.
+        """
+        if not self._supports_record_batch:
+            raise ValueError(
+                "__arrow_c_stream__ requires arrow format. "
+                "Please use format='Arrow' when calling send_query."
+            )
+        _require_pyarrow("__arrow_c_stream__()")
+        return self.record_batch().__arrow_c_stream__(requested_schema)
+
 
 class InsertResult:
     """Result of a finished streaming INSERT (returned by :meth:`StreamingInserter.finish`).

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -73,6 +73,7 @@ if (USE_PYTHON)
         ChdbPyType.cpp
         PythonScalarUDF.cpp
         PythonUDFRegistry.cpp
+        PythonArrowStream.cpp
         PythonReader.cpp
         PythonTableCache.cpp
         PythonImportCache.cpp

--- a/programs/local/DataSourceWrapper.h
+++ b/programs/local/DataSourceWrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ArrowStreamWrapper.h"
 #include "PybindWrapper.h"
 
 #include <memory>
@@ -20,6 +21,7 @@ public:
     ~DataSourceWrapper()
     {
         py::gil_scoped_acquire acquire;
+        cached_arrow_stream.reset();
         column_cache.clear();
         data_source.dec_ref();
         data_source.release();
@@ -46,9 +48,17 @@ public:
         return column_cache.contains(col_name);
     }
 
+    /// Arrow stream parked by schema inference for reuse by the scan, so a
+    /// query lifecycle calls __arrow_c_stream__ on the producer only once
+    /// (one-shot producers cannot export a second stream).
+    void cacheArrowStream(std::unique_ptr<ArrowArrayStreamWrapper> stream) { cached_arrow_stream = std::move(stream); }
+    ArrowArrayStreamWrapper * peekCachedArrowStream() { return cached_arrow_stream.get(); }
+    std::unique_ptr<ArrowArrayStreamWrapper> takeCachedArrowStream() { return std::move(cached_arrow_stream); }
+
 private:
     py::object data_source;
     std::unordered_map<std::string, py::array> column_cache;
+    std::unique_ptr<ArrowArrayStreamWrapper> cached_arrow_stream;
 };
 
 using DataSourceWrapperPtr = std::shared_ptr<DataSourceWrapper>;

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -2,6 +2,7 @@
 #include "chdb-internal.h"
 #include "DataFrameQueryResult.h"
 #include "PandasDataFrameBuilder.h"
+#include "PythonArrowStream.h"
 #include "PythonImporter.h"
 #include "ChdbPyType.h"
 #include "ChdbGlobalFunctions.h"
@@ -842,7 +843,22 @@ PYBIND11_MODULE(_chdb, m)
         .def("bytes_written", &query_result::bytes_written)
         .def("get_memview", &query_result::get_memview)
         .def("has_error", &query_result::has_error)
-        .def("error_message", &query_result::error_message);
+        .def("error_message", &query_result::error_message)
+        .def(
+            "__arrow_c_stream__",
+            [](query_result & self, py::object /*requested_schema*/)
+            {
+                if (self.has_error())
+                    throw py::value_error("query result carries an error: " + self.error_message().cast<std::string>());
+                return CHDB::exportArrowIPCAsCapsule(
+                    self.data(), self.size(), std::static_pointer_cast<void>(self.get_result_wrapper()));
+            },
+            py::arg("requested_schema") = py::none(),
+            "Arrow PyCapsule interface: export the result as an ArrowArrayStream capsule.\n"
+            "Requires the query to have produced Arrow IPC output, i.e. output format\n"
+            "\"Arrow\" or \"ArrowStream\". The exported record batches reference the\n"
+            "result buffer directly (no copy) and keep the result alive until released.\n"
+            "Can be called multiple times; each call yields an independent stream.");
 
     py::class_<streaming_query_result>(m, "streaming_query_result")
         .def(py::init<chdb_result *>(), py::return_value_policy::take_ownership)

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -849,7 +849,7 @@ PYBIND11_MODULE(_chdb, m)
             [](query_result & self, py::object /*requested_schema*/)
             {
                 if (self.has_error())
-                    throw py::value_error("query result carries an error: " + self.error_message().cast<std::string>());
+                    throw std::invalid_argument("query result carries an error: " + self.error_message().cast<std::string>());
                 return CHDB::exportArrowIPCAsCapsule(
                     self.data(), self.size(), std::static_pointer_cast<void>(self.get_result_wrapper()));
             },

--- a/programs/local/LocalChdb.h
+++ b/programs/local/LocalChdb.h
@@ -181,6 +181,7 @@ public:
     bool has_error() { return result_wrapper->has_error(); }
     py::str error_message() { return result_wrapper->error_message(); }
     memoryview_wrapper * get_memview();
+    std::shared_ptr<local_result_wrapper> get_result_wrapper() { return result_wrapper; }
 };
 
 class streaming_query_result

--- a/programs/local/PythonArrowStream.cpp
+++ b/programs/local/PythonArrowStream.cpp
@@ -1,0 +1,182 @@
+#include "PythonArrowStream.h"
+#include "ArrowSchema.h"
+#include "PybindWrapper.h"
+
+#include <cstring>
+
+#include <Common/Exception.h>
+#include <arrow/buffer.h>
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/record_batch.h>
+#include <pybind11/gil.h>
+
+#if USE_JEMALLOC
+#include <Common/memory.h>
+#endif
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int PY_EXCEPTION_OCCURED;
+extern const int BAD_ARGUMENTS;
+}
+
+}
+
+using namespace DB;
+
+namespace CHDB
+{
+
+static constexpr const char * kArrowStreamCapsuleName = "arrow_array_stream";
+
+bool hasArrowCStreamMethod(const py::handle & obj)
+{
+    chassert(py::gil_check());
+    return py::hasattr(obj, "__arrow_c_stream__");
+}
+
+std::unique_ptr<ArrowArrayStreamWrapper> importArrowCStream(const py::object & obj)
+{
+    chassert(py::gil_check());
+
+    try
+    {
+        py::object capsule = obj.attr("__arrow_c_stream__")();
+        if (!PyCapsule_IsValid(capsule.ptr(), kArrowStreamCapsuleName))
+            throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED,
+                "__arrow_c_stream__ did not return an 'arrow_array_stream' PyCapsule");
+
+        auto * src = static_cast<ArrowArrayStream *>(PyCapsule_GetPointer(capsule.ptr(), kArrowStreamCapsuleName));
+        if (!src || !src->release)
+            throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED,
+                "__arrow_c_stream__ returned a capsule with an already-released ArrowArrayStream");
+
+        /// Move the stream out of the capsule (Arrow C Data Interface move
+        /// convention): the capsule keeps a released husk, its destructor no-ops.
+        auto res = std::make_unique<ArrowArrayStreamWrapper>();
+        res->arrow_array_stream = *src;
+        src->release = nullptr;
+        return res;
+    }
+    catch (const py::error_already_set & e)
+    {
+#if USE_JEMALLOC
+        ::Memory::MemoryCheckScope memory_check_scope;
+#endif
+        throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED,
+            "Failed to import Arrow stream from Python object via __arrow_c_stream__: {}", e.what());
+    }
+}
+
+ColumnsDescription getTableStructureFromArrowCStream(const py::object & obj, ContextPtr & context)
+{
+    auto stream = importArrowCStream(obj);
+
+    ArrowSchemaWrapper schema;
+    stream->getSchema(schema);
+
+    NamesAndTypesList names_and_types;
+    ArrowSchemaWrapper::convertArrowSchema(schema, names_and_types, context);
+    return ColumnsDescription(names_and_types);
+}
+
+namespace
+{
+
+/// arrow::Buffer view over externally-owned memory; `owner` keeps the memory
+/// alive for as long as any exported record batch references it.
+class KeepaliveBuffer : public arrow::Buffer
+{
+public:
+    KeepaliveBuffer(const uint8_t * data, int64_t size, std::shared_ptr<void> owner_)
+        : arrow::Buffer(data, size), owner(std::move(owner_))
+    {
+    }
+
+private:
+    std::shared_ptr<void> owner;
+};
+
+void arrowStreamCapsuleDestructor(PyObject * capsule)
+{
+    auto * stream = static_cast<ArrowArrayStream *>(PyCapsule_GetPointer(capsule, kArrowStreamCapsuleName));
+    if (stream)
+    {
+        /// Only release if the consumer did not take ownership already.
+        if (stream->release)
+            stream->release(stream);
+        delete stream;
+    }
+}
+
+}
+
+py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_ptr<void> keepalive)
+{
+    chassert(py::gil_check());
+
+    if (!data || size == 0)
+        throw py::value_error(
+            "result has no Arrow payload; run the query with output format \"Arrow\" (or \"ArrowStream\")");
+
+    auto buffer = std::make_shared<KeepaliveBuffer>(
+        reinterpret_cast<const uint8_t *>(data), static_cast<int64_t>(size), std::move(keepalive));
+
+    static constexpr char kFileMagic[6] = {'A', 'R', 'R', 'O', 'W', '1'};
+    std::shared_ptr<arrow::RecordBatchReader> reader;
+    if (size >= 8 && std::memcmp(data, kFileMagic, sizeof(kFileMagic)) == 0)
+    {
+        /// Arrow IPC file format (output format "Arrow").
+        auto file_reader_result = arrow::ipc::RecordBatchFileReader::Open(std::make_shared<arrow::io::BufferReader>(buffer));
+        if (!file_reader_result.ok())
+            throw py::value_error("failed to open Arrow IPC file from result buffer: " + file_reader_result.status().ToString());
+        auto file_reader = std::move(file_reader_result).ValueOrDie();
+
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        batches.reserve(file_reader->num_record_batches());
+        for (int i = 0; i < file_reader->num_record_batches(); ++i)
+        {
+            auto batch_result = file_reader->ReadRecordBatch(i);
+            if (!batch_result.ok())
+                throw py::value_error("failed to read Arrow record batch from result buffer: " + batch_result.status().ToString());
+            batches.push_back(std::move(batch_result).ValueOrDie());
+        }
+
+        auto reader_result = arrow::RecordBatchReader::Make(std::move(batches), file_reader->schema());
+        if (!reader_result.ok())
+            throw py::value_error("failed to create Arrow record batch reader: " + reader_result.status().ToString());
+        reader = std::move(reader_result).ValueOrDie();
+    }
+    else
+    {
+        /// Arrow IPC stream format (output format "ArrowStream").
+        auto stream_reader_result = arrow::ipc::RecordBatchStreamReader::Open(std::make_shared<arrow::io::BufferReader>(buffer));
+        if (!stream_reader_result.ok())
+            throw py::value_error(
+                "result buffer is not Arrow IPC data; run the query with output format \"Arrow\" (or \"ArrowStream\"): "
+                + stream_reader_result.status().ToString());
+        reader = std::move(stream_reader_result).ValueOrDie();
+    }
+
+    auto stream = std::make_unique<ArrowArrayStream>();
+    auto status = arrow::ExportRecordBatchReader(std::move(reader), stream.get());
+    if (!status.ok())
+        throw py::value_error("failed to export Arrow record batch reader: " + status.ToString());
+
+    PyObject * capsule = PyCapsule_New(stream.get(), kArrowStreamCapsuleName, arrowStreamCapsuleDestructor);
+    if (!capsule)
+    {
+        stream->release(stream.get());
+        throw py::error_already_set();
+    }
+    stream.release();
+    return py::reinterpret_steal<py::object>(capsule);
+}
+
+} // namespace CHDB

--- a/programs/local/PythonArrowStream.cpp
+++ b/programs/local/PythonArrowStream.cpp
@@ -3,6 +3,7 @@
 #include "PybindWrapper.h"
 
 #include <cstring>
+#include <stdexcept>
 
 #include <Common/Exception.h>
 #include <arrow/buffer.h>
@@ -74,12 +75,10 @@ std::unique_ptr<ArrowArrayStreamWrapper> importArrowCStream(const py::object & o
     }
 }
 
-ColumnsDescription getTableStructureFromArrowCStream(const py::object & obj, ContextPtr & context)
+ColumnsDescription tableStructureFromArrowStream(ArrowArrayStreamWrapper & stream, ContextPtr & context)
 {
-    auto stream = importArrowCStream(obj);
-
     ArrowSchemaWrapper schema;
-    stream->getSchema(schema);
+    stream.getSchema(schema);
 
     NamesAndTypesList names_and_types;
     ArrowSchemaWrapper::convertArrowSchema(schema, names_and_types, context);
@@ -122,7 +121,7 @@ py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_p
     chassert(py::gil_check());
 
     if (!data || size == 0)
-        throw py::value_error(
+        throw std::invalid_argument(
             "result has no Arrow payload; run the query with output format \"Arrow\" (or \"ArrowStream\")");
 
     auto buffer = std::make_shared<KeepaliveBuffer>(
@@ -135,7 +134,7 @@ py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_p
         /// Arrow IPC file format (output format "Arrow").
         auto file_reader_result = arrow::ipc::RecordBatchFileReader::Open(std::make_shared<arrow::io::BufferReader>(buffer));
         if (!file_reader_result.ok())
-            throw py::value_error("failed to open Arrow IPC file from result buffer: " + file_reader_result.status().ToString());
+            throw std::invalid_argument("failed to open Arrow IPC file from result buffer: " + file_reader_result.status().ToString());
         auto file_reader = std::move(file_reader_result).ValueOrDie();
 
         std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
@@ -144,13 +143,13 @@ py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_p
         {
             auto batch_result = file_reader->ReadRecordBatch(i);
             if (!batch_result.ok())
-                throw py::value_error("failed to read Arrow record batch from result buffer: " + batch_result.status().ToString());
+                throw std::invalid_argument("failed to read Arrow record batch from result buffer: " + batch_result.status().ToString());
             batches.push_back(std::move(batch_result).ValueOrDie());
         }
 
         auto reader_result = arrow::RecordBatchReader::Make(std::move(batches), file_reader->schema());
         if (!reader_result.ok())
-            throw py::value_error("failed to create Arrow record batch reader: " + reader_result.status().ToString());
+            throw std::invalid_argument("failed to create Arrow record batch reader: " + reader_result.status().ToString());
         reader = std::move(reader_result).ValueOrDie();
     }
     else
@@ -158,7 +157,7 @@ py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_p
         /// Arrow IPC stream format (output format "ArrowStream").
         auto stream_reader_result = arrow::ipc::RecordBatchStreamReader::Open(std::make_shared<arrow::io::BufferReader>(buffer));
         if (!stream_reader_result.ok())
-            throw py::value_error(
+            throw std::invalid_argument(
                 "result buffer is not Arrow IPC data; run the query with output format \"Arrow\" (or \"ArrowStream\"): "
                 + stream_reader_result.status().ToString());
         reader = std::move(stream_reader_result).ValueOrDie();
@@ -167,7 +166,7 @@ py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_p
     auto stream = std::make_unique<ArrowArrayStream>();
     auto status = arrow::ExportRecordBatchReader(std::move(reader), stream.get());
     if (!status.ok())
-        throw py::value_error("failed to export Arrow record batch reader: " + status.ToString());
+        throw std::invalid_argument("failed to export Arrow record batch reader: " + status.ToString());
 
     PyObject * capsule = PyCapsule_New(stream.get(), kArrowStreamCapsuleName, arrowStreamCapsuleDestructor);
     if (!capsule)

--- a/programs/local/PythonArrowStream.h
+++ b/programs/local/PythonArrowStream.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "ArrowStreamWrapper.h"
+
+#include <memory>
+#include <Interpreters/Context_fwd.h>
+#include <Storages/ColumnsDescription.h>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace CHDB
+{
+
+/// Arrow PyCapsule interface support (both directions).
+/// https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html
+
+/// True if the object exposes the Arrow PyCapsule stream protocol
+/// (has an __arrow_c_stream__ method). GIL must be held.
+bool hasArrowCStreamMethod(const py::handle & obj);
+
+/// Call obj.__arrow_c_stream__() and take ownership of the ArrowArrayStream
+/// carried by the returned "arrow_array_stream" PyCapsule. GIL must be held.
+std::unique_ptr<ArrowArrayStreamWrapper> importArrowCStream(const py::object & obj);
+
+/// Derive the table structure from the stream schema. Calls __arrow_c_stream__
+/// once and reads only the schema (no batches are consumed). GIL must be held.
+DB::ColumnsDescription getTableStructureFromArrowCStream(const py::object & obj, DB::ContextPtr & context);
+
+/// Export a buffer holding Arrow IPC data (file or stream format) as a
+/// PyCapsule("arrow_array_stream"). The record batches reference the buffer
+/// directly (no data copy); `keepalive` is retained until the exported stream
+/// is released by the consumer. GIL must be held.
+py::object exportArrowIPCAsCapsule(const char * data, size_t size, std::shared_ptr<void> keepalive);
+
+} // namespace CHDB

--- a/programs/local/PythonArrowStream.h
+++ b/programs/local/PythonArrowStream.h
@@ -23,9 +23,10 @@ bool hasArrowCStreamMethod(const py::handle & obj);
 /// carried by the returned "arrow_array_stream" PyCapsule. GIL must be held.
 std::unique_ptr<ArrowArrayStreamWrapper> importArrowCStream(const py::object & obj);
 
-/// Derive the table structure from the stream schema. Calls __arrow_c_stream__
-/// once and reads only the schema (no batches are consumed). GIL must be held.
-DB::ColumnsDescription getTableStructureFromArrowCStream(const py::object & obj, DB::ContextPtr & context);
+/// Derive the table structure from the stream schema. get_schema is idempotent
+/// and consumes no batches, so this may be called repeatedly on a stream that
+/// is later handed to the scan.
+DB::ColumnsDescription tableStructureFromArrowStream(ArrowArrayStreamWrapper & stream, DB::ContextPtr & context);
 
 /// Export a buffer holding Arrow IPC data (file or stream format) as a
 /// PyCapsule("arrow_array_stream"). The record batches reference the buffer

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -1,5 +1,6 @@
 #include "PythonTableCache.h"
 #include "PybindWrapper.h"
+#include "PythonArrowStream.h"
 #include "PythonUtils.h"
 
 #include <Common/re2.h>
@@ -30,7 +31,8 @@ static py::object findQueryableObj(const String & var_name)
                 {
                     // Get the object using Python's indexing syntax
                     obj = namespace_obj[py::cast(var_name)];
-                    if (DB::isInheritsFromPyReader(obj) || DB::isPandasDf(obj) || DB::isPyarrowTable(obj) || DB::hasGetItem(obj))
+                    if (DB::isInheritsFromPyReader(obj) || DB::isPandasDf(obj) || DB::isPyarrowTable(obj)
+                        || CHDB::hasArrowCStreamMethod(obj) || DB::hasGetItem(obj))
                     {
                         return obj;
                     }

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -2,6 +2,7 @@
 #include "NumpyType.h"
 #include "PandasDataFrame.h"
 #include "PybindWrapper.h"
+#include "PythonArrowStream.h"
 #include "PythonImporter.h"
 #include "PythonSource.h"
 #include "PyArrowTable.h"
@@ -285,6 +286,17 @@ Pipe StoragePython::readImpl(
         if (PyArrowTable::isPyArrowTable(data_source))
         {
             auto arrow_stream = PyArrowStreamFactory::createFromPyObject(data_source, sample_block.getNames());
+            arrow_table_reader = std::make_shared<ArrowTableReader>(
+                std::move(arrow_stream), sample_block,
+                format_settings, num_streams, max_block_size);
+        }
+        else if (!is_pandas_df && CHDB::hasArrowCStreamMethod(data_source))
+        {
+            /// Generic Arrow PyCapsule stream input. pandas DataFrames also
+            /// expose __arrow_c_stream__ (>= 2.2) but stay on the dedicated
+            /// column-cache scan above, which supports pushdowns this generic
+            /// stream path cannot (the protocol has no projection mechanism).
+            auto arrow_stream = CHDB::importArrowCStream(data_source);
             arrow_table_reader = std::make_shared<ArrowTableReader>(
                 std::move(arrow_stream), sample_block,
                 format_settings, num_streams, max_block_size);

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -296,7 +296,11 @@ Pipe StoragePython::readImpl(
             /// expose __arrow_c_stream__ (>= 2.2) but stay on the dedicated
             /// column-cache scan above, which supports pushdowns this generic
             /// stream path cannot (the protocol has no projection mechanism).
-            auto arrow_stream = CHDB::importArrowCStream(data_source);
+            /// Prefer the stream parked by schema inference; export a fresh
+            /// one only for additional scans (e.g. self-joins).
+            auto arrow_stream = data_source_wrapper->takeCachedArrowStream();
+            if (!arrow_stream)
+                arrow_stream = CHDB::importArrowCStream(data_source);
             arrow_table_reader = std::make_shared<ArrowTableReader>(
                 std::move(arrow_stream), sample_block,
                 format_settings, num_streams, max_block_size);

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -296,8 +296,18 @@ Pipe StoragePython::readImpl(
             /// expose __arrow_c_stream__ (>= 2.2) but stay on the dedicated
             /// column-cache scan above, which supports pushdowns this generic
             /// stream path cannot (the protocol has no projection mechanism).
-            /// Prefer the stream parked by schema inference; export a fresh
-            /// one only for additional scans (e.g. self-joins).
+            ///
+            /// Prefer the stream parked by schema inference so a single scan
+            /// exports from the producer only once. The fresh-export fallback
+            /// covers a re-scan of this same storage; it re-invokes
+            /// __arrow_c_stream__, which yields fresh data for re-exportable
+            /// producers (polars, pyarrow.Table) but an exhausted (empty)
+            /// stream for genuinely single-use producers (a bare
+            /// pyarrow.RecordBatchReader, a generator-backed stream). This is
+            /// inherent to single-use Arrow streams: such a producer likewise
+            /// yields empty on the second reference of e.g. a self-join
+            /// (each reference is a distinct storage that exports once).
+            /// Materialize upfront (pa.table(reader)) to scan more than once.
             auto arrow_stream = data_source_wrapper->takeCachedArrowStream();
             if (!arrow_stream)
                 arrow_stream = CHDB::importArrowCStream(data_source);

--- a/programs/local/TableFunctionPython.cpp
+++ b/programs/local/TableFunctionPython.cpp
@@ -156,9 +156,16 @@ ColumnsDescription TableFunctionPython::getActualTableStructure(ContextPtr conte
     /// Generic Arrow PyCapsule stream protocol (polars DataFrame,
     /// pyarrow.RecordBatchReader, chdb/duckdb results, ...). Checked after the
     /// specialized paths above so pandas / pyarrow.Table keep their optimized
-    /// scans (projection & predicate pushdown).
+    /// scans (projection & predicate pushdown). The imported stream is parked
+    /// on the wrapper and reused by the scan, so the producer's
+    /// __arrow_c_stream__ is called only once per query lifecycle -- one-shot
+    /// producers cannot export a second stream.
     if (hasArrowCStreamMethod(reader))
-        return getTableStructureFromArrowCStream(reader, context);
+    {
+        if (!data_source_wrapper->peekCachedArrowStream())
+            data_source_wrapper->cacheArrowStream(importArrowCStream(reader));
+        return tableStructureFromArrowStream(*data_source_wrapper->peekCachedArrowStream(), context);
+    }
 
     auto schema = PyReader::getSchemaFromPyObj(reader);
     return StoragePython::getTableStructureFromData(schema, context);

--- a/programs/local/TableFunctionPython.cpp
+++ b/programs/local/TableFunctionPython.cpp
@@ -2,6 +2,7 @@
 #include "StoragePython.h"
 #include "PandasDataFrame.h"
 #include "PyArrowTable.h"
+#include "PythonArrowStream.h"
 #include "PythonDict.h"
 #include "PythonReader.h"
 #include "PythonTableCache.h"
@@ -151,6 +152,13 @@ ColumnsDescription TableFunctionPython::getActualTableStructure(ContextPtr conte
 
     if (PythonReader::isPythonReader(reader))
         return PythonReader::getActualTableStructure(reader, context);
+
+    /// Generic Arrow PyCapsule stream protocol (polars DataFrame,
+    /// pyarrow.RecordBatchReader, chdb/duckdb results, ...). Checked after the
+    /// specialized paths above so pandas / pyarrow.Table keep their optimized
+    /// scans (projection & predicate pushdown).
+    if (hasArrowCStreamMethod(reader))
+        return getTableStructureFromArrowCStream(reader, context);
 
     auto schema = PyReader::getSchemaFromPyObj(reader);
     return StoragePython::getTableStructureFromData(schema, context);

--- a/tests/test_arrow_c_stream_protocol.py
+++ b/tests/test_arrow_c_stream_protocol.py
@@ -12,7 +12,9 @@ with the Python() table engine, in addition to the dedicated pandas /
 pyarrow.Table paths.
 """
 
+import gc
 import unittest
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import chdb
@@ -183,6 +185,83 @@ class TestArrowCStreamOutput(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_stream_survives_result_garbage_collection(self):
+        # The exported stream references the result buffer directly; it must
+        # keep the result alive after the query_result object is collected
+        # (real consumers hold only the stream, not the chdb result).
+        res = chdb.query(
+            "SELECT number FROM numbers(300000) SETTINGS max_block_size = 65536", "Arrow"
+        )
+        reader = pa.RecordBatchReader.from_stream(res)
+        del res
+        gc.collect()
+        table = reader.read_all()
+        self.assertEqual(table.num_rows, 300000)
+        self.assertEqual(pc.sum(table.column("number")).as_py(), 300000 * 299999 // 2)
+
+    def test_requested_schema_accepted_and_ignored(self):
+        # The spec allows the producer to ignore requested_schema; the keyword
+        # must be accepted and the exported data stay unchanged.
+        res = chdb.query(SAMPLE_SQL, "Arrow")
+        requested = pa.schema([("id", pa.int64())]).__arrow_c_schema__()
+        capsule = res.__arrow_c_stream__(requested_schema=requested)
+        self.assertEqual(type(capsule).__name__, "PyCapsule")
+
+        class CapsuleHolder:
+            def __init__(self, cap):
+                self._cap = cap
+
+            def __arrow_c_stream__(self, requested_schema=None):
+                return self._cap
+
+        table = pa.table(CapsuleHolder(capsule))
+        self.assertEqual(table.to_pylist(), EXPECTED_ROWS)
+
+    def test_dictionary_and_nested_output_types(self):
+        sql = """
+            SELECT
+                toLowCardinality(toString(number % 3)) AS lc,
+                map('k', number) AS m,
+                tuple(number, toString(number)) AS t,
+                toFixedString('ab', 2) AS fs
+            FROM numbers(5)
+            SETTINGS output_format_arrow_low_cardinality_as_dictionary = 1
+        """
+        for fmt in ("Arrow", "ArrowStream"):
+            with self.subTest(fmt=fmt):
+                table = pa.table(chdb.query(sql, fmt))
+                self.assertTrue(pa.types.is_dictionary(table.schema.field("lc").type))
+                self.assertEqual(
+                    table.column("lc").to_pylist(), ["0", "1", "2", "0", "1"]
+                )
+                self.assertEqual(
+                    table.column("m").to_pylist(), [[("k", n)] for n in range(5)]
+                )
+                self.assertEqual(
+                    table.column("t").to_pylist()[3], {"1": 3, "2": "3"}
+                )
+                self.assertEqual(table.column("fs").to_pylist(), [b"ab"] * 5)
+
+    def test_file_magic_with_garbage_payload_raises(self):
+        # Buffer that starts with the IPC file magic but is not a valid file
+        # must surface as ValueError, not crash on ValueOrDie.
+        res = chdb.query("SELECT 'ARROW1' || repeat('x', 64)", "RawBLOB")
+        with self.assertRaisesRegex(ValueError, "Arrow IPC file"):
+            res.__arrow_c_stream__()
+
+    def test_streaming_result_second_export_yields_empty(self):
+        # Streams are single-use: pin the behavior of a second export after
+        # the first consumer drained the stream.
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number AS n FROM numbers(10)", "Arrow")
+            first = pa.table(stream)
+            self.assertEqual(first.num_rows, 10)
+            second = pa.table(stream)
+            self.assertEqual(second.num_rows, 0)
+        finally:
+            conn.close()
+
 
 class TestArrowCStreamInput(unittest.TestCase):
     @unittest.skipIf(pl is None, "polars not installed")
@@ -289,6 +368,159 @@ class TestArrowCStreamInput(unittest.TestCase):
         df = pd.DataFrame({"x": [1, 2, 3], "s": ["a", "b", "c"]})
         out = chdb.query("SELECT sum(x), max(s) FROM Python(df) WHERE x > 1", "CSV")
         self.assertEqual(str(out), '5,"c"\n')
+
+    @unittest.skipIf(pd is None, "pandas not installed")
+    def test_pandas_never_takes_generic_stream_path(self):
+        # Falsifiable version of the guard test: a pandas subclass whose
+        # __arrow_c_stream__ raises proves neither schema inference nor the
+        # scan touches the generic protocol path for pandas objects.
+        class GuardedDF(pd.DataFrame):
+            def __arrow_c_stream__(self, requested_schema=None):
+                raise AssertionError("generic stream path used for pandas")
+
+        df = GuardedDF({"x": [1, 2, 3], "s": ["a", "b", "c"]})
+        out = chdb.query("SELECT sum(x), max(s) FROM Python(df) WHERE x > 1", "CSV")
+        self.assertEqual(str(out), '5,"c"\n')
+
+    def test_large_batch_sliced_into_blocks(self):
+        # One batch far larger than max_block_size exercises the reader's
+        # offset/slice bookkeeping through the generic input path.
+        schema = pa.schema([("x", pa.int64())])
+        reader = pa.RecordBatchReader.from_batches(
+            schema, [pa.record_batch([pa.array(range(1_000_000))], schema=schema)]
+        )
+        out = chdb.query(
+            "SELECT count() AS c, sum(x) AS s, min(x) AS lo, max(x) AS hi"
+            " FROM Python(reader) SETTINGS max_block_size = 65536",
+            "CSV",
+        )
+        self.assertEqual(str(out), f"1000000,{1_000_000 * 999_999 // 2},0,999999\n")
+
+    def test_many_batches_with_parallel_scan(self):
+        # Multiple batches consumed under max_threads > 1: the scan states pull
+        # concurrently from the shared, mutex-guarded stream.
+        schema = pa.schema([("x", pa.int64())])
+        batches = [
+            pa.record_batch(
+                [pa.array(range(i * 100_000, (i + 1) * 100_000))], schema=schema
+            )
+            for i in range(10)
+        ]
+        reader = pa.RecordBatchReader.from_batches(schema, batches)
+        out = chdb.query(
+            "SELECT count() AS c, sum(x) AS s FROM Python(reader) SETTINGS max_threads = 8",
+            "CSV",
+        )
+        self.assertEqual(str(out), f"1000000,{1_000_000 * 999_999 // 2}\n")
+
+    def test_dictionary_encoded_input(self):
+        # Dictionary arrays must survive the C ABI hop and decode correctly.
+        arr = pa.array(["x", "y", "x", "z", "x"], pa.dictionary(pa.int32(), pa.string()))
+        batch = pa.record_batch([arr], names=["d"])
+        reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])
+        out = chdb.query(
+            "SELECT d, count() AS c FROM Python(reader) GROUP BY d ORDER BY d", "CSV"
+        )
+        self.assertEqual(str(out), '"x",3\n"y",1\n"z",1\n')
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_polars_categorical_input(self):
+        df = pl.DataFrame({"c": pl.Series(["a", "b", "a", "c", "a"], dtype=pl.Categorical)})
+        out = chdb.query(
+            "SELECT c, count() AS n FROM Python(df) GROUP BY c ORDER BY c", "CSV"
+        )
+        self.assertEqual(str(out), '"a",3\n"b",1\n"c",1\n')
+
+    def test_timezone_timestamp_and_decimal_input(self):
+        ts = datetime(2026, 7, 22, 1, 2, 3, 456000, tzinfo=timezone.utc)
+        expected_micros = int(ts.timestamp()) * 10**6 + 456000
+        batch = pa.record_batch(
+            [
+                pa.array([ts], pa.timestamp("us", tz="Asia/Shanghai")),
+                pa.array([Decimal("123.4567")], pa.decimal128(18, 4)),
+            ],
+            names=["ts", "dec"],
+        )
+        reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])
+        out = chdb.query(
+            "SELECT toUnixTimestamp64Micro(ts) AS micros, dec FROM Python(reader)", "CSV"
+        )
+        self.assertEqual(str(out), f"{expected_micros},123.4567\n")
+
+    def test_empty_batch_mid_stream_is_skipped(self):
+        # Zero-length batches are legal mid-stream and must not truncate the scan.
+        schema = pa.schema([("x", pa.int64())])
+        batches = [
+            pa.record_batch([pa.array([1, 2])], schema=schema),
+            pa.record_batch([pa.array([], pa.int64())], schema=schema),
+            pa.record_batch([pa.array([3, 4, 5])], schema=schema),
+        ]
+        reader = pa.RecordBatchReader.from_batches(schema, batches)
+        out = chdb.query("SELECT count() AS c, sum(x) AS s FROM Python(reader)", "CSV")
+        self.assertEqual(str(out), "5,15\n")
+
+    def test_producer_raising_on_export_fails_cleanly(self):
+        class Boom:
+            def __arrow_c_stream__(self, requested_schema=None):
+                raise RuntimeError("boom-marker")
+
+        src = Boom()
+        with self.assertRaisesRegex(Exception, "boom-marker"):
+            chdb.query("SELECT * FROM Python(src)", "CSV")
+        # Engine must stay usable after the failed producer.
+        self.assertEqual(str(chdb.query("SELECT 1", "CSV")), "1\n")
+
+    def test_producer_returning_non_capsule_fails_cleanly(self):
+        class Fake:
+            def __arrow_c_stream__(self, requested_schema=None):
+                return "not a capsule"
+
+        src = Fake()
+        with self.assertRaisesRegex(Exception, "PyCapsule"):
+            chdb.query("SELECT * FROM Python(src)", "CSV")
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_failed_query_releases_parked_stream(self):
+        # Schema inference parks the stream; if the query then fails in
+        # analysis, the parked stream is destroyed unconsumed and the object
+        # must remain queryable afterwards.
+        df = pl.DataFrame({"x": [1, 2, 3]})
+        with self.assertRaises(Exception):
+            chdb.query("SELECT no_such_col FROM Python(df)", "CSV")
+        out = chdb.query("SELECT count() FROM Python(df)", "CSV")
+        self.assertEqual(str(out), "3\n")
+
+    def test_failed_query_consumes_single_export(self):
+        # Even when the query fails after schema inference, exactly one export
+        # must have happened (the parked stream, later released unconsumed).
+        table = pa.table({"x": [1, 2, 3]})
+
+        class OneShotSource:
+            def __init__(self, tbl):
+                self._tbl = tbl
+                self._exports = 0
+
+            def __arrow_c_stream__(self, requested_schema=None):
+                self._exports += 1
+                if self._exports > 1:
+                    raise RuntimeError("stream already consumed")
+                return self._tbl.__arrow_c_stream__(requested_schema)
+
+        src = OneShotSource(table)
+        with self.assertRaises(Exception):
+            chdb.query("SELECT no_such_col FROM Python(src)", "CSV")
+        self.assertEqual(src._exports, 1)
+
+    def test_streaming_result_as_python_table_input(self):
+        # Composition of both new features: a StreamingResult (Python-backed
+        # reader) consumed by the generic Python() scan of another query.
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number AS n FROM numbers(100000)", "Arrow")
+            out = chdb.query("SELECT count() AS c, sum(n) AS s FROM Python(stream)", "CSV")
+            self.assertEqual(str(out), f"100000,{100000 * 99999 // 2}\n")
+        finally:
+            conn.close()
 
     def test_one_shot_producer_single_export_per_query(self):
         # The protocol does not guarantee producers can export more than once.

--- a/tests/test_arrow_c_stream_protocol.py
+++ b/tests/test_arrow_c_stream_protocol.py
@@ -188,16 +188,23 @@ class TestArrowCStreamOutput(unittest.TestCase):
     def test_stream_survives_result_garbage_collection(self):
         # The exported stream references the result buffer directly; it must
         # keep the result alive after the query_result object is collected
-        # (real consumers hold only the stream, not the chdb result).
-        res = chdb.query(
-            "SELECT number FROM numbers(300000) SETTINGS max_block_size = 65536", "Arrow"
-        )
-        reader = pa.RecordBatchReader.from_stream(res)
-        del res
-        gc.collect()
-        table = reader.read_all()
-        self.assertEqual(table.num_rows, 300000)
-        self.assertEqual(pc.sum(table.column("number")).as_py(), 300000 * 299999 // 2)
+        # (real consumers hold only the stream, not the chdb result). Exercise
+        # both IPC framings: "Arrow" (file, eager reader) and "ArrowStream"
+        # (stream, lazy RecordBatchStreamReader) -- both must retain the buffer.
+        for fmt in ("Arrow", "ArrowStream"):
+            with self.subTest(fmt=fmt):
+                res = chdb.query(
+                    "SELECT number FROM numbers(300000) SETTINGS max_block_size = 65536",
+                    fmt,
+                )
+                reader = pa.RecordBatchReader.from_stream(res)
+                del res
+                gc.collect()
+                table = reader.read_all()
+                self.assertEqual(table.num_rows, 300000)
+                self.assertEqual(
+                    pc.sum(table.column("number")).as_py(), 300000 * 299999 // 2
+                )
 
     def test_requested_schema_accepted_and_ignored(self):
         # The spec allows the producer to ignore requested_schema; the keyword
@@ -249,16 +256,49 @@ class TestArrowCStreamOutput(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Arrow IPC file"):
             res.__arrow_c_stream__()
 
-    def test_streaming_result_second_export_yields_empty(self):
-        # Streams are single-use: pin the behavior of a second export after
-        # the first consumer drained the stream.
+    def test_streaming_result_second_export_raises(self):
+        # Streams are single-use. A second export must fail loudly rather than
+        # silently hand back a zero-column, zero-row stream (schema loss).
         conn = chdb.connect(":memory:")
         try:
             stream = conn.send_query("SELECT number AS n FROM numbers(10)", "Arrow")
             first = pa.table(stream)
             self.assertEqual(first.num_rows, 10)
-            second = pa.table(stream)
-            self.assertEqual(second.num_rows, 0)
+            self.assertEqual(first.column_names, ["n"])
+            with self.assertRaisesRegex(RuntimeError, "already consumed"):
+                stream.__arrow_c_stream__()
+        finally:
+            conn.close()
+
+    def test_streaming_result_export_after_cancel_raises(self):
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number FROM numbers(10)", "Arrow")
+            stream.cancel()
+            with self.assertRaisesRegex(RuntimeError, "already consumed"):
+                stream.__arrow_c_stream__()
+        finally:
+            conn.close()
+
+    def test_streaming_result_requested_schema_forwarded(self):
+        # StreamingResult forwards requested_schema to pyarrow's reader, which
+        # honors a compatible cast; verify the request reaches it end-to-end.
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number AS n FROM numbers(5)", "Arrow")
+            requested = pa.schema([("n", pa.int32())]).__arrow_c_schema__()
+            capsule = stream.__arrow_c_stream__(requested_schema=requested)
+
+            class CapsuleHolder:
+                def __init__(self, cap):
+                    self._cap = cap
+
+                def __arrow_c_stream__(self, requested_schema=None):
+                    return self._cap
+
+            table = pa.table(CapsuleHolder(capsule))
+            self.assertEqual(table.schema.field("n").type, pa.int32())
+            self.assertEqual(table.column("n").to_pylist(), [0, 1, 2, 3, 4])
         finally:
             conn.close()
 

--- a/tests/test_arrow_c_stream_protocol.py
+++ b/tests/test_arrow_c_stream_protocol.py
@@ -1,0 +1,286 @@
+#!python3
+"""Tests for the Arrow PyCapsule interface (__arrow_c_stream__) on both sides:
+
+Output: chdb query results (query_result with "Arrow"/"ArrowStream" output
+format, and StreamingResult) export an ArrowArrayStream PyCapsule, so
+Arrow-native consumers (pyarrow, polars, duckdb, ...) can ingest chdb results
+zero-copy without going through explicit IPC parsing.
+
+Input: any Python object exposing __arrow_c_stream__ (polars DataFrame,
+pyarrow.RecordBatchReader, duckdb relations, chdb results, ...) can be scanned
+with the Python() table engine, in addition to the dedicated pandas /
+pyarrow.Table paths.
+"""
+
+import unittest
+from decimal import Decimal
+
+import chdb
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+try:
+    import polars as pl
+except ImportError:
+    pl = None
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None
+
+
+EXPECTED_ROWS = [
+    {"id": 1, "name": "Alice", "score": 9.5},
+    {"id": 2, "name": "宝贝", "score": 7.25},
+    {"id": 3, "name": None, "score": -1.5},
+]
+
+SAMPLE_SQL = """
+    SELECT * FROM (
+        SELECT 1 AS id, 'Alice' AS name, 9.5 AS score
+        UNION ALL SELECT 2, '宝贝', 7.25
+        UNION ALL SELECT 3, NULL, -1.5
+    ) ORDER BY id
+"""
+
+
+class TestArrowCStreamOutput(unittest.TestCase):
+    def test_pyarrow_table_from_query_result(self):
+        res = chdb.query(SAMPLE_SQL, "Arrow")
+        table = pa.table(res)
+        self.assertEqual(table.column_names, ["id", "name", "score"])
+        self.assertEqual(table.num_rows, 3)
+        self.assertEqual(table.to_pylist(), EXPECTED_ROWS)
+
+    def test_pyarrow_recordbatchreader_from_stream(self):
+        res = chdb.query(SAMPLE_SQL, "Arrow")
+        reader = pa.RecordBatchReader.from_stream(res)
+        self.assertEqual(reader.schema.names, ["id", "name", "score"])
+        table = reader.read_all()
+        self.assertEqual(table.to_pylist(), EXPECTED_ROWS)
+
+    def test_arrowstream_format_also_exports(self):
+        res = chdb.query(SAMPLE_SQL, "ArrowStream")
+        table = pa.table(res)
+        self.assertEqual(table.column_names, ["id", "name", "score"])
+        self.assertEqual(table.to_pylist(), EXPECTED_ROWS)
+
+    def test_multiple_exports_are_independent(self):
+        res = chdb.query(SAMPLE_SQL, "Arrow")
+        first = pa.table(res)
+        second = pa.table(res)
+        self.assertTrue(first.equals(second))
+        self.assertEqual(second.to_pylist(), EXPECTED_ROWS)
+
+    def test_non_arrow_format_raises_value_error(self):
+        res = chdb.query("SELECT 1 AS x", "CSV")
+        with self.assertRaisesRegex(ValueError, "Arrow"):
+            res.__arrow_c_stream__()
+
+    def test_empty_payload_raises_value_error(self):
+        # Zero-row CSV output produces an empty buffer -> no Arrow payload.
+        res = chdb.query("SELECT 1 AS x WHERE 0", "CSV")
+        with self.assertRaisesRegex(ValueError, "Arrow"):
+            res.__arrow_c_stream__()
+
+    def test_empty_result_preserves_schema(self):
+        res = chdb.query("SELECT number AS n, toString(number) AS s FROM numbers(10) WHERE number < 0", "Arrow")
+        table = pa.table(res)
+        self.assertEqual(table.num_rows, 0)
+        self.assertEqual(table.column_names, ["n", "s"])
+        self.assertEqual(table.schema.field("n").type, pa.uint64())
+
+    def test_type_coverage(self):
+        res = chdb.query(
+            """
+            SELECT
+                toInt8(-8) AS i8,
+                toUInt64(18446744073709551615) AS u64,
+                toFloat32(0.5) AS f32,
+                toNullable('x') AS ns,
+                NULL AS always_null,
+                toDate('2026-07-22') AS d,
+                toDateTime64('2026-07-22 01:02:03.456', 3, 'UTC') AS dt64,
+                toDecimal64(123.4567, 4) AS dec,
+                [1, 2, 3] AS arr
+            """,
+            "Arrow",
+        )
+        table = pa.table(res)
+        row = table.to_pylist()[0]
+        self.assertEqual(row["i8"], -8)
+        self.assertEqual(row["u64"], 18446744073709551615)
+        self.assertEqual(row["f32"], 0.5)
+        self.assertEqual(row["ns"], "x")
+        self.assertIsNone(row["always_null"])
+        self.assertEqual(str(row["d"]), "2026-07-22")
+        self.assertEqual(row["dt64"].isoformat(), "2026-07-22T01:02:03.456000+00:00")
+        self.assertEqual(row["dec"], Decimal("123.4567"))
+        self.assertEqual(row["arr"], [1, 2, 3])
+
+    def test_large_result_multiple_batches(self):
+        res = chdb.query("SELECT number FROM numbers(300000)", "Arrow")
+        reader = pa.RecordBatchReader.from_stream(res)
+        batches = list(reader)
+        self.assertGreater(len(batches), 1, "expected multiple record batches")
+        table = pa.Table.from_batches(batches)
+        self.assertEqual(table.num_rows, 300000)
+        self.assertEqual(pc.sum(table.column("number")).as_py(), 300000 * 299999 // 2)
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_polars_dataframe_from_query_result(self):
+        res = chdb.query(SAMPLE_SQL, "Arrow")
+        df = pl.DataFrame(res)
+        self.assertEqual(df.shape, (3, 3))
+        self.assertEqual(df.columns, ["id", "name", "score"])
+        self.assertEqual(df.to_dicts(), EXPECTED_ROWS)
+
+    @unittest.skipIf(duckdb is None, "duckdb not installed")
+    def test_duckdb_from_query_result(self):
+        res = chdb.query(SAMPLE_SQL, "Arrow")
+        rows = duckdb.from_arrow(res).fetchall()
+        self.assertEqual(rows, [(1, "Alice", 9.5), (2, "宝贝", 7.25), (3, None, -1.5)])
+
+    def test_streaming_result_arrow_c_stream(self):
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number FROM numbers(100000)", "Arrow")
+            table = pa.table(stream)
+            self.assertEqual(table.num_rows, 100000)
+            self.assertEqual(pc.sum(table.column("number")).as_py(), 100000 * 99999 // 2)
+        finally:
+            conn.close()
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_streaming_result_to_polars(self):
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number AS n FROM numbers(1000)", "Arrow")
+            df = pl.DataFrame(stream)
+            self.assertEqual(df.shape, (1000, 1))
+            self.assertEqual(df["n"].sum(), 1000 * 999 // 2)
+        finally:
+            conn.close()
+
+    def test_streaming_result_non_arrow_raises(self):
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT 1", "CSV")
+            with self.assertRaisesRegex(ValueError, "Arrow"):
+                stream.__arrow_c_stream__()
+            stream.cancel()
+        finally:
+            conn.close()
+
+
+class TestArrowCStreamInput(unittest.TestCase):
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_query_polars_dataframe(self):
+        df = pl.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "name": ["Alice", "宝贝", None, "Dave"],
+                "score": [9.5, 7.25, -1.5, 0.0],
+            }
+        )
+        res = chdb.query(
+            "SELECT id, name, score FROM Python(df) WHERE id != 4 ORDER BY id", "ArrowTable"
+        )
+        self.assertEqual(res.to_pylist(), EXPECTED_ROWS)
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_query_polars_aggregation(self):
+        df = pl.DataFrame({"g": ["a", "b", "a", "b", "a"], "v": [1, 2, 3, 4, 5]})
+        out = chdb.query(
+            "SELECT g, sum(v) AS s, count() AS c FROM Python(df) GROUP BY g ORDER BY g", "CSV"
+        )
+        self.assertEqual(str(out), '"a",9,3\n"b",6,2\n')
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_query_polars_list_column(self):
+        df = pl.DataFrame({"id": [1, 2], "vals": [[1, 2, 3], [4, 5]]})
+        # Arrow list items are nullable -> Array(Nullable(Int64)) on the CH side.
+        out = chdb.query(
+            "SELECT id, arraySum(x -> assumeNotNull(x), vals) AS s, length(vals) AS l"
+            " FROM Python(df) ORDER BY id",
+            "CSV",
+        )
+        self.assertEqual(str(out), "1,6,3\n2,9,2\n")
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_query_polars_projection_subset(self):
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"], "c": [1.5, 2.5]})
+        out = chdb.query("SELECT b FROM Python(df) ORDER BY b DESC", "CSV")
+        self.assertEqual(str(out), '"y"\n"x"\n')
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_query_polars_empty_dataframe(self):
+        df = pl.DataFrame(schema={"a": pl.Int64, "b": pl.String})
+        out = chdb.query("SELECT count() FROM Python(df)", "CSV")
+        self.assertEqual(str(out), "0\n")
+
+    @unittest.skipIf(pl is None, "polars not installed")
+    def test_query_polars_self_join_rescans(self):
+        # Each scan calls __arrow_c_stream__ again; polars produces a fresh
+        # stream per call, so a self-join must see the full data twice.
+        df = pl.DataFrame({"x": [1, 2, 3]})
+        out = chdb.query(
+            "SELECT count() FROM Python(df) AS a JOIN Python(df) AS b ON a.x = b.x", "CSV"
+        )
+        self.assertEqual(str(out), "3\n")
+
+    def test_query_pyarrow_recordbatchreader(self):
+        schema = pa.schema([("x", pa.int64()), ("s", pa.string())])
+        batches = [
+            pa.record_batch([[1, 2], ["a", "b"]], schema=schema),
+            pa.record_batch([[3, 4], ["c", "d"]], schema=schema),
+        ]
+        reader = pa.RecordBatchReader.from_batches(schema, batches)
+        out = chdb.query(
+            "SELECT sum(x) AS total, count() AS c, min(s) AS m FROM Python(reader)", "CSV"
+        )
+        self.assertEqual(str(out), '10,4,"a"\n')
+
+    def test_query_exhausted_recordbatchreader_returns_empty(self):
+        # Streams are single-use: a second query over the same reader sees an
+        # exhausted stream and yields zero rows (matching Arrow stream semantics).
+        schema = pa.schema([("x", pa.int64())])
+        reader = pa.RecordBatchReader.from_batches(
+            schema, [pa.record_batch([[1, 2, 3]], schema=schema)]
+        )
+        first = chdb.query("SELECT count() FROM Python(reader)", "CSV")
+        self.assertEqual(str(first), "3\n")
+        second = chdb.query("SELECT count() FROM Python(reader)", "CSV")
+        self.assertEqual(str(second), "0\n")
+
+    @unittest.skipIf(duckdb is None, "duckdb not installed")
+    def test_query_duckdb_relation(self):
+        rel = duckdb.sql("SELECT range AS x, 'v' || range::VARCHAR AS s FROM range(5)")
+        out = chdb.query("SELECT sum(x) AS total, max(s) AS m FROM Python(rel)", "CSV")
+        self.assertEqual(str(out), '10,"v4"\n')
+
+    def test_query_chdb_result_roundtrip(self):
+        res = chdb.query("SELECT number AS n FROM numbers(10)", "Arrow")
+        out = chdb.query("SELECT count() AS c, sum(n) AS s FROM Python(res)", "CSV")
+        self.assertEqual(str(out), "10,45\n")
+
+    def test_pyarrow_table_still_works(self):
+        # pyarrow.Table must keep taking its dedicated (pushdown-capable) path.
+        table = pa.table({"x": [1, 2, 3], "s": ["a", "b", "c"]})
+        out = chdb.query("SELECT sum(x), max(s) FROM Python(table)", "CSV")
+        self.assertEqual(str(out), '6,"c"\n')
+
+    def test_pandas_still_works(self):
+        # pandas >= 2.2 exposes __arrow_c_stream__ too, but must stay on the
+        # dedicated pandas scan (is_pandas_df guard).
+        import pandas as pd
+
+        df = pd.DataFrame({"x": [1, 2, 3], "s": ["a", "b", "c"]})
+        out = chdb.query("SELECT sum(x), max(s) FROM Python(df) WHERE x > 1", "CSV")
+        self.assertEqual(str(out), '5,"c"\n')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_arrow_c_stream_protocol.py
+++ b/tests/test_arrow_c_stream_protocol.py
@@ -30,6 +30,11 @@ try:
 except ImportError:
     duckdb = None
 
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
 
 EXPECTED_ROWS = [
     {"id": 1, "name": "Alice", "score": 9.5},
@@ -121,7 +126,11 @@ class TestArrowCStreamOutput(unittest.TestCase):
         self.assertEqual(row["arr"], [1, 2, 3])
 
     def test_large_result_multiple_batches(self):
-        res = chdb.query("SELECT number FROM numbers(300000)", "Arrow")
+        # Pin the block size so the multi-batch expectation does not depend on
+        # the engine's default block size or writer batching strategy.
+        res = chdb.query(
+            "SELECT number FROM numbers(300000) SETTINGS max_block_size = 65536", "Arrow"
+        )
         reader = pa.RecordBatchReader.from_stream(res)
         batches = list(reader)
         self.assertGreater(len(batches), 1, "expected multiple record batches")
@@ -272,14 +281,35 @@ class TestArrowCStreamInput(unittest.TestCase):
         out = chdb.query("SELECT sum(x), max(s) FROM Python(table)", "CSV")
         self.assertEqual(str(out), '6,"c"\n')
 
+    @unittest.skipIf(pd is None, "pandas not installed")
     def test_pandas_still_works(self):
         # pandas >= 2.2 exposes __arrow_c_stream__ too, but must stay on the
-        # dedicated pandas scan (is_pandas_df guard).
-        import pandas as pd
-
+        # dedicated pandas scan (is_pandas_df guard). With pandas < 2.2 this
+        # degenerates to a plain pandas-path regression check.
         df = pd.DataFrame({"x": [1, 2, 3], "s": ["a", "b", "c"]})
         out = chdb.query("SELECT sum(x), max(s) FROM Python(df) WHERE x > 1", "CSV")
         self.assertEqual(str(out), '5,"c"\n')
+
+    def test_one_shot_producer_single_export_per_query(self):
+        # The protocol does not guarantee producers can export more than once.
+        # Schema inference must park the imported stream for the scan instead
+        # of exporting a second one.
+        table = pa.table({"x": [1, 2, 3], "s": ["a", "b", "c"]})
+
+        class OneShotSource:
+            def __init__(self, tbl):
+                self._tbl = tbl
+                self._exported = False
+
+            def __arrow_c_stream__(self, requested_schema=None):
+                if self._exported:
+                    raise RuntimeError("stream already consumed")
+                self._exported = True
+                return self._tbl.__arrow_c_stream__(requested_schema)
+
+        src = OneShotSource(table)
+        out = chdb.query("SELECT sum(x) AS t, max(s) AS m FROM Python(src)", "CSV")
+        self.assertEqual(str(out), '6,"c"\n')
 
 
 if __name__ == "__main__":

--- a/tests/test_query_without_pandas_pyarrow.py
+++ b/tests/test_query_without_pandas_pyarrow.py
@@ -113,6 +113,39 @@ else:
 print("ERRORS_INFORMATIVE_OK")
 """
 
+_BODY_ARROW_C_STREAM_NO_PYARROW = """
+import chdb
+
+# The C++ capsule export uses the bundled Arrow, not pyarrow.
+res = chdb.query("SELECT 1 AS x", "Arrow")
+cap = res.__arrow_c_stream__()
+assert type(cap).__name__ == "PyCapsule", type(cap).__name__
+
+# Error contract must hold without pyarrow too (ValueError, not RuntimeError).
+csv_res = chdb.query("SELECT 1", "CSV")
+try:
+    csv_res.__arrow_c_stream__()
+except ValueError as e:
+    assert "Arrow" in str(e), e
+else:
+    raise AssertionError("CSV result should not export an Arrow stream")
+
+# The streaming export goes through record_batch() and does need pyarrow.
+conn = chdb.connect(":memory:")
+stream = conn.send_query("SELECT 1", "Arrow")
+try:
+    stream.__arrow_c_stream__()
+except ImportError as e:
+    assert "pyarrow" in str(e), e
+else:
+    raise AssertionError("streaming __arrow_c_stream__ should require pyarrow")
+finally:
+    stream.close()
+conn.close()
+
+print("ARROW_C_STREAM_NO_PYARROW_OK")
+"""
+
 _BODY_PANDAS_ONLY_MISSING = """
 import chdb
 
@@ -190,6 +223,10 @@ class TestQueryWithoutPandasPyarrow(unittest.TestCase):
     def test_query_works_with_only_pandas_missing(self):
         out = self._run_blocked(("pandas",), _BODY_PANDAS_ONLY_MISSING)
         self.assertIn("PANDAS_ONLY_OK", out)
+
+    def test_arrow_c_stream_capsule_export_works_without_pyarrow(self):
+        out = self._run_blocked(("pandas", "pyarrow"), _BODY_ARROW_C_STREAM_NO_PYARROW)
+        self.assertIn("ARROW_C_STREAM_NO_PYARROW_OK", out)
 
     def test_python_table_function_works_without_pandas_and_pyarrow(self):
         out = self._run_blocked(


### PR DESCRIPTION
Closes #148.

## What

**Output** — `query_result.__arrow_c_stream__` (pybind): exports the Arrow IPC result buffer as an ArrowArrayStream PyCapsule, so `pl.DataFrame(res)`, `pa.table(res)`, `duckdb.from_arrow(res)` work directly on `chdb.query(sql, "Arrow")` results. Batches reference the result buffer (KeepaliveBuffer holds the result alive until the consumer releases the stream) — no byte copy, no pyarrow dependency. Handles both IPC framings ("Arrow" file format via magic sniff, "ArrowStream" stream format). Re-callable: each call yields an independent stream. `StreamingResult.__arrow_c_stream__` (Python) delegates to the existing `record_batch()` reader (arrow format only, single-use like the stream itself, needs pyarrow).

**Input** — `Python()` now scans any object exposing `__arrow_c_stream__`: polars DataFrames, `pyarrow.RecordBatchReader`, duckdb relations, chdb results (self-roundtrip), pandas ≥ 2.2 objects from other libraries, etc. The stream feeds the existing ArrowTableReader/ArrowStreamSource path; the table structure comes from the stream's ArrowSchema via `ArrowSchemaWrapper::convertArrowSchema` (no string/regex inference). Dedicated paths keep priority and are unchanged: pandas (guarded by `is_pandas_df` — pandas ≥ 2.2 also exposes the protocol but must stay on its pushdown-capable scan) and pyarrow.Table (projection + string-predicate pushdown); the generic branch sits just before the legacy `getSchemaFromPyObj` fallback.

## Notes

- Existing output formats and APIs are untouched; the protocol methods are purely additive.
- `requested_schema` is accepted and ignored (allowed by the spec).
- Generic input streams are single-use by nature: re-scanning an exhausted `pa.RecordBatchReader` yields 0 rows (covered by a test); re-callable producers (polars, chdb results) support self-joins — each scan opens a fresh stream.
- Output type mapping matches `format="Arrow"`/`"ArrowStream"` exactly (e.g. `DateTime` → `uint32`), the same contract as #76.

## Tests

`tests/test_arrow_c_stream_protocol.py` — 26 cases, all passing (linux x86_64, free-threading 3.14.0t; pyarrow 23 / polars 1.43 / duckdb 1.5.5 / pandas 3.0.3):

- Output: pyarrow / polars / duckdb consuming materialized and streaming results; ArrowStream framing; empty results (schema preserved); multi-batch results; repeat export independence; type coverage (ints, floats, Nullable, unicode strings, Date, DateTime64 tz, Decimal, Array); ValueError on non-Arrow / empty payloads.
- Input: polars (nulls/unicode, aggregation, list columns, projection, empty frame, self-join rescans), RecordBatchReader (multi-batch, exhausted-stream semantics), duckdb relation, chdb result roundtrip; regression guards that pandas and pyarrow.Table stay on their dedicated paths.
- Existing suites re-run green: `test_query_without_pandas_pyarrow`, `test_unsupported_arrow_types`, `test_query_py`, `test_dataframe_arrow_dtype`, `test_dataframe_string_null`, `test_dataframe_string_nonascii`, `test_python_table_string_correctness`, `test_complex_pyobj` (79 tests).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Arrow PyCapsule (`__arrow_c_stream__`) interface to query results and `Python()` table input
> - Implements `__arrow_c_stream__` on `query_result` (C++) and `StreamingResult` (Python) so Arrow-native libraries (pyarrow, polars, duckdb) can consume results without intermediate copies; `query_result` supports multiple independent exports while `StreamingResult` is single-use.
> - Extends the `Python()` table function to accept any object exposing `__arrow_c_stream__`, enabling direct ingestion of Arrow stream producers without requiring a pandas DataFrame or pyarrow Table.
> - Schema inference in [`TableFunctionPython.cpp`](https://github.com/chdb-io/chdb-core/pull/149/files#diff-622d6e1d060eedd0b6c4607f2162577276d95fd32bad2d92c51663c4e71e3fdb) imports the stream once and parks it on [`DataSourceWrapper`](https://github.com/chdb-io/chdb-core/pull/149/files#diff-b3d66f256ac572192ef6e351771a834326a2992d2523f0de6a9ceccc581158a7) so single-use producers are not consumed twice before data is read.
> - New C++ utilities in [`PythonArrowStream.cpp`](https://github.com/chdb-io/chdb-core/pull/149/files#diff-f00ee1896f393c52481d23f0fe7bfb555573df9a00b24e5ce346c839457c0080) handle import, export, and schema derivation; the export path works without pyarrow on the caller side.
> - Risk: `StreamingResult.__arrow_c_stream__` raises `RuntimeError` if called more than once, which is a breaking change for any code that tries to export the same streaming result twice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2cefb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->