### PR TITLE
Fix SELECT chdb() returning "None" in libchdb.so

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -290,6 +290,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -275,6 +275,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -313,6 +313,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -314,6 +314,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,7 @@ test_main
 /examples/chdbCppStreaming
 /examples/:memory:
 /examples/chdbDlopen
+/examples/chdbVersionTest
 /examples/chdbStackTraceTest
 /examples/chdbStreamErrorTest
 /examples/chdbStreamInsertTest

--- a/chdb/vars.sh
+++ b/chdb/vars.sh
@@ -21,7 +21,18 @@ else
     CHDB_PY_MODULE="${CHDB_PY_MOD}.abi3.so"
 fi
 pushd ${PROJ_DIR} > /dev/null
-CHDB_VERSION=$(python3 -c 'import setup; print(setup.get_latest_git_tag())' 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+# get_latest_git_tag() returns None for non-three-part tags (e.g. rc tags such
+# as v26.5.1-rc.2) and prints "None" while exiting 0, so the `||` fallbacks
+# below never fire and CHDB_VERSION becomes the literal "None" — which is what
+# `SELECT chdb()` then returns. Capture the value and explicitly reject an
+# empty/"None" result before falling back to the raw tag, then "0.0.0".
+CHDB_VERSION=$(python3 -c 'import setup; print(setup.get_latest_git_tag())' 2>/dev/null)
+if [ -z "${CHDB_VERSION}" ] || [ "${CHDB_VERSION}" = "None" ]; then
+    CHDB_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+fi
+if [ -z "${CHDB_VERSION}" ]; then
+    CHDB_VERSION="0.0.0"
+fi
 popd > /dev/null
 
 if [ "$1" == "cross-compile" ]; then

--- a/chdb/vars.sh
+++ b/chdb/vars.sh
@@ -26,7 +26,10 @@ pushd ${PROJ_DIR} > /dev/null
 # below never fire and CHDB_VERSION becomes the literal "None" — which is what
 # `SELECT chdb()` then returns. Capture the value and explicitly reject an
 # empty/"None" result before falling back to the raw tag, then "0.0.0".
-CHDB_VERSION=$(python3 -c 'import setup; print(setup.get_latest_git_tag())' 2>/dev/null)
+# On a raise the helper prints its error to stdout before exiting non-zero, so
+# reset to empty on failure (|| ...) to keep that text out of CHDB_VERSION and
+# let the fallbacks fire.
+CHDB_VERSION=$(python3 -c 'import setup; print(setup.get_latest_git_tag())' 2>/dev/null) || CHDB_VERSION=""
 if [ -z "${CHDB_VERSION}" ] || [ "${CHDB_VERSION}" = "None" ]; then
     CHDB_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
 fi

--- a/examples/chdbVersionTest.c
+++ b/examples/chdbVersionTest.c
@@ -41,8 +41,8 @@ static int has_digit(const char * s, size_t n)
 }
 
 /* Runs `sql` (TabSeparated so a single string value comes back unquoted),
- * asserts it succeeded, and returns whether the trimmed output looks like a
- * version (non-empty, not "None", contains a digit). */
+ * asserts it succeeded and that the trimmed output looks like a version
+ * (non-empty, not "None", contains a digit); failures increment g_failed. */
 static void check_version(chdb_connection conn, const char * label, const char * sql)
 {
     chdb_result * r = chdb_query(conn, sql, "TabSeparated");

--- a/examples/chdbVersionTest.c
+++ b/examples/chdbVersionTest.c
@@ -1,0 +1,86 @@
+/**
+ * chdbVersionTest.c
+ *
+ * Version SQL functions through the C API:
+ *   - SELECT chdb()     -> the chDB release version (CHDB_VERSION_STRING).
+ *   - SELECT version()  -> the underlying ClickHouse engine version.
+ *
+ * Regression guard: the chDB version must be injected at build time. It was
+ * previously left as the literal "None" in libchdb.so builds because the build
+ * scripts fed CHDB_VERSION="None" (see chdb/vars.sh). This asserts chdb()
+ * returns a real, non-"None" version string.
+ *
+ * Build (against an already-built libchdb.so):
+ *   clang examples/chdbVersionTest.c -I./programs/local -L. -lchdb -o examples/chdbVersionTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbVersionTest
+ */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "chdb.h"
+
+static int g_failed = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "  ASSERT FAIL: %s (%s:%d)\n",                 \
+                    (msg), __FILE__, __LINE__);                            \
+            g_failed += 1;                                                 \
+        }                                                                  \
+    } while (0)
+
+static int has_digit(const char * s, size_t n)
+{
+    for (size_t i = 0; i < n; i++)
+        if (isdigit((unsigned char) s[i]))
+            return 1;
+    return 0;
+}
+
+/* Runs `sql` (TabSeparated so a single string value comes back unquoted),
+ * asserts it succeeded, and returns whether the trimmed output looks like a
+ * version (non-empty, not "None", contains a digit). */
+static void check_version(chdb_connection conn, const char * label, const char * sql)
+{
+    chdb_result * r = chdb_query(conn, sql, "TabSeparated");
+    const char * err = r ? chdb_result_error(r) : "null result";
+    if (err) {
+        fprintf(stderr, "  %s ERROR: %s\n", label, err);
+        g_failed += 1;
+        chdb_destroy_query_result(r);
+        return;
+    }
+    size_t len = chdb_result_length(r);
+    const char * buf = chdb_result_buffer(r);
+    /* Drop the trailing newline TabSeparated appends. */
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+        len--;
+
+    CHECK(len > 0, "version string is non-empty");
+    CHECK(!(len == 4 && memcmp(buf, "None", 4) == 0), "version is not the literal \"None\"");
+    CHECK(has_digit(buf, len), "version contains a digit");
+    printf("%-10s -> %.*s\n", label, (int) len, buf);
+    chdb_destroy_query_result(r);
+}
+
+int main(void)
+{
+    char arg0[] = "chdb";
+    char * argv[] = {arg0};
+    chdb_connection * conn = chdb_connect(1, argv);
+    if (!conn) {
+        fprintf(stderr, "chdb_connect failed\n");
+        return 1;
+    }
+
+    check_version(*conn, "chdb()", "SELECT chdb()");
+    check_version(*conn, "version()", "SELECT version()");
+
+    chdb_close_conn(conn);
+
+    printf("\n== summary: %d failed ==\n", g_failed);
+    return g_failed ? 1 : 0;
+}

