### PR TITLE
Support bytes/bytearray/memoryview values in Python UDFs

### DIFF
--- a/programs/local/PythonScalarUDF.cpp
+++ b/programs/local/PythonScalarUDF.cpp
@@ -533,6 +533,13 @@ UDFArgSpec makeUDFArgSpec(const DB::ColumnWithTypeAndName & arg, const DB::DataT
         default:
             spec.fast = false;
     }
+
+    /// as_bytes is only honored by convertArgFast; the generic convertColumnValueForUDF
+    /// path would hand back a UTF-8-decoded str. String/FixedString always take the fast
+    /// path today, so this invariant holds — assert it so a future change to spec.fast
+    /// eligibility can't silently regress bytes-declared arguments.
+    chassert(!spec.as_bytes || spec.fast);
+
     return spec;
 }
 

--- a/programs/local/PythonScalarUDF.cpp
+++ b/programs/local/PythonScalarUDF.cpp
@@ -122,6 +122,18 @@ DB::DataTypePtr fromPythonType(const py::object & annotation)
         std::string(py::str(annotation)));
 }
 
+/// True when the annotation is the builtin `bytes` or `bytearray` type. Both map
+/// to ClickHouse String, but an argument declared this way should receive a raw
+/// Python `bytes` value rather than a UTF-8-decoded `str`.
+bool isBytesLikeAnnotation(const py::object & annotation)
+{
+    if (!py::isinstance<py::type>(annotation))
+        return false;
+
+    auto builtins = py::module_::import("builtins");
+    return annotation.is(builtins.attr("bytes")) || annotation.is(builtins.attr("bytearray"));
+}
+
 DB::DataTypePtr fromString(const py::object & annotation)
 {
     auto string_value = std::string(py::str(annotation));
@@ -219,10 +231,12 @@ void resolveArgTypes(
     const py::list & arg_types_hint,
     const size_t arg_types_hint_count,
     const size_t num_args,
-    DB::DataTypes & arg_types)
+    DB::DataTypes & arg_types,
+    std::vector<bool> & arg_wants_bytes)
 {
     chassert(arg_types_hint_count > 0);
     chassert(arg_types.empty());
+    chassert(arg_wants_bytes.empty());
 
     if (arg_types_hint_count != num_args)
         throw DB::Exception(
@@ -231,7 +245,11 @@ void resolveArgTypes(
             name, py::len(arg_types_hint), num_args);
 
     for (auto item : arg_types_hint)
-        arg_types.push_back(annotationToDataType(py::reinterpret_borrow<py::object>(item)));
+    {
+        auto annotation = py::reinterpret_borrow<py::object>(item);
+        arg_types.push_back(annotationToDataType(annotation));
+        arg_wants_bytes.push_back(isBytesLikeAnnotation(annotation));
+    }
 }
 
 bool isSupportedUDFType(DB::TypeIndex type_id)
@@ -317,6 +335,7 @@ void PythonScalarUDF::initSignature(const py::list & arg_types_hint)
         bool found_varargs = false;
         size_t arg_count = static_cast<size_t>(py::len(params));
         arg_types.reserve(arg_count);
+        arg_wants_bytes.reserve(arg_count);
         const size_t arg_types_hint_count = py::len(arg_types_hint);
         bool no_arg_types_hint = arg_types_hint_count == 0;
 
@@ -349,9 +368,15 @@ void PythonScalarUDF::initSignature(const py::list & arg_types_hint)
             {
                 auto arg_annotation = value.attr("annotation");
                 if (py::none().is(arg_annotation) || empty.is(arg_annotation))
+                {
                     arg_types.emplace_back();
+                    arg_wants_bytes.push_back(false);
+                }
                 else
+                {
                     arg_types.push_back(annotationToDataType(arg_annotation));
+                    arg_wants_bytes.push_back(isBytesLikeAnnotation(arg_annotation));
+                }
             }
         }
 
@@ -375,7 +400,7 @@ void PythonScalarUDF::initSignature(const py::list & arg_types_hint)
                 "Python UDF '{}': return type not specified", name);
 
         if (!no_arg_types_hint)
-            resolveArgTypes(name, arg_types_hint, arg_types_hint_count, positional_count, arg_types);
+            resolveArgTypes(name, arg_types_hint, arg_types_hint_count, positional_count, arg_types, arg_wants_bytes);
 
         validateUDFTypes(name, return_type, arg_types);
     }
@@ -457,15 +482,17 @@ struct UDFArgSpec
     bool is_const = false;
     bool is_bool = false;
     bool cast_to_float = false;                  /// declared arg type is Float32/64
