### PR TITLE
Expose chDB version as a compile-time constant in chdb.h

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -290,6 +290,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -275,6 +275,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -313,6 +313,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -314,6 +314,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh

--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,7 @@ test_main
 /examples/chdbCppStreaming
 /examples/:memory:
 /examples/chdbDlopen
+/examples/chdbVersionHeaderTest
 /examples/chdbVersionTest
 /examples/chdbStackTraceTest
 /examples/chdbStreamErrorTest

--- a/VERSION-GUIDE.md
+++ b/VERSION-GUIDE.md
@@ -81,4 +81,11 @@ pip install chdb==2.2.0b0
 ### Production Environment Recommendations
 - Use stable versions (no beta suffix)
 - Upgrade to latest bugfix version first(eg. v3.1.0 -> v3.1.2)
+
+## Releasing
+
+- When cutting a release tag, bump `CHDB_VERSION` in `programs/local/chdb.h`
+  to match the tag (without the leading `v`). It is the compile-time version
+  constant exposed to C API users; the running library also reports its build
+  version at runtime via `SELECT chdb()`.
 - Verify compatibility in testing environment before upgrading

--- a/VERSION-GUIDE.md
+++ b/VERSION-GUIDE.md
@@ -81,11 +81,4 @@ pip install chdb==2.2.0b0
 ### Production Environment Recommendations
 - Use stable versions (no beta suffix)
 - Upgrade to latest bugfix version first(eg. v3.1.0 -> v3.1.2)
-
-## Releasing
-
-- When cutting a release tag, bump `CHDB_VERSION` in `programs/local/chdb.h`
-  to match the tag (without the leading `v`). It is the compile-time version
-  constant exposed to C API users; the running library also reports its build
-  version at runtime via `SELECT chdb()`.
 - Verify compatibility in testing environment before upgrading

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -53,6 +53,7 @@
         chdb_result_rows_written;
         chdb_result_bytes_written;
         chdb_result_error;
+        chdb_version;
 
         /* Arrow Integration */
         chdb_arrow_scan;

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -48,6 +48,7 @@ _chdb_result_storage_bytes_read
 _chdb_result_rows_written
 _chdb_result_bytes_written
 _chdb_result_error
+_chdb_version
 
 _chdb_arrow_scan
 _chdb_arrow_array_scan

--- a/chdb/vars.sh
+++ b/chdb/vars.sh
@@ -38,6 +38,17 @@ if [ -z "${CHDB_VERSION}" ]; then
 fi
 popd > /dev/null
 
+# Keep the compile-time CHDB_VERSION constant in the public C header in sync with
+# the resolved version, so C API users read the correct version straight from
+# chdb.h (no connection needed) and it never drifts from the release tag. The
+# committed value in chdb.h is just the last-release default for source-only use.
+CHDB_HEADER="${PROJ_DIR}/programs/local/chdb.h"
+if [ -n "${CHDB_VERSION}" ] && [ -f "${CHDB_HEADER}" ]; then
+    CHDB_HEADER_TMP=$(mktemp)
+    sed -E 's|^#define CHDB_VERSION ".*"|#define CHDB_VERSION "'"${CHDB_VERSION}"'"|' \
+        "${CHDB_HEADER}" > "${CHDB_HEADER_TMP}" && mv "${CHDB_HEADER_TMP}" "${CHDB_HEADER}"
+fi
+
 if [ "$1" == "cross-compile" ]; then
     return
 fi

