### PR TITLE
Fix handled_signals data race and leaked connection cell

### DIFF
--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -345,6 +345,14 @@ void close_conn(chdb_conn ** conn)
     {
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);
     }
+
+    /// Free the outer one-pointer cell itself. `conn` points at the heap cell
+    /// allocated as `new chdb_conn *(...)` in connect_chdb_with_exception(); the
+    /// inner chdb_conn (*conn) is deleted above, but the cell holding that pointer
+    /// was leaked on every connection close before this. The cell is owned solely
+    /// by close_conn's caller and is not reused after close, so deleting it here is
+    /// safe and centralizes the fix for both chdb_close_conn and direct C-API users.
+    delete conn;
 }
 
 struct local_result_v2 * query_conn(chdb_conn * conn, const char * query, const char * format)
@@ -1346,5 +1354,13 @@ void chdb_reset_signal_handlers(void)
         sigaction(sig, &sa, nullptr);
 
     if (auto * instance = HandledSignals::tryGetInstance())
+    {
+        /// Serialize the clear against concurrent appends in addSignalHandler()
+        /// (e.g. the EmbeddedServer connect path, which runs outside CHDB_MUTEX) and
+        /// against other concurrent chdb_reset_signal_handlers() callers. This leaf lock
+        /// is acquired last and released here, so it cannot deadlock with CHDB_MUTEX even
+        /// when this function is called while CHDB_MUTEX is held (pyEntryClickHouseLocal).
+        std::lock_guard<std::mutex> lock(instance->handled_signals_mutex);
         instance->handled_signals.clear();
+    }
 }

--- a/programs/local/chdb.hpp
+++ b/programs/local/chdb.hpp
@@ -275,6 +275,10 @@ public:
         {
             throw ChdbError(ChdbErrorCode::ConnectionFailed, "Failed to create database connection");
         }
+        /// `conn_ptr` is the heap-allocated outer cell that owns the connection and MUST be
+        /// handed back to chdb_close_conn() so the cell itself is freed. Keep it (previously
+        /// it was dropped here, leaking the cell) and derive the inner handle for queries.
+        conn_owner_ = conn_ptr;
         conn_ = *conn_ptr;
     }
 
@@ -284,8 +288,10 @@ public:
     explicit Connection(const std::string& path) : Connection(std::vector<std::string>{"--path=" + path}) {}
 
     ~Connection() {
-        if (conn_) {
-            chdb_close_conn(&conn_);
+        if (conn_owner_) {
+            chdb_close_conn(conn_owner_);
+            conn_owner_ = nullptr;
+            conn_ = nullptr;
         }
     }
 
@@ -295,17 +301,20 @@ public:
     Connection& operator=(const Connection&) = delete;
 
     /** Move constructor - transfers connection ownership */
-    Connection(Connection&& other) noexcept : conn_(other.conn_) {
+    Connection(Connection&& other) noexcept : conn_owner_(other.conn_owner_), conn_(other.conn_) {
+        other.conn_owner_ = nullptr;
         other.conn_ = nullptr;
     }
 
     /** Move assignment - transfers connection ownership */
     Connection& operator=(Connection&& other) noexcept {
         if (this != &other) {
-            if (conn_) {
-                chdb_close_conn(&conn_);
+            if (conn_owner_) {
+                chdb_close_conn(conn_owner_);
             }
+            conn_owner_ = other.conn_owner_;
             conn_ = other.conn_;
+            other.conn_owner_ = nullptr;
             other.conn_ = nullptr;
         }
         return *this;
@@ -364,7 +373,10 @@ public:
     }
 
 private:
-    chdb_connection conn_;
+    /// Owning outer cell (chdb_connection*), handed to chdb_close_conn() to free both
+    /// the connection and the cell. `conn_` is the non-owning inner handle used for queries.
+    chdb_connection * conn_owner_ = nullptr;
+    chdb_connection conn_ = nullptr;
 };
 
 /** Iterator for streaming query results */

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -249,7 +249,7 @@ static DISABLE_SANITIZER_INSTRUMENTATION void sanitizerDeathCallback()
     /// Sanitizer errors cannot be handled properly with our signal handlers, because it leads to deadlock.
     /// So we need to reset the signal handlers (this does not lead to deadlock),
     /// but closing the pipe leads to deadlock from death callback, so we will not close it.
-    HandledSignals::instance().reset(/* close_pipe= */ false);
+    HandledSignals::instance().reset(/* close_pipe= */ false, /* lock= */ false);
 }
 #endif
 
@@ -284,7 +284,10 @@ void HandledSignals::addSignalHandler(const std::vector<int> & signals, signal_f
             throw Poco::Exception("Cannot set signal handler.");
 
     if (register_signal)
+    {
+        std::lock_guard<std::mutex> lock(handled_signals_mutex);
         std::copy(signals.begin(), signals.end(), std::back_inserter(handled_signals));
+    }
 #endif
 }
 
@@ -702,8 +705,15 @@ HandledSignals::HandledSignals()
     instance_ptr.store(this, std::memory_order_release);
 }
 