+    bool as_bytes = false;                        /// declared bytes/bytearray -> deliver Python bytes
     bool fast = false;                           /// convertArgFast handles this type
 };
 
-UDFArgSpec makeUDFArgSpec(const DB::ColumnWithTypeAndName & arg, const DB::DataTypePtr & declared_type)
+UDFArgSpec makeUDFArgSpec(const DB::ColumnWithTypeAndName & arg, const DB::DataTypePtr & declared_type, bool declared_bytes)
 {
     UDFArgSpec spec;
     spec.column = arg.column.get();
     spec.type = arg.type;
     spec.declared_type = declared_type;
+    spec.as_bytes = declared_bytes;
 
     const DB::IColumn * col = arg.column.get();
     if (const auto * col_const = typeid_cast<const DB::ColumnConst *>(col))
@@ -551,10 +578,12 @@ py::object convertArgFast(const UDFArgSpec & spec, size_t input_row)
         case DB::TypeIndex::FixedString:
         {
             auto ref = spec.value_column->getDataAt(row);
-            PyObject * str = PyUnicode_FromStringAndSize(ref.data(), static_cast<Py_ssize_t>(ref.size()));
-            if (!str)
+            PyObject * obj = spec.as_bytes
+                ? PyBytes_FromStringAndSize(ref.data(), static_cast<Py_ssize_t>(ref.size()))
+                : PyUnicode_FromStringAndSize(ref.data(), static_cast<Py_ssize_t>(ref.size()));
+            if (!obj)
                 throw py::error_already_set();
-            return py::reinterpret_steal<py::object>(str);
+            return py::reinterpret_steal<py::object>(obj);
         }
         default:
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "convertArgFast called for unsupported type id");
@@ -865,6 +894,57 @@ void handleString(
     column.insert(DB::Field(str));
 }
 