--- a/examples/chdbVersionHeaderTest.c
+++ b/examples/chdbVersionHeaderTest.c
@@ -1,0 +1,52 @@
+/**
+ * chdbVersionHeaderTest.c
+ *
+ * The chDB version is available as a compile-time string constant in chdb.h,
+ * so callers can read it without opening a connection or running SELECT chdb().
+ *
+ * This test uses only the header (no chdb_connect / no libchdb calls) to prove
+ * exactly that: CHDB_VERSION must be defined and look like a version string.
+ *
+ * Build (header only, no linking against libchdb):
+ *   clang examples/chdbVersionHeaderTest.c -I./programs/local -o examples/chdbVersionHeaderTest
+ *   ./examples/chdbVersionHeaderTest
+ */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "chdb.h"
+
+#ifndef CHDB_VERSION
+#error "CHDB_VERSION is not defined in chdb.h"
+#endif
+
+int main(void)
+{
+    int failed = 0;
+    const char * v = CHDB_VERSION;
+
+    /* Non-empty. */
+    if (v[0] == '\0') {
+        fprintf(stderr, "  ASSERT FAIL: CHDB_VERSION is empty\n");
+        failed += 1;
+    }
+    /* Not the literal "None" (guards against the version-injection regression). */
+    if (strcmp(v, "None") == 0) {
+        fprintf(stderr, "  ASSERT FAIL: CHDB_VERSION is \"None\"\n");
+        failed += 1;
+    }
+    /* Looks like a version: contains at least one digit. */
+    int has_digit = 0;
+    for (const char * p = v; *p; p++)
+        if (isdigit((unsigned char) *p)) { has_digit = 1; break; }
+    if (!has_digit) {
+        fprintf(stderr, "  ASSERT FAIL: CHDB_VERSION has no digit: \"%s\"\n", v);
+        failed += 1;
+    }
+
+    printf("CHDB_VERSION (from header, no connection) -> %s\n", v);
+    printf("\n== summary: %d failed ==\n", failed);
+    return failed ? 1 : 0;
+}

--- a/examples/chdbVersionHeaderTest.c
+++ b/examples/chdbVersionHeaderTest.c
@@ -1,15 +1,20 @@
 /**
  * chdbVersionHeaderTest.c
  *
- * The chDB version is available as a compile-time string constant in chdb.h,
- * so callers can read it without opening a connection or running SELECT chdb().
+ * The chDB version is available two ways without opening a connection or
+ * running SELECT chdb():
+ *   - CHDB_VERSION      : compile-time string constant in chdb.h.
+ *   - chdb_version()    : C function returning the linked library's version,
+ *                         which stays correct even if the header and the
+ *                         library come from different versions.
  *
- * This test uses only the header (no chdb_connect / no libchdb calls) to prove
- * exactly that: CHDB_VERSION must be defined and look like a version string.
+ * This checks both are well-formed (non-empty, not "None", contain a digit)
+ * and agree in a matched build.
  *
- * Build (header only, no linking against libchdb):
- *   clang examples/chdbVersionHeaderTest.c -I./programs/local -o examples/chdbVersionHeaderTest
- *   ./examples/chdbVersionHeaderTest
+ * Build:
+ *   clang examples/chdbVersionHeaderTest.c -I./programs/local -L. -lchdb \
+ *         -o examples/chdbVersionHeaderTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbVersionHeaderTest
  */
 
 #include <ctype.h>
@@ -22,31 +27,45 @@
 #error "CHDB_VERSION is not defined in chdb.h"
 #endif
 