-void HandledSignals::reset(bool close_pipe)
+void HandledSignals::reset(bool close_pipe, bool lock)
 {
+    /// `lock` must be false on the async-signal / sanitizer-death-callback path, where
+    /// std::mutex is neither async-signal-safe nor allocation-free. std::unique_lock with
+    /// defer_lock lets us conditionally acquire without duplicating the reset body.
+    std::unique_lock<std::mutex> guard(handled_signals_mutex, std::defer_lock);
+    if (lock)
+        guard.lock();
+
 #if !defined(OS_WASM)
     /// Reset signals to SIG_DFL to avoid trying to write to the signal_pipe that will be closed after.
     for (int sig : handled_signals)

--- a/src/Common/SignalHandlers.h
+++ b/src/Common/SignalHandlers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <csignal>
+#include <mutex>
 
 #include <base/defines.h>
 #include <Common/Logger_fwd.h>
@@ -122,6 +123,14 @@ private:
 struct HandledSignals
 {
     std::vector<int> handled_signals;
+    /// Serializes all non-signal-context accesses to `handled_signals`.
+    /// chdb appends (addSignalHandler) and clears (reset / chdb_reset_signal_handlers)
+    /// happen from several threads under different outer mutexes (CHDB_MUTEX,
+    /// EmbeddedServer::instance_mutex, or no lock at all), so the vector needs its
+    /// own leaf-level lock. This lock is acquired last and released before returning,
+    /// so it can never participate in a lock-ordering cycle. It is intentionally NOT
+    /// taken on the async-signal / sanitizer-death-callback path (reset(lock=false)).
+    std::mutex handled_signals_mutex;
     DB::PipeFDs signal_pipe;
     std::atomic_flag fatal_error_printed;
 
@@ -139,7 +148,11 @@ struct HandledSignals
 
     void addSignalHandler(const std::vector<int> & signals, signal_function handler, bool register_signal);
 
-    void reset(bool close_pipe = true);
+    /// `lock` guards `handled_signals` with handled_signals_mutex. It MUST be false
+    /// when called from an async-signal / death-callback context (sanitizerDeathCallback),
+    /// where taking a std::mutex is neither async-signal-safe nor allocation-free and
+    /// could deadlock against a thread interrupted mid-append.
+    void reset(bool close_pipe = true, bool lock = true);
 
     static HandledSignals & instance();
     static HandledSignals * tryGetInstance();


### PR DESCRIPTION
Fixes #171.

### 1. Data race on `HandledSignals::handled_signals`

`handled_signals` (`std::vector<int>`) is appended by `addSignalHandler` and cleared by `reset()` / `chdb_reset_signal_handlers()` from several threads under **different** outer locks (`CHDB_MUTEX` on the query path, `EmbeddedServer::instance_mutex` on the connect path, or no lock at all in the C-API reset callers). Concurrent read/write or write/write on the vector is a data race → heap corruption → SIGSEGV under load.

Fix: give `handled_signals` a dedicated **leaf** mutex (`handled_signals_mutex`) taken at every non-signal access site (append, `reset()`, and the `chdb_reset_signal_handlers` clear). It is the single point of mutual exclusion regardless of which outer lock (if any) the caller holds.

- **Deadlock-safe:** the leaf is never held across `CHDB_MUTEX` / `instance_mutex`. Crucially, `chdb_reset_signal_handlers` does **not** take `CHDB_MUTEX` — `pyEntryClickHouseLocal` already holds that non-recursive mutex when it calls the reset path, so doing so would self-deadlock (and still wouldn't cover the `EmbeddedServer` append under a different lock).
- **Async-signal-safe:** `reset()` gains a `lock` parameter (default `true`); the sanitizer death-callback passes `lock=false` so no `std::mutex` is touched on the crash path (preserving `DENY_ALLOCATIONS_IN_SCOPE` semantics).

### 2. Leaked outer connection cell in `close_conn`

`connect_chdb_with_exception` returns `new chdb_conn *(conn)`; `close_conn` freed the inner `chdb_conn` + `ChdbClient` but never that outer cell — one pointer leaked per close.

Fix: `delete conn` in `close_conn`. Required companion change: the C++ `Connection` wrapper in `chdb.hpp` now owns the outer cell (`conn_owner_`) and hands it to `chdb_close_conn`, instead of passing `&conn_` — otherwise the new `delete` would bad-free a member address. Audited all other C-API callers (Python `connection_wrapper`, ADBC, wasm): all already pass the owning cell and null it after close, so no double-free.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix data race in `HandledSignals` and memory leak in `close_conn`
> - Adds `handled_signals_mutex` to `HandledSignals` and locks it in `addSignalHandler` and `reset` to prevent data races between concurrent signal registration and reset calls.
> - Updates `HandledSignals::reset` to accept a `lock` parameter so the sanitizer death callback can skip mutex acquisition in async-signal context.
> - Fixes a per-call memory leak in `close_conn` by deleting the outer `chdb_conn**` heap cell after freeing the inner connection.
> - Updates `local::Connection` in [chdb.hpp](https://github.com/chdb-io/chdb-core/pull/172/files#diff-922071325bf9d80be2536bf8cf9ba37811761d7927fb7da0f1de31587ae87c69) to retain ownership of the outer connection cell via `conn_owner_`, ensuring move construction, move assignment, and destruction all correctly transfer and free both pointer levels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98c34a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->