+/// bytes / bytearray / memoryview return values. ClickHouse String is binary-safe,
+/// so the raw bytes are inserted verbatim (no UTF-8 decode). Only String is accepted,
+/// mirroring handleString. object_type is the already-resolved kind from the caller.
+void handleBytes(
+    DB::IColumn & column,
+    const DB::DataTypePtr & actual_type,
+    const py::handle & value,
+    PythonObjectType object_type)
+{
+    if (actual_type->getTypeId() != DB::TypeIndex::String)
+        throw DB::Exception(
+            DB::ErrorCodes::TYPE_MISMATCH,
+            "Cannot convert Python object of type '{}' to {}",
+            String(py::str(value.get_type())),
+            actual_type->getName());
+
+    if (object_type == PythonObjectType::Bytes)
+    {
+        char * buffer = nullptr;
+        Py_ssize_t length = 0;
+        if (PyBytes_AsStringAndSize(value.ptr(), &buffer, &length) != 0)
+            throw py::error_already_set();
+        column.insertData(buffer, static_cast<size_t>(length));
+        return;
+    }
+
+    if (object_type == PythonObjectType::ByteArray)
+    {
+        char * buffer = PyByteArray_AsString(value.ptr());
+        if (!buffer)
+            throw py::error_already_set();
+        column.insertData(buffer, static_cast<size_t>(PyByteArray_Size(value.ptr())));
+        return;
+    }
+
+    /// memoryview (or any other buffer exporter): materialize a contiguous copy.
+    /// PyBytes_FromObject is part of the stable ABI, unlike the buffer protocol
+    /// (PyObject_GetBuffer only entered the limited API in 3.11, but the abi3
+    /// build targets 3.9).
+    PyObject * as_bytes = PyBytes_FromObject(value.ptr());
+    if (!as_bytes)
+        throw py::error_already_set();
+    py::object owner = py::reinterpret_steal<py::object>(as_bytes);
+
+    char * buffer = nullptr;
+    Py_ssize_t length = 0;
+    if (PyBytes_AsStringAndSize(as_bytes, &buffer, &length) != 0)
+        throw py::error_already_set();
+    column.insertData(buffer, static_cast<size_t>(length));
+}
+
 void handleNull(DB::IColumn & column)
 {
     column.insertDefault();
@@ -913,10 +993,13 @@ void insertPythonObjectToColumn(
         handleDatetime(column, actual_type->getTypeId(), actual_type, value);
         break;
 
-    case PythonObjectType::Decimal:
     case PythonObjectType::Bytes:
     case PythonObjectType::ByteArray:
     case PythonObjectType::MemoryView:
+        handleBytes(column, actual_type, value, object_type);
+        break;
+
+    case PythonObjectType::Decimal:
     case PythonObjectType::Uuid:
     case PythonObjectType::Time:
     case PythonObjectType::Timedelta:
@@ -958,7 +1041,10 @@ DB::ColumnPtr PythonScalarUDF::executeImpl(
     std::vector<UDFArgSpec> specs;
     specs.reserve(argc);
     for (size_t i = 0; i < argc; ++i)
-        specs.push_back(makeUDFArgSpec(arguments[i], (i < arg_types.size() && arg_types[i]) ? arg_types[i] : nullptr));
+        specs.push_back(makeUDFArgSpec(
+            arguments[i],
+            (i < arg_types.size() && arg_types[i]) ? arg_types[i] : nullptr,
+            i < arg_wants_bytes.size() && arg_wants_bytes[i]));
 
     const DB::DataTypePtr result_actual_type = DB::removeNullable(return_type);
 

--- a/programs/local/PythonScalarUDF.h
+++ b/programs/local/PythonScalarUDF.h
@@ -5,6 +5,8 @@
 #include <Functions/IFunction.h>
 #include <DataTypes/IDataType.h>
 
+#include <vector>
+
 
 namespace CHDB
 {
@@ -58,6 +60,10 @@ private:
     py::function func;
     DB::DataTypePtr return_type;
     DB::DataTypes arg_types;
+    /// Parallel to arg_types: whether the argument was declared with the Python
+    /// bytes/bytearray annotation. Such arguments receive a Python `bytes` value
+    /// instead of `str`, keeping the String column binary-safe.
+    std::vector<bool> arg_wants_bytes;
     size_t num_args;
     bool is_variadic;
     NullHandling null_handling;

--- a/tests/test_func_udf_types.py
+++ b/tests/test_func_udf_types.py
@@ -4776,6 +4776,14 @@ class TestBytesUDF(unittest.TestCase):
         self.assertEqual(str(ret).strip(), '"mv"')
         chdb.drop_function("ret_mv")
 
+    def test_return_non_contiguous_memoryview(self):
+        # PyBytes_FromObject materializes a contiguous copy, so a strided view
+        # must survive intact (guards against a future raw-buffer-copy refactor).
+        chdb.create_function("ret_mv_sliced", lambda: memoryview(b"abcdef")[::2], return_type=bytes)
+        ret = self.session.query("SELECT ret_mv_sliced()", "CSV")
+        self.assertEqual(str(ret).strip(), '"ace"')
+        chdb.drop_function("ret_mv_sliced")
+
     def test_return_bytes_is_binary_safe(self):
         # Non-UTF-8 bytes must survive verbatim; assert via hex() to avoid CSV
         # encoding ambiguity.
@@ -4860,6 +4868,25 @@ class TestBytesUDF(unittest.TestCase):
         ret = self.session.query("SELECT bytes_to_hex(unhex('00FF'))", "CSV")
         self.assertEqual(str(ret).strip(), '"00FF"')
         chdb.drop_function("bytes_to_hex")
+
+    def test_bytes_arg_null_literal_skipped(self):
+        # Default on_null='skip': a NULL argument yields NULL without calling the
+        # UDF, same as every other type — the bytes fast path checks isNullAt first.
+        chdb.create_function("arg_upper_n", lambda x: x.upper(), arg_types=[bytes], return_type=bytes)
+        ret = self.session.query("SELECT arg_upper_n(NULL)", "CSV")
+        self.assertEqual(str(ret).strip(), "\\N")
+        chdb.drop_function("arg_upper_n")
+
+    def test_bytes_arg_nullable_column_mix(self):
+        # NULL rows become NULL; non-NULL rows still receive bytes and run.
+        chdb.create_function("arg_upper_c", lambda x: x.upper(), arg_types=[bytes], return_type=bytes)
+        ret = self.session.query(
+            "SELECT arg_upper_c(x) FROM "
+            "(SELECT v AS x FROM values('v Nullable(String)', ('ab'), (NULL), ('cd')))",
+            "CSV",
+        )
+        self.assertEqual(str(ret).strip(), '"AB"\n\\N\n"CD"')
+        chdb.drop_function("arg_upper_c")
 
     # ── end-to-end binary round-trip: def f(x: bytes) -> bytes ──
 

--- a/tests/test_func_udf_types.py
+++ b/tests/test_func_udf_types.py
@@ -4732,5 +4732,146 @@ class TestDateTime64UDF(unittest.TestCase):
         chdb.drop_function("dt64_py_callable")
 
 
+class TestBytesUDF(unittest.TestCase):
+    """bytes / bytearray / memoryview support (chdb-core#115).
+
+    ClickHouse String is binary-safe. The Python bytes / bytearray annotations
+    map to String, and values carry raw bytes in both directions: returning
+    bytes/bytearray/memoryview inserts the bytes verbatim, and a bytes-declared
+    argument receives a Python ``bytes`` value rather than a UTF-8-decoded str.
+    """
+
+    def setUp(self):
+        self.session = Session()
+
+    def tearDown(self):
+        self.session.close()
+
+    # ── return direction: the exact issue repro ──
+
+    def test_return_bytes_value(self):
+        # Before the fix this raised:
+        #   Cannot convert Python object of type '<class 'bytes'>' to String
+        chdb.create_function("ret_bytes", lambda: b"xy", arg_types=[], return_type=bytes)
+        ret = self.session.query("SELECT ret_bytes()", "CSV")
+        self.assertEqual(str(ret).strip(), '"xy"')
+        chdb.drop_function("ret_bytes")
+
+    def test_return_str_with_bytes_return_type_still_works(self):
+        # A str return into a bytes-declared (String) column keeps working.
+        chdb.create_function("ret_str", lambda: "xy", arg_types=[], return_type=bytes)
+        ret = self.session.query("SELECT ret_str()", "CSV")
+        self.assertEqual(str(ret).strip(), '"xy"')
+        chdb.drop_function("ret_str")
+
+    def test_return_bytearray_value(self):
+        chdb.create_function("ret_ba", lambda: bytearray(b"hello"), return_type=bytes)
+        ret = self.session.query("SELECT ret_ba()", "CSV")
+        self.assertEqual(str(ret).strip(), '"hello"')
+        chdb.drop_function("ret_ba")
+
+    def test_return_memoryview_value(self):
+        chdb.create_function("ret_mv", lambda: memoryview(b"mv"), return_type=bytes)
+        ret = self.session.query("SELECT ret_mv()", "CSV")
+        self.assertEqual(str(ret).strip(), '"mv"')
+        chdb.drop_function("ret_mv")
+
+    def test_return_bytes_is_binary_safe(self):
+        # Non-UTF-8 bytes must survive verbatim; assert via hex() to avoid CSV
+        # encoding ambiguity.
+        chdb.create_function("ret_raw", lambda: b"\x00\x01\xff\xfe", return_type=bytes)
+        ret = self.session.query("SELECT hex(ret_raw())", "CSV")
+        self.assertEqual(str(ret).strip(), '"0001FFFE"')
+        chdb.drop_function("ret_raw")
+
+    def test_return_bytes_length(self):
+        chdb.create_function("ret_len5", lambda: b"abcde", return_type=bytes)
+        ret = self.session.query("SELECT length(ret_len5())", "CSV")
+        self.assertEqual(str(ret).strip(), "5")
+        chdb.drop_function("ret_len5")
+
+    def test_return_empty_bytes(self):
+        chdb.create_function("ret_empty", lambda: b"", return_type=bytes)
+        ret = self.session.query("SELECT length(ret_empty())", "CSV")
+        self.assertEqual(str(ret).strip(), "0")
+        chdb.drop_function("ret_empty")
+
+    def test_return_bytes_inferred_from_annotation(self):
+        def make_bytes() -> bytes:
+            return b"zz"
+
+        chdb.create_function("ret_bytes_ann", make_bytes)
+        ret = self.session.query("SELECT ret_bytes_ann()", "CSV")
+        self.assertEqual(str(ret).strip(), '"zz"')
+        chdb.drop_function("ret_bytes_ann")
+
+    def test_return_bytes_to_non_string_type_raises(self):
+        # Returning bytes where the column is not String is a clear error.
+        chdb.create_function("ret_bytes_bad", lambda: b"xy", arg_types=[], return_type=INT64)
+        with self.assertRaises(Exception):
+            self.session.query("SELECT ret_bytes_bad()", "CSV")
+        chdb.drop_function("ret_bytes_bad")
+
+    # ── input direction: bytes-declared argument receives Python bytes ──
+
+    def test_bytes_arg_receives_bytes_explicit(self):
+        chdb.create_function("arg_kind", lambda x: type(x).__name__, arg_types=[bytes], return_type=STRING)
+        ret = self.session.query("SELECT arg_kind('abc')", "CSV")
+        self.assertEqual(str(ret).strip(), '"bytes"')
+        chdb.drop_function("arg_kind")
+
+    def test_bytes_arg_receives_bytes_annotation(self):
+        def kind(x: bytes) -> str:
+            return type(x).__name__
+
+        chdb.create_function("arg_kind_ann", kind)
+        ret = self.session.query("SELECT arg_kind_ann('abc')", "CSV")
+        self.assertEqual(str(ret).strip(), '"bytes"')
+        chdb.drop_function("arg_kind_ann")
+
+    def test_bytearray_arg_receives_bytes(self):
+        # bytearray annotation also maps to String; the value is delivered as
+        # (immutable) bytes.
+        chdb.create_function("arg_kind_ba", lambda x: type(x).__name__, arg_types=[bytearray], return_type=STRING)
+        ret = self.session.query("SELECT arg_kind_ba('abc')", "CSV")
+        self.assertEqual(str(ret).strip(), '"bytes"')
+        chdb.drop_function("arg_kind_ba")
+
+    def test_str_arg_still_receives_str(self):
+        # No regression: a str-declared argument still receives a str.
+        chdb.create_function("arg_kind_str", lambda x: type(x).__name__, arg_types=[STRING], return_type=STRING)
+        ret = self.session.query("SELECT arg_kind_str('abc')", "CSV")
+        self.assertEqual(str(ret).strip(), '"str"')
+        chdb.drop_function("arg_kind_str")
+
+    def test_bytes_arg_value_content(self):
+        # The bytes value carries the actual column bytes.
+        chdb.create_function("arg_upper", lambda x: x.upper(), arg_types=[bytes], return_type=bytes)
+        ret = self.session.query("SELECT arg_upper('abc')", "CSV")
+        self.assertEqual(str(ret).strip(), '"ABC"')
+        chdb.drop_function("arg_upper")
+
+    def test_bytes_arg_binary_input_not_utf8(self):
+        # A bytes-declared arg receives raw non-UTF-8 bytes without a decode error.
+        def to_hex(x: bytes) -> str:
+            return x.hex().upper()
+
+        chdb.create_function("bytes_to_hex", to_hex)
+        ret = self.session.query("SELECT bytes_to_hex(unhex('00FF'))", "CSV")
+        self.assertEqual(str(ret).strip(), '"00FF"')
+        chdb.drop_function("bytes_to_hex")
+
+    # ── end-to-end binary round-trip: def f(x: bytes) -> bytes ──
+
+    def test_bytes_round_trip_binary_safe(self):
+        def echo(x: bytes) -> bytes:
+            return x
+
+        chdb.create_function("bytes_echo", echo)
+        ret = self.session.query("SELECT hex(bytes_echo(unhex('0001FFFE')))", "CSV")
+        self.assertEqual(str(ret).strip(), '"0001FFFE"')
+        chdb.drop_function("bytes_echo")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #115.

Python UDFs already mapped the `bytes` / `bytearray` annotations to `String` at registration, but returning an actual `bytes` value threw at query time, and a `bytes`-declared argument was handed a UTF-8-decoded `str`. ClickHouse `String` is binary-safe, so this carries raw bytes in both directions:

- **Return**: `bytes` / `bytearray` / `memoryview` values insert their raw bytes into the `String` column instead of throwing.
- **Argument**: a `bytes` / `bytearray`-declared parameter receives a Python `bytes` value instead of a `str`.

So `def f(x: bytes) -> bytes: ...` now works end-to-end, binary-safe.

The C-API calls used are all in the Python 3.9 stable ABI (the abi3 build sets `Py_LIMITED_API=0x03090000`); the buffer protocol is avoided since it only entered the limited API in 3.11.

Tests: added `TestBytesUDF` to `tests/test_func_udf_types.py` (return bytes/bytearray/memoryview, binary-safe round-trip, bytes/bytearray input args, str no-regression). Full `test_func_udf*.py` suites pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support bytes/bytearray/memoryview values in Python UDFs
> - Arguments annotated with `bytes` or `bytearray` in a Python UDF signature are now delivered to the function as `bytes` instead of a decoded `str`, using the fast conversion path in `convertArgFast`.
> - Return values of type `bytes`, `bytearray`, or `memoryview` are now accepted when the result column type is `String`, inserted verbatim via the new `handleBytes` function in [PythonScalarUDF.cpp](https://github.com/chdb-io/chdb-core/pull/162/files#diff-15a92bfc453d48a634f28e83e87266a457063d77479647d9c25962db9e75494f).
> - A parallel `arg_wants_bytes` vector tracks per-argument byte delivery intent, populated during signature inference and explicit type resolution.
> - New tests in [test_func_udf_types.py](https://github.com/chdb-io/chdb-core/pull/162/files#diff-b3ba44e9eabe389a489366eb771a7113fcd1ee927af4c00904d034a5a5e1b346) cover binary round-trips, NULL handling, empty/length edge cases, and error behavior when returning bytes to a non-String column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 931ed30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->