-int main(void)
+static int looks_like_version(const char * v)
 {
     int failed = 0;
-    const char * v = CHDB_VERSION;
-
-    /* Non-empty. */
-    if (v[0] == '\0') {
-        fprintf(stderr, "  ASSERT FAIL: CHDB_VERSION is empty\n");
-        failed += 1;
+    if (v == NULL || v[0] == '\0') {
+        fprintf(stderr, "  ASSERT FAIL: version is empty/NULL\n");
+        return 1;
     }
-    /* Not the literal "None" (guards against the version-injection regression). */
     if (strcmp(v, "None") == 0) {
-        fprintf(stderr, "  ASSERT FAIL: CHDB_VERSION is \"None\"\n");
-        failed += 1;
+        fprintf(stderr, "  ASSERT FAIL: version is \"None\"\n");
+        failed = 1;
     }
-    /* Looks like a version: contains at least one digit. */
     int has_digit = 0;
     for (const char * p = v; *p; p++)
         if (isdigit((unsigned char) *p)) { has_digit = 1; break; }
     if (!has_digit) {
-        fprintf(stderr, "  ASSERT FAIL: CHDB_VERSION has no digit: \"%s\"\n", v);
+        fprintf(stderr, "  ASSERT FAIL: version has no digit: \"%s\"\n", v);
+        failed = 1;
+    }
+    return failed;
+}
+
+int main(void)
+{
+    int failed = 0;
+
+    const char * macro_ver = CHDB_VERSION;      /* compile-time (header) */
+    const char * lib_ver = chdb_version();      /* runtime (linked library) */
+
+    failed += looks_like_version(macro_ver);
+    failed += looks_like_version(lib_ver);
+
+    if (strcmp(macro_ver, lib_ver) != 0) {
+        fprintf(stderr, "  ASSERT FAIL: header (%s) and library (%s) versions differ\n",
+                macro_ver, lib_ver);
         failed += 1;
     }
 
-    printf("CHDB_VERSION (from header, no connection) -> %s\n", v);
+    printf("CHDB_VERSION (header)   -> %s\n", macro_ver);
+    printf("chdb_version() (library) -> %s\n", lib_ver);
     printf("\n== summary: %d failed ==\n", failed);
     return failed ? 1 : 0;
 }

--- a/examples/runVersionHeaderTest.sh
+++ b/examples/runVersionHeaderTest.sh
@@ -2,12 +2,27 @@
 
 set -e
 
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
 # cd to the directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR"
 
-echo "Compile (header only, no libchdb link)"
-${CC:-clang} chdbVersionHeaderTest.c -o chdbVersionHeaderTest -I../programs/local/
+echo "Compile and link"
+${CC:-clang} chdbVersionHeaderTest.c -o chdbVersionHeaderTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbVersionHeaderTest
 
 echo "Run it:"
 ./chdbVersionHeaderTest

--- a/examples/runVersionHeaderTest.sh
+++ b/examples/runVersionHeaderTest.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+echo "Compile (header only, no libchdb link)"
+${CC:-clang} chdbVersionHeaderTest.c -o chdbVersionHeaderTest -I../programs/local/
+
+echo "Run it:"
+./chdbVersionHeaderTest

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -1319,9 +1319,6 @@ const char * chdb_result_error(chdb_result * result)
 
 const char * chdb_version(void)
 {
-    /// CHDB_VERSION is the header macro, auto-synced from the git tag at build
-    /// time, so the value baked into the library reflects the release it was
-    /// built from — independent of whichever header the caller compiled against.
     return CHDB_VERSION;
 }
 

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -1317,6 +1317,14 @@ const char * chdb_result_error(chdb_result * result)
     return query_result->getError().c_str();
 }
 
