### PR TITLE
Document the five chdb-core distribution artifacts in the README

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -17,7 +17,7 @@
 
 ## 目录
 
-- [chDB 生态](#chdb-生态)
+- [软件包与分发](#软件包与分发)
 - [特性](#特性)
 - [架构](#架构)
 - [安装](#安装)
@@ -30,14 +30,17 @@
 
 ---
 
-## chDB 生态
+## 软件包与分发
 
-chDB 项目拆分为两个包：
+**chdb-core**（本仓库）是引擎；[**chDB**](https://github.com/chdb-io/chdb) 是构建在其之上的可选 Pandas 兼容 DataStore 层（见下方示意图）。引擎本身以五种分发产物发布 —— 三个 Python wheel（同一套 `import chdb`，仅编译选项不同）和两个 JavaScript/WASM 包：
 
-| 包 | 定位 | 安装 |
-|---|---|---|
-| **chdb-core**（本仓库） | C++ 引擎 + Session / Connection / DB-API 接口 | `pip install chdb-core` |
-| [**chDB**](https://github.com/chdb-io/chdb) | 基于 chdb-core 构建的 Pandas 兼容 DataStore API | `pip install chdb` |
+| 产物 | 获取方式 | 目标 / 运行时 | 适用场景 |
+|---|---|---|---|
+| **chdb-core** | PyPI — `pip install chdb-core` | Python 3.9+（Linux/macOS） | 默认完整版，功能齐全 |
+| **chdb-core-lite** | PyPI — `pip install chdb-core-lite` | Python 3.9+（Linux/macOS） | 更精简的构建，裁剪了不常用的功能（如 MySQL、Kafka 等外部连接器） |
+| **chdb-core（free-threaded）** | GitHub release 附件 | free-threaded Python 3.14t（无 GIL） | 在无 GIL 的 Python 上运行 chDB |
+| **chdb-wasm** | npm — `npm install chdb-wasm` | 浏览器与 Node（WebAssembly） | 在浏览器或 Node 里运行完整引擎 |
+| **chdb-cloudflare** | npm — `npm install chdb-cloudflare` | Cloudflare Workers / 边缘 | 面向边缘 / Workers 的精简构建 |
 
 <div align="center">
 <pre>

--- a/README-zh.md
+++ b/README-zh.md
@@ -32,7 +32,7 @@
 
 ## 软件包与分发
 
-**chdb-core**（本仓库）是引擎；[**chDB**](https://github.com/chdb-io/chdb) 是构建在其之上的可选 Pandas 兼容 DataStore 层（见下方示意图）。引擎本身以五种分发产物发布 —— 三个 Python wheel（同一套 `import chdb`，仅编译选项不同）和两个 JavaScript/WASM 包：
+**chdb-core**（本仓库）是引擎；[**chDB**](https://github.com/chdb-io/chdb) 是构建在其之上的更高层 Pandas 兼容 DataStore API（见下方示意图）。引擎本身以五种分发产物发布 —— 三个 Python wheel（同一套 `import chdb`，仅编译选项不同）和两个 JavaScript/WASM 包：
 
 | 产物 | 获取方式 | 目标 / 运行时 | 适用场景 |
 |---|---|---|---|
@@ -40,7 +40,7 @@
 | **chdb-core-lite** | PyPI — `pip install chdb-core-lite` | Python 3.9+（Linux/macOS） | 更精简的构建，裁剪了不常用的功能（如 MySQL、Kafka 等外部连接器） |
 | **chdb-core（free-threaded）** | GitHub release 附件 | free-threaded Python 3.14t（无 GIL） | 在无 GIL 的 Python 上运行 chDB |
 | **chdb-wasm** | npm — `npm install chdb-wasm` | 浏览器与 Node（WebAssembly） | 在浏览器或 Node 里运行完整引擎 |
-| **chdb-cloudflare** | npm — `npm install chdb-cloudflare` | Cloudflare Workers / 边缘 | 面向边缘 / Workers 的精简构建 |
+| **chdb-cloudflare** | npm — `npm install chdb-cloudflare` | Cloudflare Workers | 面向 Cloudflare Workers 的精简构建 |
 
 <div align="center">
 <pre>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Packages & Distributions
 
-**chdb-core** (this repo) is the engine; [**chDB**](https://github.com/chdb-io/chdb) is an optional pandas-compatible DataStore layer built on top of it (see the diagram below). The engine itself ships as five distribution artifacts — three Python wheels (same `import chdb`, differing only by build flags) and two JavaScript/WASM packages:
+**chdb-core** (this repo) is the engine; [**chDB**](https://github.com/chdb-io/chdb) is a higher-level pandas-compatible DataStore API built on top of it (see the diagram below). The engine itself ships as five distribution artifacts — three Python wheels (same `import chdb`, differing only by build flags) and two JavaScript/WASM packages:
 
 | Artifact | How to get it | Target / runtime | Best for |
 |---|---|---|---|
@@ -40,7 +40,7 @@
 | **chdb-core-lite** | PyPI — `pip install chdb-core-lite` | Python 3.9+ (Linux/macOS) | Slimmer build that trims less-common features (e.g. external connectors like MySQL/Kafka) |
 | **chdb-core (free-threaded)** | GitHub release assets | Free-threaded Python 3.14t (no GIL) | Running chDB without the GIL |
 | **chdb-wasm** | npm — `npm install chdb-wasm` | Browsers & Node (WebAssembly) | Running the full engine in the browser or Node |
-| **chdb-cloudflare** | npm — `npm install chdb-cloudflare` | Cloudflare Workers / edge | A slimmer build for the edge |
+| **chdb-cloudflare** | npm — `npm install chdb-cloudflare` | Cloudflare Workers | A slimmer build for Cloudflare Workers |
 
 <div align="center">
 <pre>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Table of Contents
 
-- [chDB Ecosystem](#chdb-ecosystem)
+- [Packages & Distributions](#packages--distributions)
 - [Features](#features)
 - [Architecture](#architecture)
 - [Installation](#installation)
@@ -30,14 +30,17 @@
 
 ---
 
-## chDB Ecosystem
+## Packages & Distributions
 
-The chDB project is split into two packages:
+**chdb-core** (this repo) is the engine; [**chDB**](https://github.com/chdb-io/chdb) is an optional pandas-compatible DataStore layer built on top of it (see the diagram below). The engine itself ships as five distribution artifacts — three Python wheels (same `import chdb`, differing only by build flags) and two JavaScript/WASM packages:
 
-| Package | Role | Install |
-|---|---|---|
-| **chdb-core** (this repo) | C++ engine + Session / Connection / DB-API interfaces | `pip install chdb-core` |
-| [**chDB**](https://github.com/chdb-io/chdb) | Pandas-compatible DataStore API built on top of chdb-core | `pip install chdb` |
+| Artifact | How to get it | Target / runtime | Best for |
+|---|---|---|---|
+| **chdb-core** | PyPI — `pip install chdb-core` | Python 3.9+ (Linux/macOS) | Default full build — everything included |
+| **chdb-core-lite** | PyPI — `pip install chdb-core-lite` | Python 3.9+ (Linux/macOS) | Slimmer build that trims less-common features (e.g. external connectors like MySQL/Kafka) |
+| **chdb-core (free-threaded)** | GitHub release assets | Free-threaded Python 3.14t (no GIL) | Running chDB without the GIL |
+| **chdb-wasm** | npm — `npm install chdb-wasm` | Browsers & Node (WebAssembly) | Running the full engine in the browser or Node |
+| **chdb-cloudflare** | npm — `npm install chdb-cloudflare` | Cloudflare Workers / edge | A slimmer build for the edge |
 
 <div align="center">
 <pre>


### PR DESCRIPTION
Renames the top-of-README "chDB Ecosystem" section to "Packages & Distributions" and expands its two-row table into a five-row overview of every shipped artifact — chdb-core, chdb-core-lite, the free-threaded build, chdb-wasm, and chdb-cloudflare — with how to get each, its target runtime, and what it's best for.

Applied symmetrically to `README.md` and `README-zh.md` (section heading, Table of Contents entry, and anchor updated). Docs only — no code changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document five chdb-core distribution artifacts in README and README-zh
> Replaces the 'chDB Ecosystem' section in both [README.md](https://github.com/chdb-io/chdb-core/pull/155/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [README-zh.md](https://github.com/chdb-io/chdb-core/pull/155/files#diff-2b8d2db04fe3277c3a06cbdf5da2ba7659f95e19e31f59d5382b40ac81a1a98d) with a 'Packages & Distributions' section containing a four-column table covering five artifacts: `chdb-core`, `chdb-core-lite`, `chdb-core` (free-threaded), `chdb-wasm`, and `chdb-cloudflare`. Each entry documents how to obtain the package, its target/runtime, and intended use cases. Also adds an explicit `## Architecture` section header in the English README to align with the table of contents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 882696e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->