### PR TITLE
Make error-string stack traces opt-in via --stacktrace

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -290,6 +290,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -275,6 +275,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -313,6 +313,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -314,6 +314,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh

--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,7 @@ test_main
 /examples/chdbCppStreaming
 /examples/:memory:
 /examples/chdbDlopen
+/examples/chdbStackTraceTest
 /examples/chdbStreamErrorTest
 /examples/chdbStreamInsertTest
 /examples/chdbStreamQueryEofTest

--- a/examples/chdbStackTraceTest.c
+++ b/examples/chdbStackTraceTest.c
@@ -88,6 +88,17 @@ int main(void)
         chdb_close_conn(conn);
     }
 
+    /* Explicit opt-out in the space-separated form: the user's value wins
+     * over the bare-flag fallback. */
+    {
+        char a0[] = "chdb", a1[] = "--stacktrace", a2[] = "0";
+        char * argv[] = {a0, a1, a2};
+        chdb_connection * conn = chdb_connect(3, argv);
+        if (!conn) { fprintf(stderr, "connect with --stacktrace 0 failed\n"); return 1; }
+        check_conn("--stacktrace 0 (space form)", conn, /*want_trace=*/0);
+        chdb_close_conn(conn);
+    }
+
     printf("\n== summary: %d failed ==\n", g_failed);
     return g_failed ? 1 : 0;
 }

--- a/examples/chdbStackTraceTest.c
+++ b/examples/chdbStackTraceTest.c
@@ -1,0 +1,93 @@
+/**
+ * chdbStackTraceTest.c
+ *
+ * The `--stacktrace` connect flag controls whether chdb error strings carry a
+ * stack trace, matching clickhouse-client / clickhouse-local:
+ *   - default (no flag): errors are clean, e.g.
+ *       "Code: 50. DB::Exception: Unknown data type family: Nonexistent. (UNKNOWN_TYPE)"
+ *   - with --stacktrace: the same errors additionally include a "Stack trace" block.
+ *
+ * Verifies both a query error and a streaming-INSERT init error, under both a
+ * default connection and a --stacktrace connection.
+ *
+ * Build (against an already-built libchdb.so):
+ *   clang examples/chdbStackTraceTest.c -I./programs/local \
+ *         -L. -lchdb -o examples/chdbStackTraceTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbStackTraceTest
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "chdb.h"
+
+static int g_failed = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "  ASSERT FAIL: %s (%s:%d)\n",                 \
+                    (msg), __FILE__, __LINE__);                            \
+            g_failed += 1;                                                 \
+        }                                                                  \
+    } while (0)
+
+/* A query that always fails at analysis time (bad type -> UNKNOWN_TYPE), and
+ * a streaming INSERT that fails at init (same bad type). Both produce a real
+ * DB::Exception whose formatting is what the flag controls. */
+static const char * BAD_QUERY =
+    "SELECT * FROM file('chdb_st_none.csv', 'CSV', 'id Nonexistent')";
+static const char * BAD_INSERT =
+    "INSERT INTO FUNCTION file('chdb_st_none.csv', 'CSV', 'id Nonexistent')";
+
+/* Runs one bad query + one bad insert on `conn` and reports, for each, whether
+ * the error string contained a stack trace. want_trace drives the assertions. */
+static void check_conn(const char * label, chdb_connection * conn, int want_trace)
+{
+    printf("== %s ==\n", label);
+
+    chdb_result * q = chdb_query(*conn, BAD_QUERY, "CSV");
+    const char * qe = q ? chdb_result_error(q) : NULL;
+    CHECK(qe != NULL, "query error is set");
+    CHECK(qe && strstr(qe, "Nonexistent") != NULL, "query error names the real cause");
+    int q_has_trace = qe && strstr(qe, "Stack trace") != NULL;
+    CHECK(q_has_trace == want_trace,
+          want_trace ? "query error includes a stack trace" : "query error omits the stack trace");
+    chdb_destroy_query_result(q);
+
+    chdb_insert_stream s = chdb_stream_insert(*conn, BAD_INSERT, "CSV");
+    const char * se = chdb_stream_insert_error(s);
+    CHECK(se != NULL, "insert init error is set");
+    CHECK(se && strstr(se, "Nonexistent") != NULL, "insert error names the real cause");
+    int s_has_trace = se && strstr(se, "Stack trace") != NULL;
+    CHECK(s_has_trace == want_trace,
+          want_trace ? "insert error includes a stack trace" : "insert error omits the stack trace");
+    chdb_destroy_insert_stream(s);
+}
+
+int main(void)
+{
+    /* Default connection: errors must be clean (no stack trace). */
+    {
+        char a0[] = "chdb", a1[] = "--multiquery";
+        char * argv[] = {a0, a1};
+        chdb_connection * conn = chdb_connect(2, argv);
+        if (!conn) { fprintf(stderr, "connect failed\n"); return 1; }
+        check_conn("default (no --stacktrace)", conn, /*want_trace=*/0);
+        chdb_close_conn(conn);
+    }
+
+    /* --stacktrace connection: same errors must include a stack trace. Runs
+     * after the default connection is closed (one embedded server at a time). */
+    {
+        char a0[] = "chdb", a1[] = "--multiquery", a2[] = "--stacktrace";
+        char * argv[] = {a0, a1, a2};
+        chdb_connection * conn = chdb_connect(3, argv);
+        if (!conn) { fprintf(stderr, "connect with --stacktrace failed\n"); return 1; }
+        check_conn("--stacktrace", conn, /*want_trace=*/1);
+        chdb_close_conn(conn);
+    }
+
+    printf("\n== summary: %d failed ==\n", g_failed);
+    return g_failed ? 1 : 0;
+}

