### PR TITLE
Keep trailing NUL bytes when binding fixed_size_binary

### DIFF
--- a/programs/local/adbc/validation/python/README.md
+++ b/programs/local/adbc/validation/python/README.md
@@ -48,7 +48,7 @@ are session-scoped, so the run shares one chDB engine and never restarts it. It
 takes about two seconds.
 
 Latest run (macOS arm64, engine 26.5.1.1):
-**214 passed, 27 skipped, 4 xfailed, 0 failed**. Each of the four build
+**215 passed, 27 skipped, 3 xfailed, 0 failed**. Each of the four build
 workflows runs it alongside the gtest suite, against the libchdb just built.
 
 ## The capability matrix

--- a/programs/local/adbc/validation/python/queries/type/bind/fixed_size_binary.txtcase
+++ b/programs/local/adbc/validation/python/queries/type/bind/fixed_size_binary.txtcase
@@ -35,7 +35,6 @@ drop = "test_fixed_size_binary"
 
 [tags]
 sql-type-name = "VARBINARY"
-broken-driver = "binding fixed_size_binary drops trailing NUL bytes; binary and bulk ingest keep them"
 
 // part: setup_query
 

--- a/programs/local/chdb-adbc.cpp
+++ b/programs/local/chdb-adbc.cpp
@@ -1765,6 +1765,42 @@ AdbcStatusCode chdbStatementBindStream(
     return ADBC_STATUS_OK;
 }
 
+/// The projection for an INSERT ... SELECT out of a registered Arrow stream.
+///
+/// The Arrow reader turns fixed_size_binary into FixedString(n), and inserting
+/// that into a String column drops the trailing NUL bytes, because that is what
+/// ClickHouse's FixedString-to-String conversion does. Concatenating keeps them.
+/// Every other column, and every column when there is no fixed_size_binary,
+/// passes through as "*".
+///
+/// CREATE ... AS SELECT needs none of this: it makes the column FixedString(n),
+/// so there is no conversion to lose bytes in.
+std::string streamInsertProjection(ArrowArrayStream & stream)
+{
+    ArrowSchema schema;
+    std::memset(&schema, 0, sizeof(schema));
+    if (stream.get_schema(&stream, &schema) != 0 || !schema.release)
+        return "*";
+
+    std::string projection;
+    bool rewritten = false;
+    for (int64_t i = 0; i < schema.n_children; ++i)
+    {
+        const ArrowSchema * child = schema.children[i];
+        const std::string name = child->name ? child->name : "";
+        const std::string format = child->format ? child->format : "";
+        /// "w:<byte width>" is the Arrow format string for fixed_size_binary.
+        const bool fixed_size_binary = format.size() > 2 && format[0] == 'w' && format[1] == ':';
+
+        if (i)
+            projection += ", ";
+        projection += fixed_size_binary ? "concat(" + quoteIdentifier(name) + ", '')" : quoteIdentifier(name);
+        rewritten = rewritten || fixed_size_binary;
+    }
+    schema.release(&schema);
+    return rewritten ? projection : "*";
+}
+
 AdbcStatusCode executeIngest(StatementImpl * impl, int64_t * rows_affected, AdbcError * error)
 {
     if (!impl->has_bound_stream)
@@ -1788,7 +1824,8 @@ AdbcStatusCode executeIngest(StatementImpl * impl, int64_t * rows_affected, Adbc
 
     const std::string create_sql = "CREATE TABLE " + qualified
         + " ENGINE = MergeTree() ORDER BY tuple() AS SELECT * FROM arrowstream(" + reg_name + ")";
-    const std::string insert_sql = "INSERT INTO " + qualified + " SELECT * FROM arrowstream(" + reg_name + ")";
+    const std::string insert_sql = "INSERT INTO " + qualified + " SELECT "
+        + streamInsertProjection(impl->bound_stream) + " FROM arrowstream(" + reg_name + ")";
 
     AdbcStatusCode status = ADBC_STATUS_OK;
     if (impl->ingest_mode == ADBC_INGEST_OPTION_MODE_CREATE)
@@ -1883,7 +1920,10 @@ AdbcStatusCode executeBoundInsertBatch(
         return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to register bound Arrow stream");
     }
     AdbcStatusCode status = runUpdateQuery(
-        impl->connection, insert_head + " SELECT * FROM arrowstream(" + reg_name + ")", rows_affected, error);
+        impl->connection,
+        insert_head + " SELECT " + streamInsertProjection(impl->bound_stream) + " FROM arrowstream(" + reg_name + ")",
+        rows_affected,
+        error);
     chdb_arrow_unregister_table(*impl->connection->conn, reg_name.c_str());
     impl->releaseBoundStream();
     return status;

--- a/tests/test_adbc_driver.py
+++ b/tests/test_adbc_driver.py
@@ -664,6 +664,40 @@ class TestAdbcParameters(unittest.TestCase):
             cur.execute("SELECT count(), sum(id) FROM many_fast")
             self.assertEqual(cur.fetchone(), (5000, sum(r[0] for r in rows)))
 
+    def test_fixed_size_binary_keeps_trailing_nuls(self):
+        # The Arrow reader turns fixed_size_binary into FixedString(n), and
+        # ClickHouse drops trailing NUL bytes converting that to String. The
+        # bound values must survive both bind paths and read back byte-exact.
+        values = [b"\x00" * 5, b"abc\x00\x00", b"abcde"]
+        params = pa.RecordBatch.from_pydict(
+            {"0": pa.array(values, pa.binary(5))}
+        )
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE fsb_bind (v Nullable(String)) ENGINE = Memory"
+            )
+            # The plain INSERT ... VALUES (?) shape takes the Arrow-stream
+            # fast path; a bound SELECT takes the per-row path.
+            cur.adbc_statement.set_sql_query("INSERT INTO fsb_bind VALUES (?)")
+            cur.adbc_statement.bind(params)
+            cur.adbc_statement.execute_update()
+            cur.execute("SELECT v FROM fsb_bind ORDER BY v")
+            fast_path = cur.fetch_arrow_table().column("v").to_pylist()
+
+            cur.adbc_statement.set_sql_query("SELECT ? AS v")
+            cur.adbc_statement.bind(params)
+            handle, _ = cur.adbc_statement.execute_query()
+            per_row = (
+                pa.RecordBatchReader._import_from_c(handle.address)
+                .read_all()
+                .column("v")
+                .to_pylist()
+            )
+
+        expected = sorted(v.decode("latin-1") for v in values)
+        self.assertEqual(sorted(fast_path), expected)
+        self.assertEqual(sorted(per_row), expected)
+
     def test_executemany_expression_falls_back(self):
         # A constant mixed into VALUES doesn't match the fast-path shape;
         # the per-row path must produce the same result.


