### PR TITLE
Fix DROP SYNC in fresh persistent sessions

### DIFF
--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -991,7 +991,8 @@ void EmbeddedServer::processConfig()
         fs::create_directories(fs::path(path));
         status.emplace(fs::path(path) / "status", StatusFile::write_full_info);
 
-        if (fs::exists(fs::path(path) / "metadata"))
+        const bool metadata_exists = fs::exists(fs::path(path) / "metadata");
+        if (metadata_exists)
         {
             LOG_DEBUG(log, "Loading metadata from {}", path);
 
@@ -1014,6 +1015,15 @@ void EmbeddedServer::processConfig()
             }
 
             LOG_DEBUG(log, "Loaded metadata.");
+        }
+
+        /// A fresh persistent path has no metadata directory yet. DDL executed by
+        /// the first session can create it, so start the cleanup tasks even when
+        /// there was no metadata to load. Otherwise DROP ... SYNC waits forever.
+        if (!metadata_exists && !config().has("only-system-tables"))
+        {
+            DatabaseCatalog::instance().createBackgroundTasks();
+            DatabaseCatalog::instance().startupBackgroundTasks();
         }
 
         if (!attached_system_database)

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1690,7 +1690,8 @@ void LocalServer::processConfig()
         fs::create_directories(fs::path(path));
         status.emplace(fs::path(path) / "status", StatusFile::write_full_info);
 
-        if (fs::exists(fs::path(path) / "metadata"))
+        const bool metadata_exists = fs::exists(fs::path(path) / "metadata");
+        if (metadata_exists)
         {
             LOG_DEBUG(log, "Loading metadata from {}", path);
 
@@ -1712,6 +1713,15 @@ void LocalServer::processConfig()
             }
 
             LOG_DEBUG(log, "Loaded metadata.");
+        }
+
+        /// A fresh persistent path has no metadata directory yet. DDL executed by
+        /// the first session can create it, so start the cleanup tasks even when
+        /// there was no metadata to load. Otherwise DROP ... SYNC waits forever.
+        if (!metadata_exists && !getClientConfiguration().has("only-system-tables"))
+        {
+            DatabaseCatalog::instance().createBackgroundTasks();
+            DatabaseCatalog::instance().startupBackgroundTasks();
         }
 
         if (!attached_system_database)

--- a/tests/test_drop_table.py
+++ b/tests/test_drop_table.py
@@ -1,6 +1,10 @@
 #!python3
 
 import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
 import unittest
 from chdb import session
 
@@ -43,6 +47,37 @@ class TestDropTable(unittest.TestCase):
         sess.query("DROP TABLE test_table_2 SYNC")
 
         sess.close()
+
+    def test_drop_table_sync_in_first_persistent_session(self):
+        child = textwrap.dedent(
+            """
+            import sys
+            from chdb import session
+
+            sess = session.Session(sys.argv[1])
+            sess.query(
+                "CREATE TABLE first_session "
+                "(value String) ENGINE = MergeTree ORDER BY value"
+            )
+            sess.query("DROP TABLE first_session SYNC")
+            sess.close()
+            """
+        )
+
+        with tempfile.TemporaryDirectory(prefix="chdb-drop-sync-") as state_path:
+            result = subprocess.run(
+                [sys.executable, "-c", child, state_path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"child stdout:\n{result.stdout}\nchild stderr:\n{result.stderr}",
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Changelog category

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry

Fix `DROP TABLE ... SYNC` hanging when a table is created in the first persistent chDB session for a new path.

### What was happening

`EmbeddedServer::processConfig()` and `LocalServer::processConfig()` only created the database catalog background tasks when the metadata directory already existed.

A new persistent path has no metadata directory during startup. The first DDL statement creates it later, but the drop cleanup task remains uninitialized. `DROP TABLE ... SYNC` then waits for cleanup that cannot be scheduled and never returns.

The existing test did not catch this because it performed the synchronous drop after reopening the path. By that point the metadata directory existed and the background task was started.

### What changed

- Start the existing database catalog background tasks when a persistent path is new and user tables are enabled.
- Preserve the current metadata loading order for existing paths.
- Preserve the existing `only-system-tables` behavior.
- Add a subprocess test with a timeout for the first-session case, so a regression cannot hang the test suite.

### Validation

- Both focused Python tests pass against the locally built module.
- A standalone `clickhouse local --path=<new-directory>` build completes create, synchronous drop, and absence verification in the first process.
- MergeTree, IcebergLocal, asynchronous drop, reopen, and live query-result lifecycle cases were also exercised locally.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `DROP ... SYNC` blocking indefinitely in fresh persistent sessions
> When a persistent path has no metadata directory, `DatabaseCatalog` background tasks were never started, causing `DROP ... SYNC` to block indefinitely. Both [EmbeddedServer.cpp](https://github.com/chdb-io/chdb-core/pull/173/files#diff-b40e2cd65195a45a5e28818eb8a4abb4f0b06a149aad063577c767414136191b) and [LocalServer.cpp](https://github.com/chdb-io/chdb-core/pull/173/files#diff-e606245fd4a9bed218932b9548398a29fb2834f7d4bdd683b241b40d01516829) now detect this case and proactively create and start those tasks. A regression test in [test_drop_table.py](https://github.com/chdb-io/chdb-core/pull/173/files#diff-cfcc4390a3f907de24104ad41c20745670a092b281cceb199885a91a6509fc14) verifies the fix by running a child process that creates a table and drops it with `SYNC` on a fresh persistent path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6c5986.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->