--- a/examples/runStackTraceTest.sh
+++ b/examples/runStackTraceTest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Compile and link"
+clang chdbStackTraceTest.c -o chdbStackTraceTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbStackTraceTest
+
+echo "Run it:"
+./chdbStackTraceTest

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -78,7 +78,9 @@ ChdbClient::ChdbClient(EmbeddedServer & server_ref)
     is_interactive = false;
     ignore_error = false;
     echo_queries = false;
-    print_stack_trace = false;
+    /// Honor the `--stacktrace` connect flag (default off), like clickhouse-local:
+    /// error strings omit the stack trace unless the caller opts in.
+    print_stack_trace = server.config().getBool("stacktrace", false);
     initTTYBuffer(toProgressOption(getClientConfiguration().getString("progress", "default")),
         toProgressOption(getClientConfiguration().getString("progress-table", "default")));
     initKeystrokeInterceptor();
@@ -332,14 +334,14 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
 #if USE_PYTHON
         python_table_cache->clear();
 #endif
-        return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, false));
+        return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
     catch (...)
     {
 #if USE_PYTHON
         python_table_cache->clear();
 #endif
-        return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(true));
+        return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
 }
 
@@ -375,12 +377,12 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
     catch (const Exception & e)
     {
         streaming_query_context.reset();
-        return std::make_unique<CHDB::StreamQueryResult>(getExceptionMessage(e, false));
+        return std::make_unique<CHDB::StreamQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
     catch (...)
     {
         streaming_query_context.reset();
-        return std::make_unique<CHDB::StreamQueryResult>(getCurrentExceptionMessage(true));
+        return std::make_unique<CHDB::StreamQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
 }
 
@@ -507,7 +509,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
         }
         python_table_cache->clear();
 #endif
-        return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, false));
+        return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
     catch (...)
     {
@@ -520,7 +522,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
         }
         python_table_cache->clear();
 #endif
-        return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(true));
+        return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
 }
 
@@ -654,13 +656,13 @@ CHDB::QueryResultPtr ChdbClient::executeInsertStreamingInit(
         /// for all subsequent statements.
         restoreSettingsAfterInsertStream();
         streaming_insert_context.reset();
-        return std::make_unique<CHDB::InsertStreamResult>(getExceptionMessage(e, false));
+        return std::make_unique<CHDB::InsertStreamResult>(getExceptionMessage(e, print_stack_trace));
     }
     catch (...)
     {
         restoreSettingsAfterInsertStream();
         streaming_insert_context.reset();
-        return std::make_unique<CHDB::InsertStreamResult>(getCurrentExceptionMessage(true));
+        return std::make_unique<CHDB::InsertStreamResult>(getCurrentExceptionMessage(print_stack_trace));
     }
 }
 
