### PR TITLE
Avoid leak in connect_chdb_with_exception if allocation fails

### DIFF
--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -204,15 +204,17 @@ chdb_connection * connect_chdb_with_exception(int argc, char ** argv)
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Failed to create ChdbClient");
         }
 
-        auto * conn = new chdb_conn();
-        conn->server = client.release();
+        auto conn = std::make_unique<chdb_conn>();
+        conn->server = client.get();
         conn->connected = true;
-        auto ** conn_ptr = new chdb_conn *(conn);
+        auto conn_ptr = std::make_unique<chdb_conn *>(conn.get());
 
         if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
             chdb_reset_signal_handlers();
 
-        return reinterpret_cast<chdb_connection *>(conn_ptr);
+        client.release();
+        conn.release();
+        return reinterpret_cast<chdb_connection *>(conn_ptr.release());
     }
     catch (const DB::Exception & e)
     {
@@ -1332,9 +1334,7 @@ void chdb_set_signal_handlers_enabled(int enabled)
 
 void chdb_reset_signal_handlers(void)
 {
-    static const std::vector<int> deadly_signals = {
-        SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGTSTP, SIGTRAP
-    };
+    static constexpr int deadly_signals[] = {SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGTSTP, SIGTRAP};
 
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
@@ -1345,6 +1345,6 @@ void chdb_reset_signal_handlers(void)
     for (int sig : deadly_signals)
         sigaction(sig, &sa, nullptr);
 
-    auto & instance = HandledSignals::instance();
-    instance.handled_signals.clear();
+    if (auto * instance = HandledSignals::tryGetInstance())
+        instance->handled_signals.clear();
 }

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -46,6 +46,7 @@ using namespace DB;
 
 
 std::atomic<bool> HandledSignals::disable_signal_handlers = false;
+std::atomic<HandledSignals *> HandledSignals::instance_ptr = nullptr;
 
 static std::atomic_bool is_crashed = false;
 static_assert(std::atomic_bool::is_always_lock_free, "is_crashed must be lock-free for use in signal handlers");
@@ -698,6 +699,7 @@ HandledSignals::HandledSignals()
 {
     signal_pipe.setNonBlockingWrite();
     signal_pipe.tryIncreaseSize(1 << 20);
+    instance_ptr.store(this, std::memory_order_release);
 }
 
 void HandledSignals::reset(bool close_pipe)
@@ -728,6 +730,7 @@ void HandledSignals::reset(bool close_pipe)
 
 HandledSignals::~HandledSignals()
 {
+    instance_ptr.store(nullptr, std::memory_order_release);
     try
     {
         reset();
@@ -742,6 +745,11 @@ HandledSignals & HandledSignals::instance()
 {
     static HandledSignals res;
     return res;
+}
+
+HandledSignals * HandledSignals::tryGetInstance()
+{
+    return instance_ptr.load(std::memory_order_acquire);
 }
 
 void HandledSignals::setupTerminateHandler()

--- a/src/Common/SignalHandlers.h
+++ b/src/Common/SignalHandlers.h
@@ -142,4 +142,8 @@ struct HandledSignals
     void reset(bool close_pipe = true);
 
     static HandledSignals & instance();
+    static HandledSignals * tryGetInstance();
+
+private:
+    static std::atomic<HandledSignals *> instance_ptr;
 };

--- a/tests/test_signal_handler_api.py
+++ b/tests/test_signal_handler_api.py
@@ -15,6 +15,7 @@ import ctypes
 import ctypes.util
 import os
 import signal
+import subprocess
 import sys
 import unittest
 
@@ -202,7 +203,34 @@ class TestSignalHandlerControlAPI(unittest.TestCase):
             self.assertNotEqual(handler, 0,
                 "Handler must be installed after re-enabling (cycle iteration)")
 
-    # Test 6: concurrent enable/disable calls are thread-safe
+    # Test 6: disabling remains non-throwing when signal pipe creation fails
+    @unittest.skipIf(sys.platform == "win32", "requires POSIX file descriptors")
+    def test_disable_with_exhausted_file_descriptors(self):
+        script = """
+import os
+import resource
+import chdb
+
+_, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+limit = 64 if hard_limit == resource.RLIM_INFINITY else min(64, hard_limit)
+resource.setrlimit(resource.RLIMIT_NOFILE, (limit, limit))
+fds = []
+while True:
+    try:
+        fds.append(os.open('/dev/null', os.O_RDONLY))
+    except OSError:
+        break
+chdb._chdb.set_signal_handlers_enabled(0)
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    # Test 7: concurrent enable/disable calls are thread-safe
     def test_concurrent_enable_disable_no_crash(self):
         """Calling set_signal_handlers_enabled from multiple threads must not crash."""
         import threading


### PR DESCRIPTION
Also update so that `chdb_reset_signal_handlers` doesn't construct instance, includes test where file descriptor exhaustion lead to C++ exception crossing C API

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix resource leak in `connect_chdb_with_exception` when allocation fails
> - Rewrites `connect_chdb_with_exception` in [chdb.cpp](https://github.com/chdb-io/chdb-core/pull/166/files#diff-1e6f177972b741a03317763e7c2e41acac81949dabfd2913b21dd48dc0cf6e12) to use `std::unique_ptr` for `chdb_conn` and its wrapper, releasing ownership only on the success path to prevent leaks on early returns or exceptions.
> - Adds `HandledSignals::tryGetInstance()` to [SignalHandlers.cpp](https://github.com/chdb-io/chdb-core/pull/166/files#diff-fad605bbbc0d5f09f2703e2e6e3009609d478e5c6c6e25b78ced92acda02c3f6) and [SignalHandlers.h](https://github.com/chdb-io/chdb-core/pull/166/files#diff-a011a18006d4cc4507f986f8a888a23bd60a8363a40b5303454bcb6335bd89a0), backed by a `static std::atomic<HandledSignals*> instance_ptr` updated in the constructor and destructor.
> - Updates `chdb_reset_signal_handlers` to use `tryGetInstance()` so it no longer constructs the `HandledSignals` singleton as a side effect when none exists.
> - Adds a POSIX test in [test_signal_handler_api.py](https://github.com/chdb-io/chdb-core/pull/166/files#diff-cc264d9c5a6d3048aa41434d828099fe36a94431970704ef2971350601439de1) that exhausts file descriptors and verifies `set_signal_handlers_enabled(0)` exits cleanly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 522c4c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->