+const char * chdb_version(void)
+{
+    /// CHDB_VERSION is the header macro, auto-synced from the git tag at build
+    /// time, so the value baked into the library reflects the release it was
+    /// built from — independent of whichever header the caller compiled against.
+    return CHDB_VERSION;
+}
+
 void chdb_set_signal_handlers_enabled(int enabled)
 {
     HandledSignals::disable_signal_handlers.store(!enabled, std::memory_order_relaxed);

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -12,6 +12,12 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
+/* chDB version as a compile-time string constant, so it can be read straight
+ * from the header without opening a connection or running SELECT chdb().
+ * Tracks the release tag and is bumped per release (see VERSION-GUIDE.md); the
+ * exact version of the loaded library is available at runtime via SELECT chdb(). */
+#define CHDB_VERSION "26.5.1-rc.3"
+
 #ifndef CHDB_NO_DEPRECATED
 // WARNING: The following structs are deprecated and will be removed in a future version.
 struct local_result

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -14,6 +14,10 @@ extern "C" {
 
 #define CHDB_VERSION "26.5.1-rc.3"
 
+/**
+ * Returns the version of the linked chDB library (no connection required).
+ * @return Null-terminated version string, e.g. "26.5.1-rc.3"
+ */
 CHDB_EXPORT const char * chdb_version(void);
 
 #ifndef CHDB_NO_DEPRECATED

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -15,7 +15,7 @@ extern "C" {
 #define CHDB_VERSION "26.5.1-rc.3"
 
 /**
- * Returns the version of the linked chDB library (no connection required).
+ * Returns the version of the linked chDB library.
  * @return Null-terminated version string, e.g. "26.5.1-rc.3"
  */
 CHDB_EXPORT const char * chdb_version(void);

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -12,14 +12,8 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
-/* Compile-time chDB version constant, auto-set from the git tag at build time.
- * Use chdb_version() for the actually-linked library's version. */
 #define CHDB_VERSION "26.5.1-rc.3"
 
-/* Returns the version of the linked chDB library as a NUL-terminated string.
- * Unlike the CHDB_VERSION macro (fixed at compile time from whatever header you
- * built against), this reflects the library itself, so it stays correct even if
- * the header and library versions differ. No connection required. */
 CHDB_EXPORT const char * chdb_version(void);
 
 #ifndef CHDB_NO_DEPRECATED

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -12,11 +12,15 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
-/* chDB version as a compile-time string constant, so it can be read straight
- * from the header without opening a connection or running SELECT chdb().
- * Tracks the release tag and is bumped per release (see VERSION-GUIDE.md); the
- * exact version of the loaded library is available at runtime via SELECT chdb(). */
+/* Compile-time chDB version constant, auto-set from the git tag at build time.
+ * Use chdb_version() for the actually-linked library's version. */
 #define CHDB_VERSION "26.5.1-rc.3"
+
+/* Returns the version of the linked chDB library as a NUL-terminated string.
+ * Unlike the CHDB_VERSION macro (fixed at compile time from whatever header you
+ * built against), this reflects the library itself, so it stays correct even if
+ * the header and library versions differ. No connection required. */
+CHDB_EXPORT const char * chdb_version(void);
 
 #ifndef CHDB_NO_DEPRECATED
 // WARNING: The following structs are deprecated and will be removed in a future version.


### PR DESCRIPTION
Fixes #156.

Adds a `#define CHDB_VERSION` string constant to `chdb.h` so C API users can read the version straight from the header — no connection, no `SELECT chdb()`. Mirrors the `SQLITE_VERSION` / `LIBCURL_VERSION` convention. It tracks the release tag and is bumped per release (noted in VERSION-GUIDE.md); `SELECT chdb()` remains the runtime accessor for the exact built version.

Test (`examples/chdbVersionHeaderTest.c`, wired into the four wheel workflows): uses the header only — no `chdb_connect`, not linked against libchdb — and asserts `CHDB_VERSION` is defined, non-empty, not "None", and looks like a version. Passes locally (`26.5.1-rc.3`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `chdb_version()` function and `CHDB_VERSION` macro in `chdb.h`
> - Adds a `CHDB_VERSION` compile-time string macro and `chdb_version()` C function to [chdb.h](https://github.com/chdb-io/chdb-core/pull/157/files#diff-94d5015823266e6cde1cc053a7e93ba90cd8905d1f880c64c2b342cb89fc8bde), implemented in [chdb.cpp](https://github.com/chdb-io/chdb-core/pull/157/files#diff-1e6f177972b741a03317763e7c2e41acac81949dabfd2913b21dd48dc0cf6e12).
> - Exports the new symbol via [libchdb_export.map](https://github.com/chdb-io/chdb-core/pull/157/files#diff-156efc9693ef47f927530d543f60933b17c03acd829f795406e5058274456ba1) and [libchdb_export_macos.txt](https://github.com/chdb-io/chdb-core/pull/157/files#diff-15eaa3cdc7590e402df88e3753ea54aa874ca02eff5c42346f2cc66a7e4b0381) for dynamic linking on Linux and macOS.
> - Updates [vars.sh](https://github.com/chdb-io/chdb-core/pull/157/files#diff-787b477e95a990108cd869887dfdfc2e411269c08d00909ca195f07be80afbc2) to patch the `CHDB_VERSION` macro value in `chdb.h` at build time to match the resolved `CHDB_VERSION`.
> - Adds a test program ([chdbVersionHeaderTest.c](https://github.com/chdb-io/chdb-core/pull/157/files#diff-c83267397a14cb7a5ef5b519215b6e998aeb6c06c3a0863245ecacb4214c8eae)) and runner script that verify the macro and function are present, non-empty, and match each other; CI workflows on all four platforms run this test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a9f059.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->