@@ -729,11 +731,11 @@ void ChdbClient::runInsertStreamWorker(const CHDB::InsertStreamContextPtr & ctx)
                 }
                 catch (const Exception & e)
                 {
-                    reason = getExceptionMessage(e, false);
+                    reason = getExceptionMessage(e, print_stack_trace);
                 }
                 catch (...)
                 {
-                    reason = getCurrentExceptionMessage(true);
+                    reason = getCurrentExceptionMessage(print_stack_trace);
                 }
             }
             signal_init(reason.empty()
@@ -799,7 +801,7 @@ void ChdbClient::runInsertStreamWorker(const CHDB::InsertStreamContextPtr & ctx)
         ctx->error = std::current_exception();
         try
         {
-            ctx->error_message = getCurrentExceptionMessage(true);
+            ctx->error_message = getCurrentExceptionMessage(print_stack_trace);
         }
         catch (...)
         {

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -1128,6 +1128,13 @@ void EmbeddedServer::initializeWithArgs(int argc, char ** argv)
             arg_vec.push_back(arg);
         }
         argsToConfig(arg_vec, config(), 100);
+        /// argsToConfig drops a value-less flag that appears last, so capture the
+        /// boolean `--stacktrace` flag explicitly to make it position-independent
+        /// (bare `--stacktrace` works like in clickhouse-local; `--stacktrace=0`
+        /// still parses through argsToConfig as usual).
+        for (const auto & arg : args)
+            if (arg == "--stacktrace")
+                config().setBool("stacktrace", true);
 
         initialize(*this);
         int ret = main(args);

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -12,6 +12,7 @@
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Storages/StorageFactory.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <Access/AccessControl.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
@@ -1130,11 +1131,12 @@ void EmbeddedServer::initializeWithArgs(int argc, char ** argv)
         argsToConfig(arg_vec, config(), 100);
         /// argsToConfig drops a value-less flag that appears last, so capture the
         /// boolean `--stacktrace` flag explicitly to make it position-independent
-        /// (bare `--stacktrace` works like in clickhouse-local; `--stacktrace=0`
-        /// still parses through argsToConfig as usual).
-        for (const auto & arg : args)
-            if (arg == "--stacktrace")
-                config().setBool("stacktrace", true);
+        /// (bare `--stacktrace` works like in clickhouse-local). Only fall back
+        /// when argsToConfig did not capture a usable value, so explicit forms
+        /// like `--stacktrace=0` or `--stacktrace 0` keep the user's value.
+        if (config().getString("stacktrace", "").empty()
+            && std::ranges::any_of(args, [](const auto & arg) { return arg == "--stacktrace"; }))
+            config().setBool("stacktrace", true);
 
         initialize(*this);
         int ret = main(args);


### PR DESCRIPTION
Fixes #150.

Error strings omit the stack trace by default and `--stacktrace` (in the `chdb_connect()` argv) re-enables it, matching clickhouse-client / clickhouse-local. Default:
```
Code: 50. DB::Exception: Unknown data type family: Nonexistent. (UNKNOWN_TYPE)
```
with `--stacktrace`, the same error additionally carries a stack-trace block.

- `ChdbClient` reads `print_stack_trace` from the `stacktrace` config (default false) instead of hardcoding it, and the query/stream/insert error builders format with that flag instead of a hardcoded `true`.
- `EmbeddedServer` captures a bare `--stacktrace` explicitly (argsToConfig drops a value-less flag that appears last), so the flag is position-independent; `--stacktrace=0` still parses normally.
- Out of scope: the C-ABI `catch (...)` fallbacks keep a trace — they only fire for non-`std::exception` throws (the `std::exception` sibling already formats trace-free), where a trace is a useful last resort. All normal error paths honor the flag.

Test (`examples/chdbStackTraceTest.c`, wired into the four wheel workflows): a query error and a streaming-INSERT init error, under a default connection (assert no stack trace) and a `--stacktrace` connection (assert a stack trace) — both still name the real cause. Passes locally; stream-insert / EOF / #612 error suites unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make stack traces in error strings opt-in via `--stacktrace` flag
> - `DB::ChdbClient` previously hardcoded `false` for stack trace inclusion in all error paths; it now reads the `stacktrace` config key (default `false`) and passes it to all error formatting calls across materialized queries, streaming queries, and streaming INSERT paths.
> - `DB::EmbeddedServer::initializeWithArgs` adds logic to detect a bare `--stacktrace` argument (no value) and set the config entry to `true`, preserving explicit forms like `--stacktrace=0`.
> - A new C test program ([chdbStackTraceTest.c](https://github.com/chdb-io/chdb-core/pull/151/files#diff-4f4d34f87b69e94424bb691c36a72b5c18e83dfe535aa07227201f40d893803c)) and shell script ([runStackTraceTest.sh](https://github.com/chdb-io/chdb-core/pull/151/files#diff-26751fb828c88f2171397544cdd7e7e82884cbb1ad0ab484be65857aeae8ac2f)) validate presence/absence of `Stack trace` in error output for both query and streaming-INSERT paths; these are wired into all four CI workflows.
> - Behavioral Change: error messages that previously never included stack traces will now include them when `--stacktrace` is passed, which may affect downstream error string parsing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cf8123.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->