--- a/examples/runVersionTest.sh
+++ b/examples/runVersionTest.sh
@@ -16,10 +16,10 @@ fi
 
 # cd to the directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR
+cd "$DIR"
 
 echo "Compile and link"
-clang chdbVersionTest.c -o chdbVersionTest -I../programs/local/ -L../ -lchdb
+${CC:-clang} chdbVersionTest.c -o chdbVersionTest -I../programs/local/ -L../ -lchdb
 
 export ${LIB_PATH}=..
 ${LDD} chdbVersionTest

--- a/examples/runVersionTest.sh
+++ b/examples/runVersionTest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Compile and link"
+clang chdbVersionTest.c -o chdbVersionTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbVersionTest
+
+echo "Run it:"
+./chdbVersionTest


### PR DESCRIPTION
Fixes #153.

`chdb/vars.sh` fed `CHDB_VERSION="None"` into the build: `setup.get_latest_git_tag()` returns `None` for non-three-part tags (rc tags like `v26.5.1-rc.2`) and prints `"None"` with exit 0, so the `|| git describe` fallback never fired. `SELECT chdb()` then returned the literal `"None"`.

Fix: capture the helper's output and, when it is empty or `"None"`, fall back to `git describe --tags` (stripped of the leading `v`), then `0.0.0`. Scoped to the build-version wiring — `setup.py` packaging is untouched. After the fix:

```
SELECT chdb(), version()  ->  "26.5.1-rc.2", "26.5.1.1"
```

Test (`examples/chdbVersionTest.c`, wired into the four wheel workflows): `SELECT chdb()` and `SELECT version()` must each be non-empty, not the literal `"None"`, and contain a digit — so it fails on the old "None" and passes for a real tag or the `0.0.0` fallback. Passes locally (`chdb() -> 26.5.1-rc.2`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SELECT chdb()` returning "None" in libchdb.so by correcting version derivation
> - Fixes [vars.sh](https://github.com/chdb-io/chdb-core/pull/154/files#diff-787b477e95a990108cd869887dfdfc2e411269c08d00909ca195f07be80afbc2) to detect when the Python version helper returns the literal `"None"` and falls back to `git describe --tags` (stripping the leading `v`) or `"0.0.0"`.
> - Adds a C test program [examples/chdbVersionTest.c](https://github.com/chdb-io/chdb-core/pull/154/files#diff-1be089ef8cb7b613b930d894ae123444111a0760460d360036708bf673fa2dbe) that queries `chdb()` and `version()`, asserting results are non-empty, not `"None"`, and contain at least one digit.
> - Adds [examples/runVersionTest.sh](https://github.com/chdb-io/chdb-core/pull/154/files#diff-63a373edb66df5955e7b3b1442b2fb1be907a6e821a2605c67c6d785f90a7594) to compile and run the version test, integrated into all four CI workflows so a bad version string fails the build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a318b50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->