### PR DESCRIPTION
Binding a `fixed_size_binary` value dropped its trailing NUL bytes: five NUL bytes came back as an empty string. Measuring the three paths separately shows it is not one behaviour but two that disagree.

| path | `b"\x00" * 5` | `b"abc\x00\x00"` |
|---|---|---|
| bind `binary` | 5 bytes | 5 bytes |
| **bind `fixed_size_binary`** | **0 bytes** | **3 bytes** |
| ingest `fixed_size_binary` | 5 bytes | 5 bytes |

The per-row bind path declares the column `String` and escapes the value, keeping every byte. The fast path for a plain `INSERT ... VALUES (?)` instead streams the batch through `arrowstream`, where the Arrow reader makes it `FixedString(n)`, and inserting `FixedString` into a `String` column drops trailing NULs — that is what ClickHouse's conversion does:

```sql
SELECT CAST(toFixedString('abc', 5) AS String)   -- 'abc', length 3
```

So an optimization the caller cannot see changed the result. Bulk ingest in `append` mode into an existing `String` column had the same problem.

## The fix

The Arrow-to-ClickHouse mapping lives in ClickHouse's shared reader (`ArrowColumnToCHColumn.cpp`) and is used by every Arrow ingest path, so this fixes the SQL the driver builds instead: the `INSERT ... SELECT` projects `fixed_size_binary` columns as `concat(col, '')`, which keeps the bytes, and passes everything else through as before. Of the alternatives, `CAST`, `toString` and `reinterpretAsString` all truncate, and `substring` needs the width.

`CREATE ... AS SELECT` is deliberately left alone: it makes the column `FixedString(n)`, so nothing is converted and nothing is lost, and ingesting into a new table still round-trips as `fixed_size_binary`.

Only top-level columns are handled; a `fixed_size_binary` nested in a struct or list is not.

## Verification

Against a locally built libchdb:

- all three paths keep every byte, and `create`-mode ingest still yields `fixed_size_binary[5]`
- the new regression test asserts the fast and per-row bind paths agree
- conformance suite: 73 passed, 27 skipped, 0 failed
- Foundry validation suite: **215 passed, 27 skipped, 3 xfailed** — the case that documented this defect passes on its own now, so its `broken-driver` declaration is removed
- regenerating the overrides against the fixed driver reproduces the committed files byte for byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve trailing NUL bytes when binding `fixed_size_binary` columns during ingestion
> - Adds `streamInsertProjection` in [chdb-adbc.cpp](https://github.com/chdb-io/chdb-core/pull/161/files#diff-5b253d3438b0719880878a1150dcfb7b196e77c2276b7a7724d3b848c8c54c49) that inspects an Arrow stream's schema and replaces `fixed_size_binary` columns (format `w:`) with `concat(<col>, '')` to prevent ClickHouse from stripping trailing NUL bytes.
> - Applies this projection to both the bulk `executeIngest` path and the `executeBoundInsertBatch` fast path, replacing the bare `SELECT *`.
> - Adds a regression test in [test_adbc_driver.py](https://github.com/chdb-io/chdb-core/pull/161/files#diff-1ffd0fb08b222190955369dab8b91b55bde505df1b53326ec01e2466fd1346a2) covering both bind paths.
> - Behavioral Change: INSERT ... SELECT for Arrow streams now uses an explicit column projection instead of `*`; columns without `fixed_size_binary` are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea3d276.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->