### PR TITLE
Speed up pandas DataFrame scans: metadata cache, zero-copy mounts, jemalloc background threads

### DIFF
--- a/contrib/jemalloc-cmake/include_linux_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -405,7 +405,7 @@
 /*
  * If defined, all the features necessary for background threads are present.
  */
-/* #undef JEMALLOC_BACKGROUND_THREAD */
+#define JEMALLOC_BACKGROUND_THREAD
 
 /*
  * If defined, jemalloc symbols are not exported (doesn't work when

--- a/contrib/jemalloc-cmake/include_linux_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -405,7 +405,7 @@
 /*
  * If defined, all the features necessary for background threads are present.
  */
-/* #undef JEMALLOC_BACKGROUND_THREAD */
+#define JEMALLOC_BACKGROUND_THREAD
 
 /*
  * If defined, jemalloc symbols are not exported (doesn't work when

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -73,6 +73,7 @@ if (USE_PYTHON)
         ChdbPyType.cpp
         PythonScalarUDF.cpp
         PythonUDFRegistry.cpp
+        PyBorrowGuard.cpp
         PythonArrowStream.cpp
         PythonReader.cpp
         PythonTableCache.cpp

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -289,6 +289,10 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
         DB::ThreadStatus thread_status;
         if (!parseQueryTextWithOutputFormat(query_str, format_str))
         {
+#if USE_PYTHON
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
+            python_table_cache->clear();
+#endif
             return std::make_unique<CHDB::MaterializedQueryResult>(getErrorMsg());
         }
         auto * local_connection = static_cast<LocalConnection *>(connection.get());
@@ -372,6 +376,10 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
         if (!parseQueryTextWithOutputFormat(query_str, format_str))
         {
             streaming_query_context.reset();
+#if USE_PYTHON
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
+            python_table_cache->clear();
+#endif
             return std::make_unique<CHDB::StreamQueryResult>(getErrorMsg());
         }
         streaming_query_context->thread_group = DB::CurrentThread::getGroup();
@@ -383,11 +391,21 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
     catch (const Exception & e)
     {
         streaming_query_context.reset();
+#if USE_PYTHON
+        if (connection)
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
+        python_table_cache->clear();
+#endif
         return std::make_unique<CHDB::StreamQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
     catch (...)
     {
         streaming_query_context.reset();
+#if USE_PYTHON
+        if (connection)
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
+        python_table_cache->clear();
+#endif
         return std::make_unique<CHDB::StreamQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
 }

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -310,6 +310,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
                 rows_written,
                 bytes_written);
 #if USE_PYTHON
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
             python_table_cache->clear();
 #endif
             return res;
@@ -325,6 +326,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
             rows_written,
             bytes_written);
 #if USE_PYTHON
+        (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
         python_table_cache->clear();
 #endif
         return res;
@@ -332,6 +334,8 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
     catch (const Exception & e)
     {
 #if USE_PYTHON
+        if (connection)
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
         python_table_cache->clear();
 #endif
         return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, print_stack_trace));
@@ -339,6 +343,8 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
     catch (...)
     {
 #if USE_PYTHON
+        if (connection)
+            (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
         python_table_cache->clear();
 #endif
         return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(print_stack_trace));

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -57,6 +57,9 @@
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/Config/getLocalConfigPath.h>
 #include <Common/CurrentMetrics.h>
+#if USE_JEMALLOC
+#include <Common/Jemalloc.h>
+#endif
 #include <Common/ErrorHandlers.h>
 #include <Common/EventNotifier.h>
 #include <Common/Exception.h>
@@ -154,6 +157,8 @@ extern const ServerSettingsDouble max_server_memory_usage_to_ram_ratio;
 extern const ServerSettingsUInt64 max_thread_pool_free_size;
 extern const ServerSettingsUInt64 max_thread_pool_size;
 extern const ServerSettingsUInt64 max_unexpected_parts_loading_thread_pool_size;
+extern const ServerSettingsBool jemalloc_enable_background_threads;
+extern const ServerSettingsUInt64 jemalloc_max_background_threads_num;
 extern const ServerSettingsUInt64 mmap_cache_size;
 extern const ServerSettingsBool show_addresses_in_stack_traces;
 extern const ServerSettingsUInt64 thread_pool_queue_size;
@@ -237,6 +242,18 @@ void EmbeddedServer::initialize(Poco::Util::Application & self)
     }
 
     server_settings.loadSettingsFromConfig(config());
+
+#if USE_JEMALLOC
+    /// The compiled-in malloc_conf keeps jemalloc background threads OFF
+    /// (spawning them while the module is being dlopen'd crashes; see the
+    /// Linux chdb_spec in contrib/jemalloc-cmake). Enable them at runtime
+    /// instead, mirroring BaseDaemon for clickhouse-server: without them,
+    /// dirty-page purging runs synchronously on query threads and serializes
+    /// allocation-heavy aggregations on many-core machines.
+    Jemalloc::setBackgroundThreads(server_settings[ServerSetting::jemalloc_enable_background_threads]);
+    if (auto max_background_threads = server_settings[ServerSetting::jemalloc_max_background_threads_num])
+        Jemalloc::setMaxBackgroundThreads(max_background_threads);
+#endif
 
     GlobalThreadPool::initialize(
         server_settings[ServerSetting::max_thread_pool_size],

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -1,4 +1,5 @@
 #include "LocalChdb.h"
+#include "PyBorrowGuard.h"
 #include "chdb-internal.h"
 #include "DataFrameQueryResult.h"
 #include "PandasDataFrameBuilder.h"
@@ -486,6 +487,10 @@ py::object connection_wrapper::query_df(const std::string & query_str, const py:
     CHDB::PandasDataFrameBuilder builder(*chunk_result);
     auto df = builder.getDataFrame();
     chdb_destroy_query_result(result);
+    /// The destroyed chunks release their borrow guards after this query's
+    /// drain point; the GIL is held here, so settle the deferred decrefs now
+    /// instead of waiting for the next query.
+    CHDB::drainPyBorrowGuardQueue();
 
     return df;
 }
@@ -579,6 +584,7 @@ py::object connection_wrapper::streaming_fetch_df(streaming_query_result * strea
 
     py::handle df_handle = chunk_result->dataframe;
     chdb_destroy_query_result(result);
+    CHDB::drainPyBorrowGuardQueue();
 
     return py::reinterpret_steal<py::object>(df_handle);
 }

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -1,5 +1,7 @@
 #include "LocalChdb.h"
 #include "PyBorrowGuard.h"
+
+#include <base/scope_guard.h>
 #include "chdb-internal.h"
 #include "DataFrameQueryResult.h"
 #include "PandasDataFrameBuilder.h"
@@ -461,6 +463,19 @@ py::object connection_wrapper::query_df(const std::string & query_str, const py:
     chdb_result * result = nullptr;
     CHDB::ChunkQueryResult * chunk_result = nullptr;
 
+    /// Destroy the result and settle the deferred decrefs on every exit,
+    /// including exceptions thrown by the pandas conversion (which would
+    /// otherwise leak the chunks and their borrow guards outright). The GIL
+    /// is held at scope exit on all paths: the gil_scoped_release block below
+    /// is destructed before this guard runs.
+    SCOPE_EXIT({
+        if (result)
+        {
+            chdb_destroy_query_result(result);
+            CHDB::drainPyBorrowGuardQueue();
+        }
+    });
+
     const auto parsed_params = parseParametersDict(params);
     auto * client = getChdbClient(*conn);
     QueryParameterGuard guard(client, parsed_params);
@@ -474,11 +489,7 @@ py::object connection_wrapper::query_df(const std::string & query_str, const py:
 
         const auto & error_msg = CHDB::chdb_result_error_string(result);
         if (!error_msg.empty())
-        {
-            std::string msg_copy(error_msg);
-            chdb_destroy_query_result(result);
-            throw std::runtime_error(msg_copy);
-        }
+            throw std::runtime_error(std::string(error_msg));
 
         if (!(chunk_result = dynamic_cast<CHDB::ChunkQueryResult *>(reinterpret_cast<CHDB::QueryResult *>(result))))
             throw std::runtime_error("Expected ChunkQueryResult for dataframe format");
@@ -486,11 +497,6 @@ py::object connection_wrapper::query_df(const std::string & query_str, const py:
 
     CHDB::PandasDataFrameBuilder builder(*chunk_result);
     auto df = builder.getDataFrame();
-    chdb_destroy_query_result(result);
-    /// The destroyed chunks release their borrow guards after this query's
-    /// drain point; the GIL is held here, so settle the deferred decrefs now
-    /// instead of waiting for the next query.
-    CHDB::drainPyBorrowGuardQueue();
 
     return df;
 }
@@ -565,6 +571,14 @@ py::object connection_wrapper::streaming_fetch_df(streaming_query_result * strea
     chdb_result * result = nullptr;
     CHDB::DataFrameQueryResult * chunk_result = nullptr;
 
+    SCOPE_EXIT({
+        if (result)
+        {
+            chdb_destroy_query_result(result);
+            CHDB::drainPyBorrowGuardQueue();
+        }
+    });
+
     {
         py::gil_scoped_release release;
 
@@ -572,19 +586,13 @@ py::object connection_wrapper::streaming_fetch_df(streaming_query_result * strea
 
         const auto & error_msg = CHDB::chdb_result_error_string(result);
         if (!error_msg.empty())
-        {
-            std::string msg_copy(error_msg);
-            chdb_destroy_query_result(result);
-            throw std::runtime_error(msg_copy);
-        }
+            throw std::runtime_error(std::string(CHDB::chdb_result_error_string(result)));
 
         if (!(chunk_result = dynamic_cast<CHDB::DataFrameQueryResult *>(reinterpret_cast<CHDB::QueryResult*>(result))))
             throw std::runtime_error("Expected DataFrameQueryResult for dataframe format");
     }
 
     py::handle df_handle = chunk_result->dataframe;
-    chdb_destroy_query_result(result);
-    CHDB::drainPyBorrowGuardQueue();
 
     return py::reinterpret_steal<py::object>(df_handle);
 }

--- a/programs/local/LocalChdb.h
+++ b/programs/local/LocalChdb.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "PyBorrowGuard.h"
+
 #include "chdb.h"
 #include "ChdbPyType.h"
 #include "PybindWrapper.h"
@@ -194,6 +196,10 @@ public:
     ~streaming_query_result()
     {
         chdb_destroy_query_result(result);
+        /// Runs on a Python thread with the GIL held; settle borrow-guard
+        /// decrefs from any still-buffered batches instead of leaving them
+        /// queued until the next query.
+        CHDB::drainPyBorrowGuardQueue();
     }
     bool has_error() { return chdb_result_error(result) != nullptr; }
     py::str error_message()

--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -1,5 +1,6 @@
 #include "PandasDataFrame.h"
 #include "NumpyType.h"
+#include "PyBorrowGuard.h"
 
 #include <functional>
 #include <set>
@@ -296,6 +297,8 @@ static bool tryFillArrowStringColumn(DB::ColumnWrapper & column, const py::objec
     column.buf = chunked.ptr(); /// non-null sentinel, never dereferenced on this path
     column.tmp = chunked;       /// keep the ChunkedArray (and its buffers) alive
     column.tmp.inc_ref();
+    if (zeroCopyEnabled())
+        column.borrow_guard = makePyBorrowGuard(chunked.ptr());
     return true;
 }
 
@@ -426,6 +429,9 @@ void PandasDataFrame::fillColumn(
     column.stride = array.attr("strides").attr("__getitem__")(0).cast<size_t>();
     column.data = array;
     column.buf = const_cast<void *>(array.data());
+    /// Plain (non-masked) numpy buffers may be mounted zero-copy by the scan.
+    if (zeroCopyEnabled() && !column.registered_array && !column.is_object_type)
+        column.borrow_guard = makePyBorrowGuard(array.ptr());
 }
 
 } // namespace CHDB

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -227,7 +227,9 @@ ColumnPtr PandasScan::scanObject(
     auto ** object_array = static_cast<PyObject **>(col_wrap.buf);
     auto serialization = data_type->getDefaultSerialization();
 
-    innerScanObject(cursor, count, format_settings, serialization, object_array, column);
+    innerScanObject(
+        cursor, count, format_settings, serialization, object_array, column,
+        WhichDataType(TypeIndex::Object), col_wrap.stride);
 
     return column;
 }
@@ -243,7 +245,9 @@ void PandasScan::scanObject(
     auto data_type = std::make_shared<DataTypeObject>(DataTypeObject::SchemaFormat::JSON);
     SerializationPtr serialization = data_type->getDefaultSerialization();
 
-    innerScanObject(cursor, count, format_settings, serialization, object_array, column);
+    innerScanObject(
+        cursor, count, format_settings, serialization, object_array, column,
+        WhichDataType(TypeIndex::Object), sizeof(PyObject *));
 }
 
 void PandasScan::innerScanObject(
@@ -256,7 +260,9 @@ void PandasScan::innerScanObject(
     WhichDataType which,
     size_t stride)
 {
-    const size_t effective_stride = (stride == 0) ? sizeof(PyObject *) : stride;
+    /// stride == 0 is a numpy broadcast view over a single element: multiplying
+    /// by the raw stride re-reads element 0, which is exactly what broadcast
+    /// semantics require (and is also correct for the count <= 1 case).
     const auto * base_ptr = reinterpret_cast<const char *>(objects);
 
     switch (which.idx)
@@ -273,7 +279,7 @@ void PandasScan::innerScanObject(
 
             for (size_t i = cursor; i < cursor + count; ++i)
             {
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 auto handle = py::handle(obj_ptr);
                 if (!py::isinstance<py::dict>(handle))
                 {
@@ -317,7 +323,7 @@ void PandasScan::innerScanObject(
                         string_chars_ptr->reserve(reserve_size);
                 }
 
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 auto handle = py::handle(obj_ptr);
 
                 bool is_null = false;
@@ -357,7 +363,7 @@ void PandasScan::innerScanObject(
 
             for (size_t i = cursor; i < cursor + count; ++i)
             {
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 auto handle = py::handle(obj_ptr);
 
                 if (!py::isinstance<py::int_>(handle) && !py::isinstance<py::float_>(handle))
@@ -403,7 +409,7 @@ void PandasScan::innerScanObject(
 #endif
             for (size_t i = cursor; i < cursor + count; ++i)
             {
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 scanIntegerColumn<Int64>(py::handle(obj_ptr), column);
             }
             break;
@@ -416,7 +422,7 @@ void PandasScan::innerScanObject(
 #endif
             for (size_t i = cursor; i < cursor + count; ++i)
             {
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 scanIntegerColumn<Int32>(py::handle(obj_ptr), column);
             }
             break;
@@ -429,7 +435,7 @@ void PandasScan::innerScanObject(
 #endif
             for (size_t i = cursor; i < cursor + count; ++i)
             {
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 scanIntegerColumn<UInt64>(py::handle(obj_ptr), column);
             }
             break;
@@ -448,7 +454,7 @@ void PandasScan::innerScanObject(
 
             for (size_t i = cursor; i < cursor + count; ++i)
             {
-                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+                auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
                 auto handle = py::handle(obj_ptr);
 
                 if (isNone(handle) || (isFloat(handle) && std::isnan(PyFloat_AsDouble(handle.ptr()))))
@@ -488,7 +494,7 @@ void PandasScan::innerScanFloat(
     auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
     auto & null_map = nullable_column.getNullMapData();
 
-    if (stride == 0 || stride == sizeof(T))
+    if (stride == sizeof(T))
     {
         ColumnVectorHelper * helper = static_cast<ColumnVectorHelper *>(data_column.get());
         const T * start = ptr + cursor;
@@ -530,8 +536,8 @@ void PandasScan::innerScanNumeric(
     auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
     auto & null_map = nullable_column.getNullMapData();
 
-    const bool data_contiguous = (stride == 0 || stride == sizeof(T));
-    const bool mask_contiguous = (mask_stride == 0 || mask_stride == sizeof(bool));
+    const bool data_contiguous = (stride == sizeof(T));
+    const bool mask_contiguous = (mask_stride == sizeof(bool));
 
     if (data_contiguous && mask_contiguous)
     {
@@ -553,19 +559,17 @@ void PandasScan::innerScanNumeric(
     {
         // Slow path: non-contiguous data or mask
         auto & container = assert_cast<ColumnVector<T> &>(*data_column).getData();
-        const size_t effective_stride = (stride == 0) ? sizeof(T) : stride;
-        const size_t effective_mask_stride = (mask_stride == 0) ? sizeof(bool) : mask_stride;
         const auto * data_base = reinterpret_cast<const char *>(data_ptr);
         const auto * mask_base = reinterpret_cast<const char *>(mask_ptr);
 
         for (size_t i = cursor; i < cursor + count; ++i)
         {
-            T value = *reinterpret_cast<const T *>(data_base + i * effective_stride);
+            T value = *reinterpret_cast<const T *>(data_base + i * stride);
             container.push_back(value);
 
             if (mask_ptr != nullptr)
             {
-                bool is_null = *reinterpret_cast<const bool *>(mask_base + i * effective_mask_stride);
+                bool is_null = *reinterpret_cast<const bool *>(mask_base + i * mask_stride);
                 null_map.push_back(is_null ? 1 : 0);
             }
             else
@@ -596,7 +600,7 @@ void PandasScan::innerScanDateTime64(
     auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
     auto & null_map = nullable_column.getNullMapData();
 
-    if (stride == 0 || stride == sizeof(Int64))
+    if (stride == sizeof(Int64))
     {
         ColumnVectorHelper * helper = static_cast<ColumnVectorHelper *>(data_column.get());
         const Int64 * start = ptr + cursor;
@@ -634,7 +638,7 @@ void PandasScan::innerScanInterval(
     auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
     auto & null_map = nullable_column.getNullMapData();
 
-    if (stride == 0 || stride == sizeof(Int64))
+    if (stride == sizeof(Int64))
     {
         ColumnVectorHelper * helper = static_cast<ColumnVectorHelper *>(data_column.get());
         const Int64 * start = ptr + cursor;
@@ -1069,7 +1073,9 @@ void PandasScan::innerScanCategory(
     MutableColumnPtr & column,
     size_t stride)
 {
-    const size_t effective_stride = (stride == 0) ? sizeof(T) : stride;
+    /// stride == 0 is a numpy broadcast view over a single element: multiplying
+    /// by the raw stride re-reads element 0, which is exactly what broadcast
+    /// semantics require (and is also correct for the count <= 1 case).
     const auto * base_ptr = reinterpret_cast<const char *>(codes_ptr);
 
     auto indexes_column = ColumnVector<IndexType>::create();
@@ -1078,7 +1084,7 @@ void PandasScan::innerScanCategory(
 
     for (size_t i = cursor; i < cursor + count; ++i)
     {
-        T code = *reinterpret_cast<const T *>(base_ptr + i * effective_stride);
+        T code = *reinterpret_cast<const T *>(base_ptr + i * stride);
         indexes_data.push_back(code < 0 ? 0 : static_cast<IndexType>(code + 1));
     }
 

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -1,4 +1,5 @@
 #include "PandasScan.h"
+#include "PyBorrowGuard.h"
 #include "PythonConversion.h"
 #include "PythonImporter.h"
 #include "ColumnVectorHelper.h"
@@ -660,6 +661,44 @@ void PandasScan::innerScanInterval(
     }
 }
 
+static constexpr size_t BORROW_MIN_BYTES = 16384;
+
+/// Mount the payload of a fully-valid, single-chunk segment as borrowed chars;
+/// offsets are rebuilt (Arrow start-offsets -> ClickHouse cumulative offsets).
+template <typename OffsetT>
+static bool tryBorrowArrowStringSegment(
+    const ArrowStringChunkView & chunk,
+    const size_t local_start,
+    const size_t n,
+    ColumnString & column_string,
+    NullMap * null_map,
+    const std::shared_ptr<void> & guard)
+{
+    if (chunk.validity != nullptr || !column_string.getChars().empty() || !column_string.getOffsets().empty())
+        return false;
+
+    const OffsetT * off = static_cast<const OffsetT *>(chunk.offsets) + chunk.offset + local_start;
+    const size_t total_bytes = static_cast<size_t>(off[n] - off[0]);
+    if (total_bytes < BORROW_MIN_BYTES)
+        return false;
+
+    const char * begin = chunk.data + off[0];
+    if (!CHDB::borrowTailReadable(begin + total_bytes))
+        return false;
+
+    column_string.borrowChars(begin, total_bytes, guard);
+
+    auto & offsets = column_string.getOffsets();
+    offsets.resize_exact(n);
+    const OffsetT base = off[0];
+    for (size_t i = 0; i < n; ++i)
+        offsets[i] = static_cast<size_t>(off[i + 1] - base);
+
+    if (null_map)
+        null_map->resize_fill(null_map->size() + n, 0);
+    return true;
+}
+
 template <typename OffsetT>
 static void scanArrowStringSegment(
     const ArrowStringChunkView & chunk,
@@ -766,6 +805,22 @@ void PandasScan::innerScanArrowString(
             lo = mid + 1;
         else
             hi = mid;
+    }
+
+    /// Zero-copy: a block that lies entirely inside one fully-valid chunk
+    /// mounts the Arrow payload instead of copying it.
+    if (col_wrap.borrow_guard && lo < chunks.size())
+    {
+        const auto & chunk = chunks[lo];
+        const size_t local_start = cursor - chunk.row_start;
+        if (local_start + count <= chunk.length)
+        {
+            const bool borrowed = col_wrap.arrow_large_offsets
+                ? tryBorrowArrowStringSegment<Int64>(chunk, local_start, count, *column_string, null_map, col_wrap.borrow_guard)
+                : tryBorrowArrowStringSegment<Int32>(chunk, local_start, count, *column_string, null_map, col_wrap.borrow_guard);
+            if (borrowed)
+                return;
+        }
     }
 
     size_t row = cursor;

--- a/programs/local/PandasScan.h
+++ b/programs/local/PandasScan.h
@@ -66,8 +66,8 @@ private:
         DB::SerializationPtr & serialization,
         PyObject ** objects,
         DB::MutableColumnPtr & column,
-        DB::WhichDataType which = DB::WhichDataType(DB::TypeIndex::Object),
-        size_t stride = 0);
+        DB::WhichDataType which,
+        size_t stride);
 
     template <typename T>
     static void innerScanFloat(
@@ -75,7 +75,7 @@ private:
         const size_t count,
         const T * ptr,
         DB::MutableColumnPtr & column,
-        size_t stride = 0);
+        size_t stride);
 
     template <typename T>
     static void innerScanNumeric(
@@ -84,22 +84,22 @@ private:
         const T * data_ptr,
         const bool * mask_ptr,
         DB::MutableColumnPtr & column,
-        size_t stride = 0,
-        size_t mask_stride = 0);
+        size_t stride,
+        size_t mask_stride);
 
     static void innerScanDateTime64(
         const size_t cursor,
         const size_t count,
         const Int64 * ptr,
         DB::MutableColumnPtr & column,
-        size_t stride = 0);
+        size_t stride);
 
     static void innerScanInterval(
         const size_t cursor,
         const size_t count,
         const Int64 * ptr,
         DB::MutableColumnPtr & column,
-        size_t stride = 0);
+        size_t stride);
 
     template <typename T, typename IndexType>
     static void innerScanCategory(
@@ -108,7 +108,7 @@ private:
         const T * codes_ptr,
         const DB::ColumnUniquePtr & category_unique,
         DB::MutableColumnPtr & column,
-        size_t stride = 0);
+        size_t stride);
 };
 
 } // namespace CHDB

--- a/programs/local/PyBorrowGuard.cpp
+++ b/programs/local/PyBorrowGuard.cpp
@@ -1,6 +1,7 @@
 #include "PyBorrowGuard.h"
 #include "PybindWrapper.h"
 
+#include <atomic>
 #include <cstdlib>
 #include <mutex>
 #include <vector>
@@ -8,8 +9,22 @@
 namespace CHDB
 {
 
-static std::mutex pending_decrefs_mutex;
-static std::vector<PyObject *> pending_decrefs;
+/// Leaky singletons: guard deleters can run during static destruction (e.g. a
+/// connection left open at process exit destroys columns whose deleters
+/// enqueue here), so these must outlive every static destructor.
+static std::mutex & pendingDecrefsMutex()
+{
+    static auto * mutex = new std::mutex;
+    return *mutex;
+}
+
+static std::vector<PyObject *> & pendingDecrefs()
+{
+    static auto * pending = new std::vector<PyObject *>;
+    return *pending;
+}
+
+static std::atomic_flag drain_scheduled = ATOMIC_FLAG_INIT;
 
 bool zeroCopyEnabled()
 {
@@ -21,14 +36,33 @@ bool zeroCopyEnabled()
     return enabled;
 }
 
+static int drainPendingCallTrampoline(void *)
+{
+    drain_scheduled.clear(std::memory_order_release);
+    drainPyBorrowGuardQueue();
+    return 0;
+}
+
 std::shared_ptr<void> makePyBorrowGuard(PyObject * obj)
 {
     py::gil_assert();
     Py_INCREF(obj);
     return {static_cast<void *>(obj), [](void * ptr)
     {
-        std::lock_guard lock(pending_decrefs_mutex);
-        pending_decrefs.push_back(static_cast<PyObject *>(ptr));
+        {
+            std::lock_guard lock(pendingDecrefsMutex());
+            pendingDecrefs().push_back(static_cast<PyObject *>(ptr));
+        }
+        /// The deleter may run on a server thread with no GIL and no upcoming
+        /// chdb API call (e.g. a table with borrowed columns dropped in the
+        /// background). Schedule a drain on the interpreter's pending-call
+        /// queue so the release point is bounded and query-independent;
+        /// the drains at query boundaries remain as belt-and-braces.
+        if (!drain_scheduled.test_and_set(std::memory_order_acq_rel))
+        {
+            if (Py_AddPendingCall(drainPendingCallTrampoline, nullptr) != 0)
+                drain_scheduled.clear(std::memory_order_release);
+        }
     }};
 }
 
@@ -39,10 +73,10 @@ void drainPyBorrowGuardQueue()
 
     std::vector<PyObject *> drained;
     {
-        std::lock_guard lock(pending_decrefs_mutex);
-        if (pending_decrefs.empty())
+        std::lock_guard lock(pendingDecrefsMutex());
+        if (pendingDecrefs().empty())
             return;
-        drained.swap(pending_decrefs);
+        drained.swap(pendingDecrefs());
     }
     for (auto * obj : drained)
         Py_DECREF(obj);

--- a/programs/local/PyBorrowGuard.cpp
+++ b/programs/local/PyBorrowGuard.cpp
@@ -1,0 +1,48 @@
+#include "PyBorrowGuard.h"
+#include "PybindWrapper.h"
+
+#include <cstdlib>
+#include <mutex>
+#include <vector>
+
+namespace CHDB
+{
+
+static std::mutex pending_decrefs_mutex;
+static std::vector<PyObject *> pending_decrefs;
+
+bool zeroCopyEnabled()
+{
+    static const bool enabled = []
+    {
+        const char * env = getenv("CHDB_ZERO_COPY"); // NOLINT(concurrency-mt-unsafe)
+        return !(env && env[0] == '0');
+    }();
+    return enabled;
+}
+
+std::shared_ptr<void> makePyBorrowGuard(PyObject * obj)
+{
+    py::gil_assert();
+    Py_INCREF(obj);
+    return {static_cast<void *>(obj), [](void * ptr)
+    {
+        std::lock_guard lock(pending_decrefs_mutex);
+        pending_decrefs.push_back(static_cast<PyObject *>(ptr));
+    }};
+}
+
+void drainPyBorrowGuardQueue()
+{
+    std::vector<PyObject *> drained;
+    {
+        std::lock_guard lock(pending_decrefs_mutex);
+        if (pending_decrefs.empty())
+            return;
+        drained.swap(pending_decrefs);
+    }
+    for (auto * obj : drained)
+        Py_DECREF(obj);
+}
+
+}

--- a/programs/local/PyBorrowGuard.cpp
+++ b/programs/local/PyBorrowGuard.cpp
@@ -34,6 +34,9 @@ std::shared_ptr<void> makePyBorrowGuard(PyObject * obj)
 
 void drainPyBorrowGuardQueue()
 {
+    if (!Py_IsInitialized())
+        return;
+
     std::vector<PyObject *> drained;
     {
         std::lock_guard lock(pending_decrefs_mutex);

--- a/programs/local/PyBorrowGuard.cpp
+++ b/programs/local/PyBorrowGuard.cpp
@@ -58,6 +58,11 @@ std::shared_ptr<void> makePyBorrowGuard(PyObject * obj)
         /// background). Schedule a drain on the interpreter's pending-call
         /// queue so the release point is bounded and query-independent;
         /// the drains at query boundaries remain as belt-and-braces.
+        /// During/after finalization the pending-call machinery is gone:
+        /// leave the queued refs intentionally leaked instead of crashing.
+        if (!Py_IsInitialized())
+            return;
+
         if (!drain_scheduled.test_and_set(std::memory_order_acq_rel))
         {
             if (Py_AddPendingCall(drainPendingCallTrampoline, nullptr) != 0)

--- a/programs/local/PyBorrowGuard.h
+++ b/programs/local/PyBorrowGuard.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+
+typedef struct _object PyObject; /// NOLINT(modernize-use-using)
+
+namespace CHDB
+{
+
+/// Whether zero-copy mounting of Python buffers into ClickHouse columns is
+/// enabled (CHDB_ZERO_COPY=0 disables it).
+bool zeroCopyEnabled();
+
+/// Take a strong reference on `obj` (GIL must be held) and wrap it in a
+/// shared_ptr guard. The deleter never touches the GIL: it enqueues the
+/// pointer for a deferred decref, drained at the next query start / cache
+/// clear while the GIL is held. This makes guard release safe from any
+/// executor thread and structurally free of GIL deadlocks.
+std::shared_ptr<void> makePyBorrowGuard(PyObject * obj);
+
+/// Decref all queued objects. GIL must be held.
+void drainPyBorrowGuardQueue();
+
+/// 63 bytes past a mounted buffer's end must be readable (PaddedPODArray
+/// read-overflow contract). Same-page check: O(1) and conservative; a false
+/// negative just falls back to copying.
+inline bool borrowTailReadable(const void * end)
+{
+    const auto addr = reinterpret_cast<unsigned long long>(end); /// NOLINT(google-runtime-int)
+    return ((addr - 1) >> 12) == ((addr + 62) >> 12);
+}
+
+}

--- a/programs/local/PythonSource.cpp
+++ b/programs/local/PythonSource.cpp
@@ -2,6 +2,7 @@
 #include "ColumnVectorHelper.h"
 #include "ListScan.h"
 #include "PandasScan.h"
+#include "PyBorrowGuard.h"
 #include "StoragePython.h"
 
 #include <algorithm>
@@ -76,7 +77,8 @@ PythonSource::PythonSource(
     const FormatSettings & format_settings_,
     ArrowTableReaderPtr arrow_table_reader_,
     PrewhereActionsPtr prewhere_,
-    TopKActionsPtr topk_)
+    TopKActionsPtr topk_,
+    BlockBoundsPtr block_bounds_)
     : ISource(std::make_shared<Block>(prewhere_ ? prewhere_->output_header.cloneEmpty() : sample_block_.cloneEmpty()))
     , data_source_wrapper(std::move(data_source_wrapper_))
     , isInheritsFromPyReader(isInheritsFromPyReader_)
@@ -92,6 +94,7 @@ PythonSource::PythonSource(
     , arrow_table_reader(arrow_table_reader_)
     , prewhere(std::move(prewhere_))
     , topk(std::move(topk_))
+    , block_bounds(std::move(block_bounds_))
 {
 }
 
@@ -188,18 +191,37 @@ void PythonSource::convert_string_array_to_block(
 }
 
 template <typename T>
-void PythonSource::insert_from_ptr(const void * ptr, const MutableColumnPtr & column, const size_t offset, const size_t row_count, size_t stride)
+void PythonSource::insert_from_ptr(
+    const void * ptr, const MutableColumnPtr & column, const size_t offset, const size_t row_count, size_t stride,
+    const std::shared_ptr<void> & borrow_guard)
 {
-    column->reserve(row_count);
-
     if (stride == 0 || stride == sizeof(T))
     {
-        ColumnVectorHelper * helper = static_cast<ColumnVectorHelper *>(column.get());
         const char * start = static_cast<const char *>(ptr) + offset * sizeof(T);
+
+        /// Zero-copy: mount the numpy buffer slice instead of copying it.
+        if constexpr (!is_decimal<T>)
+        {
+            if (borrow_guard && row_count * sizeof(T) >= 4096
+                && reinterpret_cast<uintptr_t>(start) % alignof(T) == 0)
+            {
+                if (auto * vec = typeid_cast<ColumnVector<T> *>(column.get());
+                    vec && vec->getData().empty()
+                    && CHDB::borrowTailReadable(start + row_count * sizeof(T)))
+                {
+                    vec->borrowData(start, row_count, borrow_guard);
+                    return;
+                }
+            }
+        }
+
+        column->reserve(row_count);
+        ColumnVectorHelper * helper = static_cast<ColumnVectorHelper *>(column.get());
         helper->appendRawData<sizeof(T)>(start, row_count);
     }
     else
     {
+        column->reserve(row_count);
         const auto * base_ptr = static_cast<const char *>(ptr);
         for (size_t i = offset; i < offset + row_count; ++i)
         {
@@ -287,7 +309,7 @@ ColumnPtr PythonSource::convert_and_insert_array(const ColumnWrapper & col_wrap,
     if constexpr (std::is_same_v<T, String>)
         convert_string_array_to_block(static_cast<PyObject **>(col_wrap.buf), column, cursor, count, col_wrap.stride);
     else
-        insert_from_ptr<T>(col_wrap.buf, column, cursor, count, col_wrap.stride);
+        insert_from_ptr<T>(col_wrap.buf, column, cursor, count, col_wrap.stride, col_wrap.borrow_guard);
 
     return column;
 }
@@ -1020,10 +1042,24 @@ Chunk PythonSource::generate()
 
 std::pair<size_t, size_t> PythonSource::calculateOffsetAndCount()
 {
-    /// Streams take blocks round-robin on fixed max_block_size boundaries:
-    /// stream i emits blocks i, i + num_streams, i + 2*num_streams, ...
-    /// Fixed boundaries keep blocks identical across queries regardless of
-    /// stream count, which lets the cross-query block cache match them.
+    /// Streams take blocks round-robin: stream i emits blocks
+    /// i, i + num_streams, i + 2*num_streams, ...
+    if (block_bounds)
+    {
+        /// Boundaries additionally cut at Arrow chunk starts so a block never
+        /// spans chunks and its string payload can be mounted zero-copy.
+        const size_t n_blocks = block_bounds->size() - 1;
+        const size_t block_idx = stream_index + blocks_emitted * num_streams;
+        if (block_idx >= n_blocks)
+            return std::make_pair(0, 0);
+
+        ++blocks_emitted;
+        const size_t offset = (*block_bounds)[block_idx];
+        return std::make_pair(offset, (*block_bounds)[block_idx + 1] - offset);
+    }
+
+    /// Fixed max_block_size boundaries keep blocks identical across queries
+    /// regardless of stream count.
     const size_t n_blocks = (data_source_row_count + max_block_size - 1) / max_block_size;
     const size_t block_idx = stream_index + blocks_emitted * num_streams;
     if (block_idx >= n_blocks)

--- a/programs/local/PythonSource.cpp
+++ b/programs/local/PythonSource.cpp
@@ -160,12 +160,14 @@ void PythonSource::convert_string_array_to_block(
     ColumnString::Offsets & offsets = string_column->getOffsets();
     offsets.reserve(row_count);
 
-    const size_t effective_stride = (stride == 0) ? sizeof(PyObject *) : stride;
+    /// stride == 0 is a numpy broadcast view over a single element: multiplying
+    /// by the raw stride re-reads element 0, which is exactly what broadcast
+    /// semantics require (and is also correct for the row_count <= 1 case).
     const auto * base_ptr = reinterpret_cast<const char *>(buf);
 
     for (size_t i = offset; i < offset + row_count; ++i)
     {
-        auto * obj = *reinterpret_cast<PyObject * const *>(base_ptr + i * effective_stride);
+        auto * obj = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
         if (!PyUnicode_Check(obj))
         {
             insertObjToStringColumn(obj, string_column);
@@ -195,7 +197,11 @@ void PythonSource::insert_from_ptr(
     const void * ptr, const MutableColumnPtr & column, const size_t offset, const size_t row_count, size_t stride,
     const std::shared_ptr<void> & borrow_guard)
 {
-    if (stride == 0 || stride == sizeof(T))
+    /// stride == 0 means a broadcast view backed by a single element; it must
+    /// take the per-element loop below (which re-reads element 0), never the
+    /// contiguous paths that would walk row_count * sizeof(T) bytes of memory
+    /// that does not belong to the array.
+    if (stride == sizeof(T))
     {
         const char * start = static_cast<const char *>(ptr) + offset * sizeof(T);
 
@@ -278,7 +284,7 @@ ColumnPtr PythonSource::convert_and_insert(const py::object & obj, UInt32 scale,
         else if constexpr (std::is_same_v<T, String>)
             insert_string_from_array(py_array, column);
         else
-            insert_from_ptr<T>(data, column, 0, row_count);
+            insert_from_ptr<T>(data, column, 0, row_count, sizeof(T));
         return column;
     }
 
@@ -580,10 +586,12 @@ MutableColumnPtr gatherFromTypedBuffer(
     auto & container = assert_cast<ColumnType &>(*column).getData();
     container.reserve(selected);
     const auto * base = reinterpret_cast<const char *>(buf);
-    const size_t effective_stride = (stride == 0) ? sizeof(ValueT) : stride;
+    /// stride == 0 is a numpy broadcast view over a single element: multiplying
+    /// by the raw stride re-reads element 0, which is exactly what broadcast
+    /// semantics require (and is also correct for the count <= 1 case).
     for (size_t i = 0; i < count; ++i)
         if (mask[i])
-            container.push_back(*reinterpret_cast<const ValueT *>(base + (offset + i) * effective_stride));
+            container.push_back(*reinterpret_cast<const ValueT *>(base + (offset + i) * stride));
     return column;
 }
 
@@ -622,10 +630,9 @@ ColumnPtr wrapGatheredNullable(
     {
         null_map.reserve(selected);
         const auto * mask_base = reinterpret_cast<const char *>(col.registered_array->numpy_array.data());
-        const size_t mask_stride = (col.mask_stride == 0) ? sizeof(bool) : col.mask_stride;
         for (size_t r = 0; r < count; ++r)
             if (mask[r])
-                null_map.push_back(*reinterpret_cast<const bool *>(mask_base + (offset + r) * mask_stride) ? 1 : 0);
+                null_map.push_back(*reinterpret_cast<const bool *>(mask_base + (offset + r) * col.mask_stride) ? 1 : 0);
     }
     else
         fillGatheredNullMap<NullSourceColumn>(*nested, null_map);

--- a/programs/local/PythonSource.h
+++ b/programs/local/PythonSource.h
@@ -86,6 +86,11 @@ public:
     };
     using TopKActionsPtr = std::shared_ptr<const TopKActions>;
 
+    /// Fixed-grid block boundaries, additionally cut at Arrow chunk starts so
+    /// that (almost) every block lies inside one chunk and its string payload
+    /// can be mounted zero-copy. Shared by all streams of one read.
+    using BlockBoundsPtr = std::shared_ptr<const std::vector<UInt64>>;
+
     PythonSource(
         CHDB::DataSourceWrapperPtr data_source_wrapper_,
         bool isInheritsFromPyReader_,
@@ -99,7 +104,8 @@ public:
         const FormatSettings & format_settings_,
         CHDB::ArrowTableReaderPtr arrow_table_reader_ = nullptr,
         PrewhereActionsPtr prewhere_ = nullptr,
-        TopKActionsPtr topk_ = nullptr);
+        TopKActionsPtr topk_ = nullptr,
+        BlockBoundsPtr block_bounds_ = nullptr);
 
     ~PythonSource() override = default;
 
@@ -138,7 +144,13 @@ private:
     template <typename T>
     ColumnPtr convert_and_insert(const py::object & obj, UInt32 scale = 0, bool is_json = false);
     template <typename T>
-    void insert_from_ptr(const void * ptr, const MutableColumnPtr & column, size_t offset, size_t row_count, size_t stride = 0);
+    void insert_from_ptr(
+        const void * ptr,
+        const MutableColumnPtr & column,
+        size_t offset,
+        size_t row_count,
+        size_t stride = 0,
+        const std::shared_ptr<void> & borrow_guard = nullptr);
 
     void convert_string_array_to_block(PyObject ** buf, const MutableColumnPtr & column, size_t offset, size_t row_count, size_t stride = 0);
 
@@ -163,6 +175,7 @@ private:
 
     PrewhereActionsPtr prewhere;
     TopKActionsPtr topk;
+    BlockBoundsPtr block_bounds;
     bool topk_done = false;
 };
 }

--- a/programs/local/PythonSource.h
+++ b/programs/local/PythonSource.h
@@ -149,10 +149,10 @@ private:
         const MutableColumnPtr & column,
         size_t offset,
         size_t row_count,
-        size_t stride = 0,
+        size_t stride,
         const std::shared_ptr<void> & borrow_guard = nullptr);
 
-    void convert_string_array_to_block(PyObject ** buf, const MutableColumnPtr & column, size_t offset, size_t row_count, size_t stride = 0);
+    void convert_string_array_to_block(PyObject ** buf, const MutableColumnPtr & column, size_t offset, size_t row_count, size_t stride = sizeof(PyObject *));
 
     template <typename T>
     void insert_from_list(const py::list & obj, const MutableColumnPtr & column);

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -1,4 +1,6 @@
 #include "PythonTableCache.h"
+#include "NumpyType.h"
+#include "PyBorrowGuard.h"
 #include "PybindWrapper.h"
 #include "PythonArrowStream.h"
 #include "PythonUtils.h"
@@ -6,6 +8,69 @@
 #include <Common/re2.h>
 
 namespace CHDB {
+
+static bool pandasMetaCacheEnabled()
+{
+    static const bool enabled = []
+    {
+        const char * env = getenv("CHDB_PANDAS_META_CACHE"); // NOLINT(concurrency-mt-unsafe)
+        return !(env && env[0] == '0');
+    }();
+    return enabled;
+}
+
+PandasTableMeta::~PandasTableMeta()
+{
+    if (!Py_IsInitialized())
+    {
+        /// Interpreter is gone: decref / GIL are unusable. Leak the Python
+        /// references (and the wrappers, whose destructors take the GIL)
+        /// instead of crashing at teardown.
+        weak_ref.release();
+        columns_index.release();
+        for (auto & dtype_obj : dtype_objs)
+            dtype_obj.release();
+        for (auto & sb : str_backings)
+        {
+            sb.label.release();
+            sb.chunked.release();
+        }
+        auto * leaked = new std::unordered_map<std::string, std::shared_ptr<DB::ColumnWrapper>>(std::move(arrow_wrappers));
+        (void)leaked;
+        return;
+    }
+    try
+    {
+        py::gil_scoped_acquire acquire;
+        weak_ref.release().dec_ref();
+        columns_index.release().dec_ref();
+        dtype_objs.clear();
+        str_backings.clear();
+        arrow_wrappers.clear();
+    }
+    catch (...)
+    {
+    }
+}
+
+PythonTableCache::~PythonTableCache()
+{
+    if (!Py_IsInitialized())
+    {
+        auto * leaked = new std::list<PandasTableMetaPtr>(std::move(meta_lru));
+        (void)leaked;
+        return;
+    }
+    try
+    {
+        py::gil_scoped_acquire acquire;
+        meta_lru.clear();
+        drainPyBorrowGuardQueue();
+    }
+    catch (...)
+    {
+    }
+}
 
 /// Function to find instance of PyReader, pandas DataFrame, or PyArrow Table, filtered by variable name
 static py::object findQueryableObj(const String & var_name)
@@ -69,6 +134,24 @@ void PythonTableCache::findQueryableObjFromQuery(const String & query_str)
 
     py::gil_assert();
 
+    /// New query: cached-metadata witnesses must be re-checked once per query.
+    ++query_epoch;
+    drainPyBorrowGuardQueue();
+
+    /// Evict entries whose DataFrame died, so cached backing arrays (string
+    /// payloads) are not kept alive longer than one query boundary.
+    meta_lru.remove_if([](const PandasTableMetaPtr & e)
+    {
+        try
+        {
+            return e->weak_ref.ptr() != nullptr && e->weak_ref().is_none();
+        }
+        catch (...)
+        {
+            return false;
+        }
+    });
+
     // RE2 pattern to match Python()/python() patterns with single/double quotes or no quotes
     static const RE2 pattern(R"([Pp]ython\s*\(\s*(?:['"]([^'"]+)['"]|([a-zA-Z_][a-zA-Z0-9_]*))\s*\))");
 
@@ -106,10 +189,156 @@ void PythonTableCache::clear()
 	{
         py::gil_scoped_acquire acquire;
         py_table_cache.clear();
+        drainPyBorrowGuardQueue();
 	}
 	catch (...)
 	{
 	}
+}
+
+void PythonTableCache::dropMeta(PyObject * df_ptr)
+{
+    meta_lru.remove_if([&](const PandasTableMetaPtr & e) { return e->df_ptr == df_ptr; });
+}
+
+PandasTableMetaPtr PythonTableCache::findValidatedPandasMeta(const py::handle & df)
+{
+    if (!pandasMetaCacheEnabled())
+        return nullptr;
+
+    py::gil_assert();
+
+    auto it = std::find_if(meta_lru.begin(), meta_lru.end(), [&](const PandasTableMetaPtr & e) { return e->df_ptr == df.ptr(); });
+    if (it == meta_lru.end())
+        return nullptr;
+
+    auto entry = *it;
+    if (entry->validated_epoch == query_epoch)
+    {
+        meta_lru.splice(meta_lru.begin(), meta_lru, it);
+        return entry;
+    }
+
+    bool valid = false;
+    try
+    {
+        do
+        {
+            py::object alive = entry->weak_ref();
+            if (!alive.is(df))
+                break;
+            if (static_cast<size_t>(py::len(df)) != entry->row_count)
+                break;
+            py::object columns = df.attr("columns");
+            if (columns.ptr() != entry->columns_index.ptr())
+                break;
+            py::list dtypes = py::list(df.attr("dtypes"));
+            if (dtypes.size() != entry->dtype_objs.size())
+                break;
+            bool dtypes_match = true;
+            for (size_t i = 0; i < entry->dtype_objs.size(); ++i)
+            {
+                py::object cur = dtypes[i];
+                if (cur.ptr() != entry->dtype_objs[i].ptr())
+                {
+                    dtypes_match = false;
+                    break;
+                }
+            }
+            if (!dtypes_match)
+                break;
+            bool backings_match = true;
+            for (const auto & sb : entry->str_backings)
+            {
+                py::object series = df[sb.label];
+                py::object arr = series.attr("array");
+                if (!py::hasattr(arr, "_pa_array") || arr.attr("_pa_array").ptr() != sb.chunked.ptr())
+                {
+                    backings_match = false;
+                    break;
+                }
+            }
+            if (!backings_match)
+                break;
+            valid = true;
+        } while (false);
+    }
+    catch (...)
+    {
+        valid = false;
+    }
+
+    if (!valid)
+    {
+        meta_lru.erase(it);
+        return nullptr;
+    }
+
+    entry->validated_epoch = query_epoch;
+    meta_lru.splice(meta_lru.begin(), meta_lru, it);
+    return entry;
+}
+
+void PythonTableCache::storePandasMeta(const py::handle & df, const DB::ColumnsDescription & schema)
+{
+    if (!pandasMetaCacheEnabled())
+        return;
+
+    py::gil_assert();
+
+    try
+    {
+        auto entry = std::make_shared<PandasTableMeta>();
+        entry->df_ptr = df.ptr();
+        entry->schema = schema;
+        entry->row_count = py::len(df);
+        entry->columns_index = df.attr("columns");
+        py::list names = py::list(entry->columns_index);
+        py::list dtypes = py::list(df.attr("dtypes"));
+        if (names.size() != dtypes.size())
+            return;
+
+        for (size_t i = 0; i < names.size(); ++i)
+        {
+            py::object name_obj = names[i];
+            py::object dtype_obj = dtypes[i];
+            auto numpy_type = ConvertNumpyType(dtype_obj);
+            switch (numpy_type.type)
+            {
+                case NumpyNullableType::OBJECT:
+                case NumpyNullableType::CATEGORY:
+                    return; /// value-derived schema / per-query wrapper side effects: not cacheable
+                case NumpyNullableType::STRING:
+                {
+                    py::object series = df[name_obj];
+                    py::object arr = series.attr("array");
+                    if (py::hasattr(arr, "_pa_array"))
+                        entry->str_backings.push_back({i, name_obj, arr.attr("_pa_array").cast<py::object>()});
+                    break;
+                }
+                default:
+                    break;
+            }
+            entry->dtype_objs.emplace_back(std::move(dtype_obj));
+        }
+
+        static py::handle weakref_ref = []
+        {
+            py::object ref_fn = py::module_::import("weakref").attr("ref");
+            return ref_fn.release();
+        }();
+        entry->weak_ref = weakref_ref(df);
+        entry->validated_epoch = query_epoch;
+
+        dropMeta(df.ptr());
+        meta_lru.push_front(std::move(entry));
+        while (meta_lru.size() > max_meta_entries)
+            meta_lru.pop_back();
+    }
+    catch (...)
+    {
+        /// Building the witness set failed: skip caching, behavior stays per-query.
+    }
 }
 
 } // namespace CHDB

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -19,6 +19,16 @@ static bool pandasMetaCacheEnabled()
     return enabled;
 }
 
+static py::object makeWeakref(const py::handle & obj)
+{
+    static py::handle weakref_ref = []
+    {
+        py::object ref_fn = py::module_::import("weakref").attr("ref");
+        return ref_fn.release();
+    }();
+    return weakref_ref(obj);
+}
+
 PandasTableMeta::~PandasTableMeta()
 {
     if (!Py_IsInitialized())
@@ -33,10 +43,8 @@ PandasTableMeta::~PandasTableMeta()
         for (auto & sb : str_backings)
         {
             sb.label.release();
-            sb.chunked.release();
+            sb.chunked_wr.release();
         }
-        auto * leaked = new std::unordered_map<std::string, std::shared_ptr<DB::ColumnWrapper>>(std::move(arrow_wrappers));
-        (void)leaked;
         return;
     }
     try
@@ -250,9 +258,15 @@ PandasTableMetaPtr PythonTableCache::findValidatedPandasMeta(const py::handle & 
             bool backings_match = true;
             for (const auto & sb : entry->str_backings)
             {
+                py::object alive = sb.chunked_wr();
+                if (alive.is_none())
+                {
+                    backings_match = false;
+                    break;
+                }
                 py::object series = df[sb.label];
                 py::object arr = series.attr("array");
-                if (!py::hasattr(arr, "_pa_array") || arr.attr("_pa_array").ptr() != sb.chunked.ptr())
+                if (!py::hasattr(arr, "_pa_array") || !alive.is(arr.attr("_pa_array")))
                 {
                     backings_match = false;
                     break;
@@ -313,7 +327,7 @@ void PythonTableCache::storePandasMeta(const py::handle & df, const DB::ColumnsD
                     py::object series = df[name_obj];
                     py::object arr = series.attr("array");
                     if (py::hasattr(arr, "_pa_array"))
-                        entry->str_backings.push_back({i, name_obj, arr.attr("_pa_array").cast<py::object>()});
+                        entry->str_backings.push_back({i, name_obj, makeWeakref(arr.attr("_pa_array"))});
                     break;
                 }
                 default:
@@ -322,12 +336,7 @@ void PythonTableCache::storePandasMeta(const py::handle & df, const DB::ColumnsD
             entry->dtype_objs.emplace_back(std::move(dtype_obj));
         }
 
-        static py::handle weakref_ref = []
-        {
-            py::object ref_fn = py::module_::import("weakref").attr("ref");
-            return ref_fn.release();
-        }();
-        entry->weak_ref = weakref_ref(df);
+        entry->weak_ref = makeWeakref(df);
         entry->validated_epoch = query_epoch;
 
         dropMeta(df.ptr());

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -72,6 +72,7 @@ PythonTableCache::~PythonTableCache()
     try
     {
         py::gil_scoped_acquire acquire;
+        std::lock_guard lock(state_mutex);
         meta_lru.clear();
         drainPyBorrowGuardQueue();
     }
@@ -142,6 +143,8 @@ void PythonTableCache::findQueryableObjFromQuery(const String & query_str)
 
     py::gil_assert();
 
+    std::lock_guard lock(state_mutex);
+
     /// New query: cached-metadata witnesses must be re-checked once per query.
     ++query_epoch;
     drainPyBorrowGuardQueue();
@@ -183,6 +186,8 @@ void PythonTableCache::findQueryableObjFromQuery(const String & query_str)
 
 py::handle PythonTableCache::getQueryableObj(const String & table_name)
 {
+    std::lock_guard lock(state_mutex);
+
     auto iter = py_table_cache.find(table_name);
 
     if (iter != py_table_cache.end())
@@ -196,6 +201,7 @@ void PythonTableCache::clear()
     try
 	{
         py::gil_scoped_acquire acquire;
+        std::lock_guard lock(state_mutex);
         py_table_cache.clear();
         drainPyBorrowGuardQueue();
 	}
@@ -215,6 +221,8 @@ PandasTableMetaPtr PythonTableCache::findValidatedPandasMeta(const py::handle & 
         return nullptr;
 
     py::gil_assert();
+
+    std::lock_guard lock(state_mutex);
 
     auto it = std::find_if(meta_lru.begin(), meta_lru.end(), [&](const PandasTableMetaPtr & e) { return e->df_ptr == df.ptr(); });
     if (it == meta_lru.end())
@@ -299,6 +307,8 @@ void PythonTableCache::storePandasMeta(const py::handle & df, const DB::ColumnsD
         return;
 
     py::gil_assert();
+
+    std::lock_guard lock(state_mutex);
 
     try
     {

--- a/programs/local/PythonTableCache.h
+++ b/programs/local/PythonTableCache.h
@@ -1,22 +1,75 @@
 #pragma once
 
 #include "PybindWrapper.h"
+#include "PythonUtils.h"
 
+#include <list>
+#include <memory>
 #include <unordered_map>
 #include <base/types.h>
+#include <Storages/ColumnsDescription.h>
+#include <Storages/IStorage.h>
 
 namespace CHDB {
 
+/// Session-level cache of per-DataFrame metadata whose recomputation dominates
+/// small-query latency: schema inference, memory_usage-based column sizes and
+/// the per-chunk Arrow buffer tables. Entries cache only facts that are either
+/// re-read live each query, implied by backing-object identity (Arrow arrays
+/// are immutable; pandas CoW swaps the backing object on modification), or
+/// self-healing location facts. Value-derived facts (object-dtype sampling,
+/// category dictionaries) disqualify the whole DataFrame from caching.
+struct PandasTableMeta
+{
+    PyObject * df_ptr = nullptr;
+    py::object weak_ref;
+    py::object columns_index;
+    std::vector<py::object> dtype_objs;
+    /// (column position, original label object, backing ChunkedArray) per
+    /// string column. The label is kept as a Python object so validation
+    /// indexes the frame correctly for non-string labels too.
+    struct StrBacking
+    {
+        size_t pos;
+        py::object label;
+        py::object chunked;
+    };
+    std::vector<StrBacking> str_backings;
+    size_t row_count = 0;
+    DB::ColumnsDescription schema;
+    bool has_column_sizes = false;
+    DB::IStorage::ColumnSizeByName column_sizes;
+    std::unordered_map<std::string, std::shared_ptr<DB::ColumnWrapper>> arrow_wrappers;
+    UInt64 validated_epoch = 0;
+
+    ~PandasTableMeta();
+};
+
+using PandasTableMetaPtr = std::shared_ptr<PandasTableMeta>;
+
 class PythonTableCache {
 public:
+    ~PythonTableCache();
+
     void findQueryableObjFromQuery(const String & query_str);
 
     py::handle getQueryableObj(const String & table_name);
 
     void clear();
 
+    /// Pandas metadata cache. All methods must be called with the GIL held.
+    PandasTableMetaPtr findValidatedPandasMeta(const py::handle & df);
+    void storePandasMeta(const py::handle & df, const DB::ColumnsDescription & schema);
+    void invalidatePandasMeta(PyObject * df_ptr) { dropMeta(df_ptr); }
+
 private:
+    void dropMeta(PyObject * df_ptr);
+
     std::unordered_map<String, py::handle> py_table_cache;
+
+    static constexpr size_t max_meta_entries = 4;
+    std::list<PandasTableMetaPtr> meta_lru;
+    UInt64 query_epoch = 0;
 };
 
 } // namespace CHDB

--- a/programs/local/PythonTableCache.h
+++ b/programs/local/PythonTableCache.h
@@ -25,21 +25,37 @@ struct PandasTableMeta
     py::object weak_ref;
     py::object columns_index;
     std::vector<py::object> dtype_objs;
-    /// (column position, original label object, backing ChunkedArray) per
-    /// string column. The label is kept as a Python object so validation
-    /// indexes the frame correctly for non-string labels too.
+    /// (column position, original label object, weakref to the backing
+    /// ChunkedArray) per string column. The label is kept as a Python object
+    /// so validation indexes the frame correctly for non-string labels too.
+    /// The backing is held only through a weakref: identity validation needs
+    /// to know whether the old object DIED, not to keep it alive — a dead
+    /// weakref invalidates the entry before any pointer is compared, and a
+    /// live one makes the identity check exact. This way the cache never
+    /// pins the string payload of a deleted DataFrame.
     struct StrBacking
     {
         size_t pos;
         py::object label;
-        py::object chunked;
+        py::object chunked_wr;
     };
     std::vector<StrBacking> str_backings;
     size_t row_count = 0;
     DB::ColumnsDescription schema;
     bool has_column_sizes = false;
     DB::IStorage::ColumnSizeByName column_sizes;
-    std::unordered_map<std::string, std::shared_ptr<DB::ColumnWrapper>> arrow_wrappers;
+    /// Cached per-chunk buffer tables for Arrow string columns: plain PODs
+    /// plus the identity of the backing ChunkedArray. No Python references —
+    /// validity is re-established per query from the live column (whose
+    /// identity the str_backings witness already verified).
+    struct ArrowWrapperMaster
+    {
+        std::vector<DB::ArrowStringChunkView> chunks;
+        bool large_offsets = false;
+        size_t row_count = 0;
+        uintptr_t chunked_ptr = 0;
+    };
+    std::unordered_map<std::string, ArrowWrapperMaster> arrow_wrappers;
     UInt64 validated_epoch = 0;
 
     ~PandasTableMeta();

--- a/programs/local/PythonTableCache.h
+++ b/programs/local/PythonTableCache.h
@@ -5,6 +5,7 @@
 
 #include <list>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <base/types.h>
 #include <Storages/ColumnsDescription.h>
@@ -76,11 +77,23 @@ public:
     /// Pandas metadata cache. All methods must be called with the GIL held.
     PandasTableMetaPtr findValidatedPandasMeta(const py::handle & df);
     void storePandasMeta(const py::handle & df, const DB::ColumnsDescription & schema);
-    void invalidatePandasMeta(PyObject * df_ptr) { dropMeta(df_ptr); }
+    void invalidatePandasMeta(PyObject * df_ptr)
+    {
+        std::lock_guard lock(state_mutex);
+        dropMeta(df_ptr);
+    }
 
 private:
+    /// Must be called with state_mutex held.
     void dropMeta(PyObject * df_ptr);
 
+    /// Guards py_table_cache, meta_lru and query_epoch. The GIL alone is not
+    /// enough: the pybind-side prefill (before client_mutex is taken) can
+    /// interleave with an in-flight query's storage-side lookups at GIL yield
+    /// points, and on free-threaded builds the GIL is no lock at all. Lock
+    /// order is GIL first, then state_mutex; no Python code that could
+    /// re-enter this object runs while the mutex is held by the same thread.
+    std::mutex state_mutex;
     std::unordered_map<String, py::handle> py_table_cache;
 
     static constexpr size_t max_meta_entries = 4;

--- a/programs/local/PythonUtils.h
+++ b/programs/local/PythonUtils.h
@@ -58,6 +58,11 @@ struct ColumnWrapper
     bool arrow_large_offsets = false;
     std::vector<ArrowStringChunkView> arrow_string_chunks;
 
+    /// Keeps the Python owner of `buf`/chunk buffers alive for columns that
+    /// mount the memory zero-copy; copied into each borrowed column. Created
+    /// under the GIL, releasable from any thread (deferred decref).
+    std::shared_ptr<void> borrow_guard;
+
     ~ColumnWrapper()
     {
         py::gil_scoped_acquire acquire;

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -148,22 +148,25 @@ static bool detectArrowStringPredicate(
     return false;
 }
 
-/// Reuse a session-cached Arrow string wrapper: copies the chunk-view table
+/// Reuse a session-cached Arrow string chunk table: copies the chunk views
 /// (plain PODs) instead of re-walking every pyarrow chunk's buffers() under
-/// the GIL. Validity is guaranteed by the metadata-cache witness check (the
-/// backing ChunkedArray identity was verified for the current query).
-static void transplantArrowWrapper(const ColumnWrapper & src, ColumnWrapper & dst)
+/// the GIL. The master holds no Python references; `chunked` is the live
+/// backing fetched from the DataFrame this query, whose identity the
+/// metadata-cache witness already verified for the current epoch.
+static void mountCachedArrowWrapper(
+    const CHDB::PandasTableMeta::ArrowWrapperMaster & master, const py::object & chunked, ColumnWrapper & dst)
 {
-    dst.arrow_string_chunks = src.arrow_string_chunks;
-    dst.arrow_large_offsets = src.arrow_large_offsets;
+    dst.arrow_string_chunks = master.chunks;
+    dst.arrow_large_offsets = master.large_offsets;
     dst.is_arrow_string = true;
     dst.is_object_type = false;
-    dst.data = src.data;
-    dst.buf = src.buf;
-    dst.row_count = src.row_count;
-    dst.tmp = src.data;
+    dst.data = chunked;
+    dst.buf = chunked.ptr();
+    dst.row_count = master.row_count;
+    dst.tmp = chunked;
     dst.tmp.inc_ref();
-    dst.borrow_guard = src.borrow_guard;
+    if (CHDB::zeroCopyEnabled())
+        dst.borrow_guard = CHDB::makePyBorrowGuard(chunked.ptr());
 }
 
 /// Block boundaries for the pandas scan: the fixed max_block_size grid, cut
@@ -709,27 +712,41 @@ void StoragePython::prepareColumnCache(
             {
                 if (is_pandas_df)
                 {
-                    std::shared_ptr<ColumnWrapper> cached_master;
+                    bool mounted = false;
                     if (meta)
                     {
                         auto found = meta->arrow_wrappers.find(col_name);
                         if (found != meta->arrow_wrappers.end())
-                            cached_master = found->second;
+                        {
+                            py::object series = data_source[py::str(col_name)];
+                            if (py::hasattr(series, "array"))
+                            {
+                                py::object underlying = series.attr("array");
+                                if (py::hasattr(underlying, "_pa_array"))
+                                {
+                                    py::object chunked = underlying.attr("_pa_array");
+                                    if (reinterpret_cast<uintptr_t>(chunked.ptr()) == found->second.chunked_ptr)
+                                    {
+                                        mountCachedArrowWrapper(found->second, chunked, col);
+                                        mounted = true;
+                                    }
+                                }
+                            }
+                            if (!mounted)
+                                meta->arrow_wrappers.erase(found);
+                        }
                     }
-                    if (cached_master)
-                    {
-                        transplantArrowWrapper(*cached_master, col);
-                    }
-                    else
+                    if (!mounted)
                     {
                         CHDB::PandasDataFrame::fillColumn(data_source, col_name, col, *data_source_wrapper);
                         if (meta && col.is_arrow_string)
-                        {
-                            auto master = std::make_shared<ColumnWrapper>();
-                            transplantArrowWrapper(col, *master);
-                            master->name = col_name;
-                            meta->arrow_wrappers.emplace(col_name, std::move(master));
-                        }
+                            meta->arrow_wrappers.emplace(
+                                col_name,
+                                CHDB::PandasTableMeta::ArrowWrapperMaster{
+                                    col.arrow_string_chunks,
+                                    col.arrow_large_offsets,
+                                    col.row_count,
+                                    reinterpret_cast<uintptr_t>(col.data.ptr())});
                     }
                 }
                 else

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -1,10 +1,12 @@
 #include "StoragePython.h"
 #include "NumpyType.h"
 #include "PandasDataFrame.h"
+#include "PyBorrowGuard.h"
 #include "PybindWrapper.h"
 #include "PythonArrowStream.h"
 #include "PythonImporter.h"
 #include "PythonSource.h"
+#include "PythonTableCache.h"
 #include "PyArrowTable.h"
 #include "PyArrowStreamFactory.h"
 #include "PythonUtils.h"
@@ -144,6 +146,65 @@ static bool detectArrowStringPredicate(
         }
     }
     return false;
+}
+
+/// Reuse a session-cached Arrow string wrapper: copies the chunk-view table
+/// (plain PODs) instead of re-walking every pyarrow chunk's buffers() under
+/// the GIL. Validity is guaranteed by the metadata-cache witness check (the
+/// backing ChunkedArray identity was verified for the current query).
+static void transplantArrowWrapper(const ColumnWrapper & src, ColumnWrapper & dst)
+{
+    dst.arrow_string_chunks = src.arrow_string_chunks;
+    dst.arrow_large_offsets = src.arrow_large_offsets;
+    dst.is_arrow_string = true;
+    dst.is_object_type = false;
+    dst.data = src.data;
+    dst.buf = src.buf;
+    dst.row_count = src.row_count;
+    dst.tmp = src.data;
+    dst.tmp.inc_ref();
+    dst.borrow_guard = src.borrow_guard;
+}
+
+/// Block boundaries for the pandas scan: the fixed max_block_size grid, cut
+/// additionally at every Arrow chunk start so that blocks do not straddle
+/// chunks (a block inside one fully-valid chunk mounts its payload zero-copy).
+/// Returns nullptr when there is nothing to cut or the chunk layout is so
+/// fragmented that cutting would degenerate the block sizes.
+static PythonSource::BlockBoundsPtr computeBlockBounds(
+    const PyColumnVec & columns, size_t total_rows, size_t max_block_size)
+{
+    if (total_rows == 0)
+        return nullptr;
+
+    std::vector<UInt64> bounds;
+    for (size_t b = 0; b * max_block_size < total_rows; ++b)
+        bounds.push_back(b * max_block_size);
+
+    const size_t grid_blocks = bounds.size();
+    bool has_chunk_cuts = false;
+    for (const auto & col : columns)
+    {
+        if (!col.is_arrow_string || col.arrow_string_chunks.size() <= 1)
+            continue;
+        for (const auto & chunk : col.arrow_string_chunks)
+            if (chunk.row_start != 0 && chunk.row_start < total_rows)
+            {
+                bounds.push_back(chunk.row_start);
+                has_chunk_cuts = true;
+            }
+    }
+    if (!has_chunk_cuts)
+        return nullptr;
+
+    bounds.push_back(total_rows);
+    std::sort(bounds.begin(), bounds.end());
+    bounds.erase(std::unique(bounds.begin(), bounds.end()), bounds.end());
+
+    if (bounds.size() - 1 > 4 * (grid_blocks + 1))
+        return nullptr;
+
+    return std::make_shared<const std::vector<UInt64>>(std::move(bounds));
 }
 
 static Block pythonReadSampleBlock(StoragePython & storage, const Names & column_names, const StorageSnapshotPtr & snapshot)
@@ -318,7 +379,7 @@ Pipe StoragePython::readImpl(
     }
 
     if (!arrow_table_reader)
-        prepareColumnCache(column_names, sample_block, this->is_pandas_df, is_virtual_column);
+        prepareColumnCache(column_names, sample_block, this->is_pandas_df, is_virtual_column, context_);
 
     /// PREWHERE: prepare shared expression actions; sources convert the
     /// predicate input columns, filter, and gather the remaining columns.
@@ -477,10 +538,14 @@ Pipe StoragePython::readImpl(
         }
     }
 
+    PythonSource::BlockBoundsPtr block_bounds;
+    if (this->is_pandas_df && !arrow_table_reader && column_cache && CHDB::zeroCopyEnabled())
+        block_bounds = computeBlockBounds(*column_cache, data_source_row_count, max_block_size);
+
     Pipes pipes;
     for (size_t stream = 0; stream < num_streams; ++stream)
         pipes.emplace_back(std::make_shared<PythonSource>(
-            data_source_wrapper, false, this->is_pandas_df, sample_block, column_cache, data_source_row_count, max_block_size, stream, num_streams, format_settings, arrow_table_reader, prewhere, topk));
+            data_source_wrapper, false, this->is_pandas_df, sample_block, column_cache, data_source_row_count, max_block_size, stream, num_streams, format_settings, arrow_table_reader, prewhere, topk, block_bounds));
     return Pipe::unitePipes(std::move(pipes));
 }
 
@@ -497,6 +562,19 @@ IStorage::ColumnSizeByName StoragePython::getColumnSizes() const
     {
         py::gil_scoped_acquire acquire;
         auto & data_source = data_source_wrapper->getDataSource();
+
+        CHDB::PandasTableMetaPtr meta;
+        if (auto ctx = context.lock())
+            if (auto query_context = ctx->getQueryContext())
+                if (auto * table_cache = query_context->getPythonTableCache())
+                    meta = table_cache->findValidatedPandasMeta(data_source);
+        if (meta && meta->has_column_sizes)
+        {
+            column_sizes = meta->column_sizes;
+            column_sizes_computed = true;
+            return column_sizes;
+        }
+
         /// memory_usage(deep=False) is O(ncols) and counts Arrow buffers for
         /// arrow-backed columns; good enough to order PREWHERE conditions.
         py::object usage = data_source.attr("memory_usage")(py::arg("index") = false, py::arg("deep") = false);
@@ -511,6 +589,11 @@ IStorage::ColumnSizeByName StoragePython::getColumnSizes() const
             size.data_compressed = bytes;
             size.data_uncompressed = bytes;
             column_sizes[name] = size;
+        }
+        if (meta)
+        {
+            meta->column_sizes = column_sizes;
+            meta->has_column_sizes = true;
         }
     }
     catch (...)
@@ -568,7 +651,8 @@ void StoragePython::prepareColumnCache(
     const Names & names,
     const Block & sample_block,
     const bool is_pandas_df,
-    const std::vector<bool> & is_virtual_column)
+    const std::vector<bool> & is_virtual_column,
+    const ContextPtr & context_)
 {
     py::gil_scoped_acquire acquire;
 #if USE_JEMALLOC
@@ -603,6 +687,12 @@ void StoragePython::prepareColumnCache(
 
     if (need_rebuild)
     {
+        CHDB::PandasTableMetaPtr meta;
+        if (is_pandas_df && context_)
+            if (auto query_context = context_->getQueryContext())
+                if (auto * table_cache = query_context->getPythonTableCache())
+                    meta = table_cache->findValidatedPandasMeta(data_source);
+
         column_cache = std::make_shared<PyColumnVec>(names.size());
         for (size_t i = 0; i < names.size(); ++i)
         {
@@ -619,7 +709,28 @@ void StoragePython::prepareColumnCache(
             {
                 if (is_pandas_df)
                 {
-                    CHDB::PandasDataFrame::fillColumn(data_source, col_name, col, *data_source_wrapper);
+                    std::shared_ptr<ColumnWrapper> cached_master;
+                    if (meta)
+                    {
+                        auto found = meta->arrow_wrappers.find(col_name);
+                        if (found != meta->arrow_wrappers.end())
+                            cached_master = found->second;
+                    }
+                    if (cached_master)
+                    {
+                        transplantArrowWrapper(*cached_master, col);
+                    }
+                    else
+                    {
+                        CHDB::PandasDataFrame::fillColumn(data_source, col_name, col, *data_source_wrapper);
+                        if (meta && col.is_arrow_string)
+                        {
+                            auto master = std::make_shared<ColumnWrapper>();
+                            transplantArrowWrapper(col, *master);
+                            master->name = col_name;
+                            meta->arrow_wrappers.emplace(col_name, std::move(master));
+                        }
+                    }
                 }
                 else
                 {

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -753,6 +753,12 @@ void StoragePython::prepareColumnCache(
                 {
                     py::object col_data = data_source[py::str(col_name)];
                     col.buf = const_cast<void *>(tryGetPyArray(col_data, col.data, col.tmp, col.py_type, col.row_count));
+                    /// stride 0 now means a broadcast view in the scan loops;
+                    /// record the real element stride for array-backed buffers
+                    /// so a future consumer of this path cannot misread an
+                    /// unset default as broadcast.
+                    if (col.buf != nullptr && col.data.ptr() != nullptr && py::hasattr(col.data, "strides"))
+                        col.stride = col.data.attr("strides").attr("__getitem__")(0).cast<size_t>();
                 }
                 if (col.buf == nullptr)
                     throw Exception(

--- a/programs/local/StoragePython.h
+++ b/programs/local/StoragePython.h
@@ -168,7 +168,8 @@ private:
         const Names & names,
         const Block & sample_block,
         const bool is_pandas_df,
-        const std::vector<bool> & is_virtual_column);
+        const std::vector<bool> & is_virtual_column,
+        const ContextPtr & context_);
     PyColumnVecPtr column_cache;
     bool is_pandas_df;
     CHDB::DataSourceWrapperPtr data_source_wrapper;

--- a/programs/local/TableFunctionPython.cpp
+++ b/programs/local/TableFunctionPython.cpp
@@ -142,7 +142,39 @@ ColumnsDescription TableFunctionPython::getActualTableStructure(ContextPtr conte
     const auto & reader = data_source_wrapper->getDataSource();
 
     if (is_pandas_df)
-        return PandasDataFrame::getActualTableStructure(*data_source_wrapper, context);
+    {
+        auto * table_cache = context->getQueryContext() ? context->getQueryContext()->getPythonTableCache() : nullptr;
+        if (table_cache)
+        {
+            if (auto meta = table_cache->findValidatedPandasMeta(reader))
+            {
+                static const bool strict = []
+                {
+                    const char * env = getenv("CHDB_PANDAS_META_CACHE_STRICT"); // NOLINT(concurrency-mt-unsafe)
+                    return env && env[0] == '1';
+                }();
+                if (strict)
+                {
+                    auto fresh = PandasDataFrame::getActualTableStructure(*data_source_wrapper, context);
+                    if (fresh.toString(false) != meta->schema.toString(false))
+                    {
+                        LOG_ERROR(
+                            logger,
+                            "Pandas metadata cache strict check failed, cached schema differs from fresh inference:\n{}\nvs\n{}",
+                            meta->schema.toString(false),
+                            fresh.toString(false));
+                        table_cache->invalidatePandasMeta(reader.ptr());
+                        return fresh;
+                    }
+                }
+                return meta->schema;
+            }
+        }
+        auto columns = PandasDataFrame::getActualTableStructure(*data_source_wrapper, context);
+        if (table_cache)
+            table_cache->storePandasMeta(reader, columns);
+        return columns;
+    }
 
     if (PyArrowTable::isPyArrowTable(reader))
         return PyArrowTable::getActualTableStructure(reader, context);

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -48,6 +48,7 @@ void ColumnString::insertManyFrom(const IColumn & src, size_t position, size_t l
 void ColumnString::doInsertManyFrom(const IColumn & src, size_t position, size_t length)
 #endif
 {
+    materializeBorrowedStorage();
     /// Inserting zero copies is a no-op regardless of `position`. Returning early avoids
     /// eagerly reading `offsets[position - 1]` below, which would go out of bounds on
     /// a caller-side garbage `position` (e.g. from a `size_t` underflow).
@@ -137,6 +138,8 @@ void ColumnString::doInsertRangeFrom(const IColumn & src, size_t start, size_t l
 {
     if (length == 0)
         return;
+
+    materializeBorrowedStorage();
 
     const ColumnString & src_concrete = assert_cast<const ColumnString &>(src);
 
@@ -361,6 +364,7 @@ void ColumnString::batchSerializeValueIntoMemory(VectorWithMemoryTracking<char *
 
 void ColumnString::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings)
 {
+    materializeBorrowedStorage();
     size_t string_size = 0;
     readBinaryLittleEndian<size_t>(string_size, in);
 
@@ -627,6 +631,7 @@ size_t ColumnString::capacity() const
 
 void ColumnString::prepareForSquashing(const VectorWithMemoryTracking<ColumnPtr> & source_columns, size_t factor)
 {
+    materializeBorrowedStorage();
     size_t new_size = size();
     size_t new_chars_size = chars.size();
     for (const auto & source_column : source_columns)
@@ -642,6 +647,7 @@ void ColumnString::prepareForSquashing(const VectorWithMemoryTracking<ColumnPtr>
 
 void ColumnString::shrinkToFit()
 {
+    materializeBorrowedStorage();
     chars.shrink_to_fit();
     offsets.shrink_to_fit();
 }

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -821,8 +821,22 @@ size_t ColumnString::getEqualRangeEndAssumeSorted(size_t begin, size_t end, int 
 
 void ColumnString::protect()
 {
-    getChars().protect();
+    if (!borrow_guard)
+        getChars().protect();
     getOffsets().protect();
+}
+
+void ColumnString::materializeBorrowedStorage()
+{
+    if (!borrow_guard)
+        return;
+    const char * borrowed = reinterpret_cast<const char *>(chars.data());
+    const size_t bytes = chars.size();
+    chars.release_external_storage();
+    chars.resize_exact(bytes);
+    if (bytes)
+        memcpy(chars.data(), borrowed, bytes);
+    borrow_guard.reset();
 }
 
 void ColumnString::validate() const

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -218,6 +218,7 @@ void ColumnString::filter(const Filter & filt)
     if (offsets.empty())
         return;
 
+    materializeBorrowedStorage();
     filterArraysImplInPlace<UInt8>(chars, offsets, filt);
 }
 

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -833,10 +833,8 @@ void ColumnString::protect()
     getOffsets().protect();
 }
 
-void ColumnString::materializeBorrowedStorage()
+void ColumnString::materializeBorrowedStorageSlow()
 {
-    if (!borrow_guard)
-        return;
     const char * borrowed = reinterpret_cast<const char *>(chars.data());
     const size_t bytes = chars.size();
     chars.release_external_storage();

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -40,6 +40,10 @@ private:
     /// Bytes of strings, placed contiguously. Note that strings are not zero-terminated and could contain zero bytes in the middle.
     Chars chars;
 
+    /// When set, `chars` aliases externally-owned memory kept alive by this
+    /// guard (offsets stay owned). See borrowChars().
+    std::shared_ptr<void> borrow_guard;
+
     size_t ALWAYS_INLINE offsetAt(ssize_t i) const { return offsets[i - 1]; }
 
     /// Size of i-th element
@@ -69,6 +73,27 @@ private:
     ColumnString(const ColumnString & src);
 
 public:
+    ~ColumnString() override
+    {
+        if (borrow_guard)
+            chars.release_external_storage();
+    }
+
+    /// Mount externally-owned string payload without copying; offsets must be
+    /// filled by the caller (cumulative, relative to `data`). The guard keeps
+    /// the memory owner alive; `data + bytes` must have >= 63 readable bytes
+    /// after it (PaddedPODArray read-overflow contract). The column must be
+    /// empty. Any mutation materializes an owned copy via IColumn::mutate.
+    void borrowChars(const char * data, size_t bytes, std::shared_ptr<void> guard)
+    {
+        chassert(chars.empty() && offsets.empty());
+        chars.borrow_external_storage(const_cast<char *>(data), bytes);
+        borrow_guard = std::move(guard);
+    }
+
+    bool hasBorrowedStorage() const override { return borrow_guard != nullptr; }
+    void materializeBorrowedStorage() override;
+
     const char * getFamilyName() const override { return "String"; }
     TypeIndex getDataType() const override { return TypeIndex::String; }
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -154,6 +154,7 @@ public:
 
     void insert(const Field & x) override
     {
+        materializeBorrowedStorage();
         const String & s = x.safeGet<String>();
         const size_t old_size = chars.size();
         const size_t size_to_append = s.size();
@@ -179,6 +180,7 @@ public:
     void doInsertFrom(const IColumn & src_, size_t n) override
 #endif
     {
+        materializeBorrowedStorage();
         const ColumnString & src = assert_cast<const ColumnString &>(src_);
         const size_t size_to_append = src.sizeAt(n);
 
@@ -207,6 +209,7 @@ public:
 
     void insertData(const char * pos, size_t length) override
     {
+        materializeBorrowedStorage();
         const size_t old_size = chars.size();
         const size_t new_size = old_size + length;
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -92,7 +92,15 @@ public:
     }
 
     bool hasBorrowedStorage() const override { return borrow_guard != nullptr; }
-    void materializeBorrowedStorage() override;
+    /// Only the null check is inlined into the (hot, per-row) mutators; the
+    /// cold copy-out body stays out of line so their prologues remain minimal.
+    void materializeBorrowedStorage() override
+    {
+        if (borrow_guard) [[unlikely]]
+            materializeBorrowedStorageSlow();
+    }
+
+    NO_INLINE void materializeBorrowedStorageSlow();
 
     const char * getFamilyName() const override { return "String"; }
     TypeIndex getDataType() const override { return TypeIndex::String; }

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -995,6 +995,8 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
 template <typename T>
 void ColumnVector<T>::filter(const IColumn::Filter & filt)
 {
+    materializeBorrowedStorage();
+
     const auto size = data.size();
     const auto filter_size = filt.size();
 
@@ -1033,6 +1035,7 @@ void ColumnVector<T>::filter(const IColumn::Filter & filt)
 template <typename T>
 void ColumnVector<T>::expand(const IColumn::Filter & mask, bool inverted)
 {
+    materializeBorrowedStorage();
     expandDataByMask<T>(data, mask, inverted);
 }
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -1415,6 +1415,18 @@ ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_
 }
 
 template <typename T>
+void ColumnVector<T>::materializeBorrowedStorageSlow()
+{
+    const char * borrowed = data.raw_data();
+    const size_t n = data.size();
+    data.release_external_storage();
+    data.resize_exact(n);
+    if (n)
+        memcpy(data.data(), borrowed, n * sizeof(T));
+    borrow_guard.reset();
+}
+
+template <typename T>
 std::span<char> ColumnVector<T>::insertRawUninitialized(size_t count)
 {
     materializeBorrowedStorage();

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -55,6 +55,7 @@ namespace ErrorCodes
 template <typename T>
 void ColumnVector<T>::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings *)
 {
+    materializeBorrowedStorage();
     T element{};
     readBinaryLittleEndian<T>(element, in);
     data.emplace_back(std::move(element));
@@ -706,6 +707,7 @@ Float32 ColumnVector<T>::getFloat32(size_t n [[maybe_unused]]) const
 template <typename T>
 bool ColumnVector<T>::tryInsert(const DB::Field & x)
 {
+    materializeBorrowedStorage();
     NearestFieldType<T> value;
     if (!x.tryGet<NearestFieldType<T>>(value))
     {
@@ -732,6 +734,7 @@ void ColumnVector<T>::insertRangeFrom(const IColumn & src, size_t start, size_t 
 void ColumnVector<T>::doInsertRangeFrom(const IColumn & src, size_t start, size_t length)
 #endif
 {
+    materializeBorrowedStorage();
     const ColumnVector & src_vec = assert_cast<const ColumnVector &>(src);
 
     if (start + length > src_vec.data.size())
@@ -1259,6 +1262,7 @@ ColumnPtr ColumnVector<T>::createWithOffsets(const IColumn::Offsets & offsets, c
 template <typename T>
 void ColumnVector<T>::updateAt(const IColumn & src, size_t dst_pos, size_t src_pos)
 {
+    materializeBorrowedStorage();
     const auto & src_data = assert_cast<const Self &>(src).getData();
     data[dst_pos] = src_data[src_pos];
 }
@@ -1413,6 +1417,7 @@ ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_
 template <typename T>
 std::span<char> ColumnVector<T>::insertRawUninitialized(size_t count)
 {
+    materializeBorrowedStorage();
     size_t start = data.size();
     data.resize(start + count);
     return {reinterpret_cast<char *>(data.data() + start), count * sizeof(T)};

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -133,7 +133,40 @@ public:
 
     void protect() override
     {
-        data.protect();
+        if (!borrow_guard)
+            data.protect();
+    }
+
+    ~ColumnVector() override
+    {
+        if (borrow_guard)
+            data.release_external_storage();
+    }
+
+    /// Mount an externally-owned, contiguous value buffer without copying.
+    /// The guard keeps the owner alive; `ptr + n * sizeof(T)` must have >= 63
+    /// readable bytes after it. The column must be empty. Any mutation
+    /// materializes an owned copy via IColumn::mutate.
+    void borrowData(const void * ptr, size_t n, std::shared_ptr<void> guard)
+    {
+        chassert(data.empty());
+        data.borrow_external_storage(const_cast<char *>(static_cast<const char *>(ptr)), n * sizeof(T));
+        borrow_guard = std::move(guard);
+    }
+
+    bool hasBorrowedStorage() const override { return borrow_guard != nullptr; }
+
+    void materializeBorrowedStorage() override
+    {
+        if (!borrow_guard)
+            return;
+        const char * borrowed = data.raw_data();
+        const size_t n = data.size();
+        data.release_external_storage();
+        data.resize_exact(n);
+        if (n)
+            memcpy(data.data(), borrowed, n * sizeof(T));
+        borrow_guard.reset();
     }
 
     void insertValue(const T value)
@@ -381,6 +414,10 @@ public:
 
 protected:
     Container data;
+
+private:
+    /// When set, `data` aliases externally-owned memory kept alive by this guard.
+    std::shared_ptr<void> borrow_guard;
 };
 
 template <class TCol>

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -162,17 +162,14 @@ public:
 
     bool hasBorrowedStorage() const override { return borrow_guard != nullptr; }
 
+    NO_INLINE void materializeBorrowedStorageSlow();
+
+    /// Only the null check is inlined into the (hot, per-row) mutators; the
+    /// cold copy-out body stays out of line so their prologues remain minimal.
     void materializeBorrowedStorage() override
     {
-        if (!borrow_guard)
-            return;
-        const char * borrowed = data.raw_data();
-        const size_t n = data.size();
-        data.release_external_storage();
-        data.resize_exact(n);
-        if (n)
-            memcpy(data.data(), borrowed, n * sizeof(T));
-        borrow_guard.reset();
+        if (borrow_guard) [[unlikely]]
+            materializeBorrowedStorageSlow();
     }
 
     void insertValue(const T value)

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -64,6 +64,7 @@ public:
     void doInsertFrom(const IColumn & src, size_t n) override
 #endif
     {
+        materializeBorrowedStorage();
         data.push_back(assert_cast<const Self &>(src).getData()[n]);
     }
 
@@ -73,27 +74,32 @@ public:
     void doInsertManyFrom(const IColumn & src, size_t position, size_t length) override
 #endif
     {
+        materializeBorrowedStorage();
         ValueType v = assert_cast<const Self &>(src).getData()[position];
         data.resize_fill(data.size() + length, v);
     }
 
     void insertMany(const Field & field, size_t length) override
     {
+        materializeBorrowedStorage();
         data.resize_fill(data.size() + length, static_cast<T>(field.safeGet<T>()));
     }
 
     void insertData(const char * pos, size_t) override
     {
+        materializeBorrowedStorage();
         data.emplace_back(unalignedLoad<T>(pos));
     }
 
     void insertDefault() override
     {
+        materializeBorrowedStorage();
         data.push_back(T());
     }
 
     void insertManyDefaults(size_t length) override
     {
+        materializeBorrowedStorage();
         data.resize_fill(data.size() + length, T());
     }
 
@@ -245,6 +251,7 @@ public:
 
     void reserve(size_t n) override
     {
+        materializeBorrowedStorage();
         data.reserve_exact(n);
     }
 
@@ -255,6 +262,7 @@ public:
 
     void shrinkToFit() override
     {
+        materializeBorrowedStorage();
         data.shrink_to_fit();
     }
 
@@ -310,6 +318,7 @@ public:
 
     void insert(const Field & x) override
     {
+        materializeBorrowedStorage();
         data.push_back(static_cast<T>(x.safeGet<T>()));
     }
 

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -763,6 +763,13 @@ public:
     /// Same as above but assumes every entry in the list is non-null
     virtual void fillFromBlocksAndRowNumbers(size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers);
 
+    /// Whether the column's storage aliases externally-owned memory (e.g.
+    /// Python buffers mounted zero-copy by chdb). Such columns are read-only;
+    /// IColumn::mutate materializes them into owned storage before handing
+    /// out a mutable reference.
+    virtual bool hasBorrowedStorage() const { return false; }
+    virtual void materializeBorrowedStorage() {}
+
     /// Some columns may require finalization before using of other operations.
     virtual void finalize() {}
     virtual bool isFinalized() const { return true; }
@@ -779,6 +786,8 @@ public:
         MutablePtr res = ptr->shallowMutate(); /// Now use_count is 2.
         ptr.reset(); /// Reset use_count to 1.
         res->forEachMutableSubcolumn([](WrappedPtr & subcolumn) { subcolumn = IColumn::mutate(std::move(subcolumn).detach()); });
+        if (res->hasBorrowedStorage())
+            res->materializeBorrowedStorage();
         return res;
     }
 

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -143,6 +143,9 @@ protected:
         if (c_start == null)
             return;
 
+#ifndef NDEBUG
+        chassert(!borrowed_external);
+#endif
         unprotect();
 
         TAllocator::free(c_start - pad_left, allocated_bytes());
@@ -157,6 +160,9 @@ protected:
             return;
         }
 
+#ifndef NDEBUG
+        chassert(!borrowed_external);
+#endif
         unprotect();
 
         ptrdiff_t end_diff = c_end - c_start;
@@ -222,6 +228,8 @@ protected:
 
     /// Restore memory protection in destructor or realloc for further reuse by allocator.
     bool mprotected = false;
+    /// Storage aliases externally-owned memory (see borrow_external_storage).
+    bool borrowed_external = false;
 #endif
 
 public:
@@ -301,9 +309,41 @@ public:
         c_end += bytes_to_copy;
     }
 
+    /// Point the array at externally-owned memory (e.g. Arrow/numpy buffers)
+    /// without copying. Constraints the owner (a column) must uphold:
+    /// - the external owner outlives the array's use of the memory;
+    /// - at least 63 readable bytes follow `ptr + bytes` (pad_right contract);
+    /// - the memory is never written through this array: any mutation path
+    ///   must materialize an owned copy first (IColumn::mutate hook), and
+    ///   release_external_storage() must be called before destruction.
+    void borrow_external_storage(char * ptr, size_t bytes) /// NOLINT
+    {
+        dealloc();
+        c_start = ptr;
+        c_end = ptr + bytes;
+        c_end_of_storage = ptr + bytes;
+#ifndef NDEBUG
+        borrowed_external = true;
+#endif
+    }
+
+    /// Forget borrowed pointers; the array becomes empty. Must only be called
+    /// while the storage is borrowed (owned storage would leak).
+    void release_external_storage() /// NOLINT
+    {
+#ifndef NDEBUG
+        chassert(borrowed_external || c_start == null);
+        borrowed_external = false;
+#endif
+        c_start = null;
+        c_end = null;
+        c_end_of_storage = null;
+    }
+
     void protect()
     {
 #ifndef NDEBUG
+        chassert(!borrowed_external);
         protectImpl(PROT_READ);
         mprotected = true;
 #endif

--- a/src/Processors/Sinks/SinkToStorage.cpp
+++ b/src/Processors/Sinks/SinkToStorage.cpp
@@ -1,12 +1,50 @@
 #include <Processors/Sinks/SinkToStorage.h>
 
+#include <Columns/IColumn.h>
+
 namespace DB
 {
+
+namespace
+{
+
+bool hasBorrowedStorageDeep(const IColumn & column)
+{
+    if (column.hasBorrowedStorage())
+        return true;
+    bool found = false;
+    column.forEachSubcolumnRecursively([&](const IColumn & subcolumn)
+    {
+        found = found || subcolumn.hasBorrowedStorage();
+    });
+    return found;
+}
+
+/// Columns handed to a storage sink may be retained beyond the current query
+/// (Memory/Join/Set/Buffer tables, materialized views). A column mounted
+/// zero-copy over an externally-owned buffer (e.g. Python(df)) must own its
+/// memory before that: otherwise the stored data would alias - and be
+/// silently rewritten by - later writes to the external buffer, and would pin
+/// it for the lifetime of the storage. No-op for regular columns.
+void materializeBorrowedColumns(Chunk & chunk)
+{
+    if (!chunk.hasColumns())
+        return;
+    const size_t num_rows = chunk.getNumRows();
+    auto columns = chunk.detachColumns();
+    for (auto & column : columns)
+        if (column && hasBorrowedStorageDeep(*column))
+            column = IColumn::mutate(std::move(column));
+    chunk.setColumns(std::move(columns), num_rows);
+}
+
+}
 
 SinkToStorage::SinkToStorage(SharedHeader header) : ExceptionKeepingTransform(header, header, false) {}
 
 void SinkToStorage::onConsume(Chunk chunk)
 {
+    materializeBorrowedColumns(chunk);
     consume(chunk);
     cur_chunk = std::move(chunk);
 }

--- a/tests/test_pandas_meta_cache.py
+++ b/tests/test_pandas_meta_cache.py
@@ -1,0 +1,260 @@
+#!python3
+
+import gc
+import os
+import subprocess
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import chdb
+
+PANDAS3 = int(pd.__version__.split(".")[0]) >= 3
+
+
+def make_df(nrows=1000, tag=""):
+    return pd.DataFrame(
+        {
+            "i64": np.arange(nrows, dtype=np.int64),
+            "i32": np.arange(nrows, dtype=np.int32) * 2,
+            "f64": np.arange(nrows, dtype=np.float64) / 3.0,
+            "s": [f"{tag}str{j % 7}" for j in range(nrows)],
+        }
+    )
+
+
+class TestPandasMetaCache(unittest.TestCase):
+    def setUp(self):
+        self.conn = chdb.connect(":memory:")
+
+    def tearDown(self):
+        self.conn.close()
+
+    def q(self, sql):
+        return str(self.conn.query(sql, "CSV")).strip()
+
+    def test_repeated_query_stable(self):
+        df = make_df()  # noqa: F841
+        expected = self.q("SELECT count(), sum(i64), sum(i32), min(s), max(s) FROM Python(df)")
+        for _ in range(5):
+            self.assertEqual(
+                self.q("SELECT count(), sum(i64), sum(i32), min(s), max(s) FROM Python(df)"), expected
+            )
+        self.assertEqual(expected, '1000,499500,999000,"str0","str6"')
+
+    def test_rebind_to_new_dataframe(self):
+        df = make_df(100)  # noqa: F841
+        self.assertEqual(self.q("SELECT count(), sum(i64) FROM Python(df)"), "100,4950")
+        df = make_df(50, tag="new")  # noqa: F841
+        self.assertEqual(self.q("SELECT count(), sum(i64), min(s) FROM Python(df)"), '50,1225,"newstr0"')
+
+    def test_replace_numeric_column_same_dtype(self):
+        df = make_df(100)
+        self.assertEqual(self.q("SELECT sum(i64) FROM Python(df)"), "4950")
+        df["i64"] = df["i64"] + 1000000
+        self.assertEqual(self.q("SELECT sum(i64) FROM Python(df)"), str(4950 + 100 * 1000000))
+
+    def test_inplace_numeric_write_visible(self):
+        df = make_df(100)
+        self.assertEqual(self.q("SELECT sum(i64) FROM Python(df)"), "4950")
+        df.loc[0, "i64"] = 777
+        self.assertEqual(self.q("SELECT sum(i64) FROM Python(df)"), str(4950 + 777))
+        self.assertEqual(self.q("SELECT i64 FROM Python(df) WHERE i64 = 777"), "777")
+
+    def test_string_column_write_visible(self):
+        df = make_df(100)
+        self.assertEqual(self.q("SELECT count() FROM Python(df) WHERE s = 'CHANGED'"), "0")
+        df.loc[3, "s"] = "CHANGED"
+        self.assertEqual(self.q("SELECT count() FROM Python(df) WHERE s = 'CHANGED'"), "1")
+        self.assertEqual(self.q("SELECT i64 FROM Python(df) WHERE s = 'CHANGED'"), "3")
+
+    def test_replace_whole_string_column(self):
+        df = make_df(10)
+        self.q("SELECT count() FROM Python(df)")
+        df["s"] = [f"rep{j}" for j in range(10)]
+        self.assertEqual(self.q("SELECT min(s), max(s) FROM Python(df)"), '"rep0","rep9"')
+
+    def test_add_drop_rename_column(self):
+        df = make_df(10)
+        self.assertEqual(self.q("SELECT count() FROM Python(df)"), "10")
+        df["extra"] = np.arange(10, dtype=np.int64) * 10
+        self.assertEqual(self.q("SELECT sum(extra) FROM Python(df)"), "450")
+        df = df.drop(columns=["extra"])
+        with self.assertRaises(Exception):
+            self.conn.query("SELECT sum(extra) FROM Python(df)", "CSV")
+        df = df.rename(columns={"i64": "renamed"})
+        self.assertEqual(self.q("SELECT sum(renamed) FROM Python(df)"), "45")
+
+    def test_append_rows_visible(self):
+        df = make_df(10)
+        self.assertEqual(self.q("SELECT count() FROM Python(df)"), "10")
+        df.loc[len(df)] = [999, 999, 9.9, "appended"]
+        self.assertEqual(self.q("SELECT count() FROM Python(df)"), "11")
+        self.assertEqual(self.q("SELECT count() FROM Python(df) WHERE s = 'appended'"), "1")
+
+    def test_dtype_change_visible(self):
+        df = make_df(10)
+        self.assertEqual(self.q("SELECT toTypeName(i64) FROM Python(df) LIMIT 1"), '"Int64"')
+        df["i64"] = df["i64"].astype(np.float64)
+        self.assertIn("Float64", self.q("SELECT toTypeName(i64) FROM Python(df) LIMIT 1"))
+
+    def test_del_and_recreate(self):
+        df = make_df(10)
+        self.assertEqual(self.q("SELECT count() FROM Python(df)"), "10")
+        del df
+        gc.collect()
+        df = make_df(20, tag="again")  # noqa: F841
+        self.assertEqual(self.q("SELECT count(), min(s) FROM Python(df)"), '20,"againstr0"')
+
+    def test_weakref_does_not_extend_lifetime(self):
+        import weakref
+
+        df = make_df(10)
+        ref = weakref.ref(df)
+        self.q("SELECT count() FROM Python(df)")
+        del df
+        # The previous query's storage may hold the frame until the next query
+        # flushes it (pre-existing chdb behavior, cache-independent).
+        self.q("SELECT 1")
+        gc.collect()
+        self.assertIsNone(ref(), "metadata cache must not keep the DataFrame alive")
+
+    def test_object_column_bypass_and_mutation(self):
+        df = pd.DataFrame({"a": np.arange(5, dtype=np.int64), "o": pd.Series([{"k": 1}] * 5, dtype=object)})
+        first = self.q("SELECT count() FROM Python(df)")
+        self.assertEqual(first, "5")
+        second = self.q("SELECT count() FROM Python(df)")
+        self.assertEqual(second, "5")
+
+    def test_category_column_bypass(self):
+        df = pd.DataFrame({"c": pd.Categorical(["x", "y", "x", "z"]), "v": np.arange(4, dtype=np.int64)})
+        self.assertEqual(
+            self.q("SELECT c, sum(v) FROM Python(df) GROUP BY c ORDER BY c"), '"x",2\n"y",1\n"z",3'
+        )
+        self.assertEqual(
+            self.q("SELECT c, sum(v) FROM Python(df) GROUP BY c ORDER BY c"), '"x",2\n"y",1\n"z",3'
+        )
+
+    @unittest.skipUnless(PANDAS3, "arrow-backed str dtype requires pandas 3")
+    def test_nullable_flip_string_column(self):
+        df = pd.DataFrame({"s": pd.array(["a", "b", "c"], dtype="str")})
+        self.assertEqual(self.q("SELECT toTypeName(s) FROM Python(df) LIMIT 1"), '"String"')
+        df.loc[1, "s"] = None
+        self.assertIn("Nullable", self.q("SELECT toTypeName(s) FROM Python(df) LIMIT 1"))
+        self.assertEqual(self.q("SELECT count() FROM Python(df) WHERE s IS NULL"), "1")
+        df.loc[1, "s"] = "b"
+        self.assertEqual(self.q("SELECT toTypeName(s) FROM Python(df) LIMIT 1"), '"String"')
+        self.assertEqual(self.q("SELECT count() FROM Python(df) WHERE s IS NULL"), "0")
+
+    def test_multiple_dataframes_lru(self):
+        dfs = {}
+        for k in range(6):
+            dfs[f"lru{k}"] = make_df(10 + k, tag=f"t{k}")
+        for k in range(6):
+            globals()[f"lru{k}"] = dfs[f"lru{k}"]
+        try:
+            for _ in range(2):
+                for k in range(6):
+                    self.assertEqual(
+                        self.q(f"SELECT count(), min(s) FROM Python(lru{k})"), f'{10 + k},"t{k}str0"'
+                    )
+        finally:
+            for k in range(6):
+                del globals()[f"lru{k}"]
+
+    def test_integer_column_labels_consistent(self):
+        # Scanning int-labeled columns is a pre-existing chdb limitation
+        # (fillColumn indexes with str(label)); the cache must not change the
+        # behavior between the first and repeated runs.
+        df = pd.DataFrame({0: np.arange(10, dtype=np.int64), 1: [f"v{j}" for j in range(10)]})
+        outcomes = []
+        for _ in range(3):
+            try:
+                outcomes.append(("ok", self.q('SELECT sum("0") FROM Python(df)')))
+            except Exception as e:
+                outcomes.append(("err", type(e).__name__))
+        self.assertEqual(len(set(outcomes)), 1, outcomes)
+        self.assertEqual(self.q("SELECT count() FROM Python(df)"), "10")
+
+    def test_dead_entry_evicted_on_next_query(self):
+        import weakref
+
+        df = make_df(10)
+        backing = weakref.ref(df["s"].array._pa_array) if PANDAS3 else None
+        self.q("SELECT count() FROM Python(df)")
+        del df
+        gc.collect()
+        other = make_df(5)  # noqa: F841
+        # First query releases the prior query's storage (which still holds the
+        # frame); the second query's eviction sweep then sees the dead weakref.
+        self.q("SELECT count() FROM Python(other)")
+        gc.collect()
+        self.q("SELECT count() FROM Python(other)")
+        gc.collect()
+        if backing is not None:
+            self.assertIsNone(backing(), "cached string backing must be released after the owner died")
+
+    def test_two_tables_in_one_query(self):
+        left = make_df(10, tag="l")  # noqa: F841
+        right = make_df(10, tag="r")  # noqa: F841
+        self.assertEqual(
+            self.q(
+                "SELECT count() FROM Python(left) a JOIN Python(right) b ON a.i64 = b.i64"
+            ),
+            "10",
+        )
+
+    def test_multi_chunk_string_column(self):
+        parts = [make_df(100, tag=f"p{i}") for i in range(5)]
+        df = pd.concat(parts, ignore_index=True)
+        if PANDAS3:
+            self.assertGreater(df["s"].array._pa_array.num_chunks, 1)
+        expected = "500," + str(sum(range(100)) * 5 + 100 * 2 * sum(range(5)) * 0)
+        self.assertEqual(self.q("SELECT count(), sum(i64) FROM Python(df)"), "500," + str(sum(range(100)) * 5))
+        self.assertEqual(self.q("SELECT countDistinct(s) FROM Python(df)"), str(7 * 5))
+        del expected
+
+
+ENV_MODE_SCRIPT = r"""
+import numpy as np, pandas as pd, chdb
+conn = chdb.connect(':memory:')
+df = pd.DataFrame({'a': np.arange(100, dtype=np.int64), 's': [f's{i%5}' for i in range(100)]})
+out = []
+out.append(str(conn.query('SELECT count(), sum(a), min(s) FROM Python(df)', 'CSV')).strip())
+out.append(str(conn.query('SELECT count(), sum(a), min(s) FROM Python(df)', 'CSV')).strip())
+df.loc[0, 's'] = 'zz'
+out.append(str(conn.query("SELECT count() FROM Python(df) WHERE s = 'zz'", 'CSV')).strip())
+df['a'] = df['a'] * 2
+out.append(str(conn.query('SELECT sum(a) FROM Python(df)', 'CSV')).strip())
+print('|'.join(out))
+"""
+
+
+class TestMetaCacheEnvModes(unittest.TestCase):
+    def run_mode(self, extra_env):
+        env = dict(os.environ)
+        env.update(extra_env)
+        res = subprocess.run(
+            [sys.executable, "-c", ENV_MODE_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=180,
+            check=False,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr[-2000:])
+        return res.stdout.strip().splitlines()[-1]
+
+    def test_disabled_and_strict_match_default(self):
+        default = self.run_mode({})
+        disabled = self.run_mode({"CHDB_PANDAS_META_CACHE": "0"})
+        strict = self.run_mode({"CHDB_PANDAS_META_CACHE_STRICT": "1"})
+        self.assertEqual(default, disabled)
+        self.assertEqual(default, strict)
+        self.assertEqual(default, "100,4950,\"s0\"|100,4950,\"s0\"|1|9900")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pandas_meta_cache.py
+++ b/tests/test_pandas_meta_cache.py
@@ -14,6 +14,15 @@ import chdb
 PANDAS3 = int(pd.__version__.split(".")[0]) >= 3
 
 
+def refresh_frame_locals():
+    """chdb's variable lookup walks every stack frame's f_locals; on
+    Python <= 3.12 (pre-PEP 667) that access materializes a cached snapshot
+    dict on the frame which holds strong references and is NOT updated by
+    `del`. Re-reading f_locals refreshes the snapshot and drops deleted
+    entries, so weakref-release assertions see the true liveness."""
+    sys._getframe(1).f_locals  # noqa: B018
+
+
 def make_df(nrows=1000, tag=""):
     return pd.DataFrame(
         {
@@ -115,6 +124,7 @@ class TestPandasMetaCache(unittest.TestCase):
         ref = weakref.ref(df)
         self.q("SELECT count() FROM Python(df)")
         del df
+        refresh_frame_locals()
         gc.collect()
         self.assertIsNone(ref(), "metadata cache must not keep the DataFrame alive")
 
@@ -182,6 +192,7 @@ class TestPandasMetaCache(unittest.TestCase):
         backing = weakref.ref(df["s"].array._pa_array) if PANDAS3 else None
         self.q("SELECT count(), min(s) FROM Python(df)")
         del df
+        refresh_frame_locals()
         gc.collect()
         if backing is not None:
             self.assertIsNone(

--- a/tests/test_pandas_meta_cache.py
+++ b/tests/test_pandas_meta_cache.py
@@ -115,9 +115,6 @@ class TestPandasMetaCache(unittest.TestCase):
         ref = weakref.ref(df)
         self.q("SELECT count() FROM Python(df)")
         del df
-        # The previous query's storage may hold the frame until the next query
-        # flushes it (pre-existing chdb behavior, cache-independent).
-        self.q("SELECT 1")
         gc.collect()
         self.assertIsNone(ref(), "metadata cache must not keep the DataFrame alive")
 
@@ -178,23 +175,20 @@ class TestPandasMetaCache(unittest.TestCase):
         self.assertEqual(len(set(outcomes)), 1, outcomes)
         self.assertEqual(self.q("SELECT count() FROM Python(df)"), "10")
 
-    def test_dead_entry_evicted_on_next_query(self):
+    def test_string_backing_released_immediately(self):
         import weakref
 
         df = make_df(10)
         backing = weakref.ref(df["s"].array._pa_array) if PANDAS3 else None
-        self.q("SELECT count() FROM Python(df)")
+        self.q("SELECT count(), min(s) FROM Python(df)")
         del df
         gc.collect()
-        other = make_df(5)  # noqa: F841
-        # First query releases the prior query's storage (which still holds the
-        # frame); the second query's eviction sweep then sees the dead weakref.
-        self.q("SELECT count() FROM Python(other)")
-        gc.collect()
-        self.q("SELECT count() FROM Python(other)")
-        gc.collect()
         if backing is not None:
-            self.assertIsNone(backing(), "cached string backing must be released after the owner died")
+            self.assertIsNone(
+                backing(),
+                "the metadata cache holds string backings only via weakref; "
+                "deleting the DataFrame must free the payload without any follow-up query",
+            )
 
     def test_two_tables_in_one_query(self):
         left = make_df(10, tag="l")  # noqa: F841

--- a/tests/test_zero_copy_lifetime.py
+++ b/tests/test_zero_copy_lifetime.py
@@ -1,0 +1,339 @@
+#!python3
+
+"""Lifetime, memory-integrity, and repeated-execution tests for the pandas
+scan optimizations (metadata cache + zero-copy mounts).
+
+Invariants pinned here:
+- Borrowed buffers are never modified by query execution (checksums).
+- Python references taken for a query are released at that query's end;
+  nothing waits for a future query.
+- DDL that stores scan output (CREATE TABLE ... AS SELECT) keeps data valid
+  after the source DataFrame dies, and connection close releases everything.
+- Repeated and concurrent execution is stable and does not accumulate memory.
+"""
+
+import gc
+import hashlib
+import threading
+import unittest
+import weakref
+
+import numpy as np
+import pandas as pd
+
+import chdb
+
+PANDAS3 = int(pd.__version__.split(".")[0]) >= 3
+
+
+def make_df(n=100_000, tag=""):
+    return pd.DataFrame(
+        {
+            "i64": np.arange(n, dtype=np.int64),
+            "f64": np.arange(n, dtype=np.float64) / 7.0,
+            "s": pd.array([f"{tag}payload-{i % 9973:05d}" for i in range(n)], dtype="str")
+            if PANDAS3
+            else [f"{tag}payload-{i % 9973:05d}" for i in range(n)],
+        }
+    )
+
+
+def buffer_checksums(df):
+    """Hashes of the raw memory the engine may borrow: numpy data + arrow chunk buffers."""
+    sums = [hashlib.sha256(df["i64"].to_numpy().tobytes()).hexdigest(),
+            hashlib.sha256(df["f64"].to_numpy().tobytes()).hexdigest()]
+    if PANDAS3:
+        for chunk in df["s"].array._pa_array.chunks:
+            for buf in chunk.buffers():
+                if buf is not None:
+                    sums.append(hashlib.sha256(bytes(buf)).hexdigest())
+    return sums
+
+
+class TestBorrowedBufferIntegrity(unittest.TestCase):
+    """Query execution must never write through borrowed df buffers."""
+
+    def test_query_matrix_leaves_buffers_untouched(self):
+        conn = chdb.connect(":memory:")
+        try:
+            df = make_df()  # noqa: F841
+            before = buffer_checksums(df)
+            queries = [
+                "SELECT count(), sum(i64), sum(f64) FROM Python(df)",
+                "SELECT s, count() FROM Python(df) GROUP BY s ORDER BY count() DESC, s LIMIT 10",
+                "SELECT * FROM Python(df) ORDER BY i64 DESC LIMIT 5",
+                "SELECT * FROM Python(df) WHERE s LIKE '%payload-000%' ORDER BY i64 LIMIT 7",
+                "SELECT lower(s), upper(s), length(s) FROM Python(df) ORDER BY i64 LIMIT 3",
+                "SELECT a.i64 FROM Python(df) a JOIN Python(df) b ON a.i64 = b.i64 WHERE a.i64 < 100 ORDER BY a.i64",
+                "SELECT i64, f64, s FROM Python(df) WHERE i64 % 3 = 0 ORDER BY f64 DESC LIMIT 11",
+                "SELECT DISTINCT s FROM Python(df) ORDER BY s LIMIT 13",
+                "SELECT sum(cityHash64(s)) FROM Python(df)",
+                "SELECT max(s), min(s) FROM Python(df)",
+            ]
+            for q in queries:
+                str(conn.query(q, "CSV"))
+            conn.query("CREATE TABLE zc_mat ENGINE = Memory AS SELECT * FROM Python(df)", "CSV")
+            conn.query("DROP TABLE zc_mat", "CSV")
+            self.assertEqual(before, buffer_checksums(df),
+                             "query execution modified borrowed DataFrame memory")
+        finally:
+            conn.close()
+
+
+class TestDDLRetention(unittest.TestCase):
+    """Scan output stored into a table must stay valid after the df dies."""
+
+    def test_memory_table_correct_after_df_deleted(self):
+        conn = chdb.connect(":memory:")
+        try:
+            n = 200_000
+            df = make_df(n)  # noqa: F841
+            wr_df = weakref.ref(df)
+            conn.query("CREATE TABLE zc_keep ENGINE = Memory AS SELECT * FROM Python(df)", "CSV")
+            del df
+            gc.collect()
+            self.assertIsNone(wr_df(), "df itself must not be pinned after the DDL query ends")
+            got = str(conn.query(
+                "SELECT count(), sum(i64), min(s), max(s) FROM zc_keep", "CSV")).strip()
+            expected = f'{n},{(n - 1) * n // 2},"payload-00000","payload-09972"'
+            self.assertEqual(got, expected)
+            conn.query("DROP TABLE zc_keep", "CSV")
+        finally:
+            conn.close()
+
+    @unittest.skipUnless(PANDAS3, "arrow-backed str dtype requires pandas 3")
+    def test_stored_table_owns_its_data(self):
+        # Sinks materialize borrowed columns, so a table built from Python(df)
+        # owns copies: nothing pins the df once the DDL query has ended.
+        conn = chdb.connect(":memory:")
+        try:
+            df = make_df(200_000)
+            wr_pa = weakref.ref(df["s"].array._pa_array)
+            conn.query("CREATE TABLE zc_pin ENGINE = Memory AS SELECT * FROM Python(df)", "CSV")
+            del df
+            gc.collect()
+            self.assertIsNone(wr_pa(),
+                              "table must store owned copies; df backing still pinned")
+            conn.query("DROP TABLE zc_pin", "CSV")
+        finally:
+            conn.close()
+
+    def test_memory_table_is_snapshot_not_alias(self):
+        # Mutating the DataFrame after INSERT must not rewrite table data.
+        conn = chdb.connect(":memory:")
+        try:
+            n = 100_000
+            arr = np.arange(n, dtype=np.int64)
+            df = pd.DataFrame({"x": arr}, copy=False)  # noqa: F841
+            conn.query("CREATE TABLE zc_snap ENGINE = Memory AS SELECT * FROM Python(df)", "CSV")
+            arr[:] = 0
+            got = str(conn.query("SELECT sum(x), min(x), max(x) FROM zc_snap", "CSV")).strip()
+            self.assertEqual(got, f"{(n - 1) * n // 2},0,{n - 1}",
+                             "Memory table aliases the numpy buffer instead of owning a snapshot")
+            if df["x"].to_numpy().base is not None:  # buffer actually shared
+                live = str(conn.query("SELECT sum(x) FROM Python(df)", "CSV")).strip()
+                self.assertEqual(live, "0", "direct scans do read live values by design")
+            conn.query("DROP TABLE zc_snap", "CSV")
+        finally:
+            conn.close()
+
+    def test_join_table_is_snapshot(self):
+        conn = chdb.connect(":memory:")
+        try:
+            n = 50_000
+            arr = np.arange(n, dtype=np.int64)
+            df = pd.DataFrame({"k": arr, "v": arr * 2}, copy=False)  # noqa: F841
+            conn.query("CREATE TABLE zc_join (k Int64, v Int64) ENGINE = Join(ANY, LEFT, k)", "CSV")
+            conn.query("INSERT INTO zc_join SELECT * FROM Python(df)", "CSV")
+            arr[:] = 0
+            got = str(conn.query("SELECT joinGet('zc_join', 'v', toInt64(100))", "CSV")).strip()
+            self.assertEqual(got, "200", "Join table payload aliases the numpy buffer")
+            conn.query("DROP TABLE zc_join", "CSV")
+        finally:
+            conn.close()
+
+
+class TestZeroCopyEligibility(unittest.TestCase):
+    def test_broadcast_stride_zero_column(self):
+        # numpy broadcast views (stride 0) must yield the broadcast value,
+        # never a walk over unrelated process memory.
+        conn = chdb.connect(":memory:")
+        try:
+            n = 100_000
+            df = pd.DataFrame({"f": np.broadcast_to(np.float64(7.0), (n,)),
+                               "i": np.broadcast_to(np.int64(42), (n,))}, copy=False)
+            self.assertEqual(df["f"].to_numpy().strides[0], 0)
+            got = str(conn.query(
+                "SELECT count(), min(f), max(f), min(i), max(i) FROM Python(df)", "CSV")).strip()
+            self.assertEqual(got, f"{n},7,7,42,42")
+        finally:
+            conn.close()
+
+
+class TestErrorPathStateReset(unittest.TestCase):
+    def test_streaming_init_error_then_rebind(self):
+        # A failed send_query must not leave a stale df handle: rebinding the
+        # name serves the new data, deleting it raises instead of hanging.
+        conn = chdb.connect(":memory:")
+        try:
+            global sdf
+            sdf = pd.DataFrame({"a": np.array([1, 2, 3], dtype=np.int64)})
+            with self.assertRaises(Exception):
+                conn.send_query("SELECT * FROM Python(sdf) WHERE ((", "CSV")
+            sdf = pd.DataFrame({"a": np.array([99], dtype=np.int64)})
+            got = str(conn.query("SELECT sum(a) FROM Python(sdf)", "CSV")).strip()
+            self.assertEqual(got, "99", "stale handle from failed streaming init was reused")
+            del sdf
+            gc.collect()
+            with self.assertRaises(Exception):
+                conn.query("SELECT sum(a) FROM Python(sdf)", "CSV")
+        finally:
+            globals().pop("sdf", None)
+            conn.close()
+
+
+class TestReleaseWithoutFutureQuery(unittest.TestCase):
+    """Refs taken for a query are dropped at that query's end - never later."""
+
+    @unittest.skipUnless(PANDAS3, "arrow-backed str dtype requires pandas 3")
+    def test_plain_query_releases_at_query_end(self):
+        conn = chdb.connect(":memory:")
+        try:
+            df = make_df()
+            wr_pa = weakref.ref(df["s"].array._pa_array)
+            str(conn.query("SELECT count(), max(s) FROM Python(df)", "CSV"))
+            del df
+            gc.collect()
+            self.assertIsNone(wr_pa())
+        finally:
+            conn.close()
+
+    @unittest.skipUnless(PANDAS3, "arrow-backed str dtype requires pandas 3")
+    def test_streaming_close_releases(self):
+        conn = chdb.connect(":memory:")
+        try:
+            df = make_df()
+            wr_pa = weakref.ref(df["s"].array._pa_array)
+            stream = conn.send_query("SELECT i64, s FROM Python(df)", "CSV")
+            next(iter(stream))  # consume one chunk, abandon the rest
+            stream.close()
+            del stream, df
+            gc.collect()
+            self.assertIsNone(wr_pa(), "abandoned stream must release on close, not on a later query")
+        finally:
+            conn.close()
+
+    @unittest.skipUnless(PANDAS3, "arrow-backed str dtype requires pandas 3")
+    def test_failed_query_releases(self):
+        conn = chdb.connect(":memory:")
+        try:
+            df = make_df()
+            wr_pa = weakref.ref(df["s"].array._pa_array)
+            with self.assertRaises(Exception):
+                conn.query("SELECT throwIf(i64 = 5000, 'boom'), s FROM Python(df)", "CSV")
+            del df
+            gc.collect()
+            self.assertIsNone(wr_pa(), "error path must release without a follow-up query")
+        finally:
+            conn.close()
+
+
+class TestRepeatedAndConcurrent(unittest.TestCase):
+    def test_repeated_queries_stable_and_bounded(self):
+        conn = chdb.connect(":memory:")
+        try:
+            df = make_df()  # noqa: F841
+            expected = str(conn.query(
+                "SELECT s, count() AS c FROM Python(df) GROUP BY s ORDER BY c DESC, s LIMIT 5", "CSV"))
+
+            def rss_kb():
+                with open("/proc/self/status") as f:
+                    for line in f:
+                        if line.startswith("VmRSS:"):
+                            return int(line.split()[1])
+
+            samples = []
+            for i in range(100):
+                got = str(conn.query(
+                    "SELECT s, count() AS c FROM Python(df) GROUP BY s ORDER BY c DESC, s LIMIT 5", "CSV"))
+                self.assertEqual(got, expected, f"iteration {i} diverged")
+                samples.append(rss_kb())
+            growth_kb = samples[-1] - samples[9]
+            self.assertLess(growth_kb, 200_000,
+                            f"RSS grew {growth_kb} KB over 90 repeated queries")
+        finally:
+            conn.close()
+
+    def test_cross_thread_serialized_queries(self):
+        """Queries issued from different threads (one at a time) must behave
+        exactly like same-thread queries: frame discovery, cache revalidation,
+        and per-query release all work per issuing thread."""
+        conn = chdb.connect(":memory:")
+        lock = threading.Lock()
+        try:
+            n1, n2 = 50_000, 30_000
+            global tdf1, tdf2
+            tdf1, tdf2 = make_df(n1, "a"), make_df(n2, "b")
+            exp = {"tdf1": f"{n1},{(n1 - 1) * n1 // 2}", "tdf2": f"{n2},{(n2 - 1) * n2 // 2}"}
+            errors = []
+
+            def worker(name):
+                try:
+                    for _ in range(20):
+                        with lock:
+                            got = str(conn.query(
+                                f"SELECT count(), sum(i64) FROM Python({name})", "CSV")).strip()
+                        if got != exp[name]:
+                            errors.append(f"{name}: {got} != {exp[name]}")
+                except Exception as e:  # noqa: BLE001
+                    errors.append(f"{name}: {type(e).__name__}: {e}")
+
+            threads = [threading.Thread(target=worker, args=(n,))
+                       for n in ("tdf1", "tdf2", "tdf1", "tdf2")]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            self.assertEqual(errors, [])
+        finally:
+            del tdf1, tdf2
+            conn.close()
+
+    def test_unsynchronized_threads_never_return_wrong_data(self):
+        """True concurrent submission on one connection is a pre-existing
+        weak spot (the stock 26.5 wheel fails most such queries with
+        PY_OBJECT_NOT_FOUND). Pin the safety property that matters: a query
+        either returns the exact correct result or raises - it must never
+        return wrong data, crash, or hang."""
+        conn = chdb.connect(":memory:")
+        try:
+            n1, n2 = 50_000, 30_000
+            global udf1, udf2
+            udf1, udf2 = make_df(n1, "a"), make_df(n2, "b")
+            exp = {"udf1": f"{n1},{(n1 - 1) * n1 // 2}", "udf2": f"{n2},{(n2 - 1) * n2 // 2}"}
+            wrong = []
+
+            def worker(name):
+                for _ in range(20):
+                    try:
+                        got = str(conn.query(
+                            f"SELECT count(), sum(i64) FROM Python({name})", "CSV")).strip()
+                        if got != exp[name]:
+                            wrong.append(f"{name}: {got} != {exp[name]}")
+                    except Exception:  # noqa: BLE001 - acceptable failure mode
+                        pass
+
+            threads = [threading.Thread(target=worker, args=(n,))
+                       for n in ("udf1", "udf2", "udf1", "udf2")]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            self.assertEqual(wrong, [], "concurrent queries returned WRONG data")
+        finally:
+            del udf1, udf2
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zero_copy_lifetime.py
+++ b/tests/test_zero_copy_lifetime.py
@@ -15,6 +15,7 @@ Invariants pinned here:
 import gc
 import hashlib
 import threading
+import sys
 import unittest
 import weakref
 
@@ -24,6 +25,15 @@ import pandas as pd
 import chdb
 
 PANDAS3 = int(pd.__version__.split(".")[0]) >= 3
+
+
+def refresh_frame_locals():
+    """chdb's variable lookup walks every stack frame's f_locals; on
+    Python <= 3.12 (pre-PEP 667) that access materializes a cached snapshot
+    dict on the frame which holds strong references and is NOT updated by
+    `del`. Re-reading f_locals refreshes the snapshot and drops deleted
+    entries, so weakref-release assertions see the true liveness."""
+    sys._getframe(1).f_locals  # noqa: B018
 
 
 def make_df(n=100_000, tag=""):
@@ -91,6 +101,7 @@ class TestDDLRetention(unittest.TestCase):
             wr_df = weakref.ref(df)
             conn.query("CREATE TABLE zc_keep ENGINE = Memory AS SELECT * FROM Python(df)", "CSV")
             del df
+            refresh_frame_locals()
             gc.collect()
             self.assertIsNone(wr_df(), "df itself must not be pinned after the DDL query ends")
             got = str(conn.query(
@@ -111,6 +122,7 @@ class TestDDLRetention(unittest.TestCase):
             wr_pa = weakref.ref(df["s"].array._pa_array)
             conn.query("CREATE TABLE zc_pin ENGINE = Memory AS SELECT * FROM Python(df)", "CSV")
             del df
+            refresh_frame_locals()
             gc.collect()
             self.assertIsNone(wr_pa(),
                               "table must store owned copies; df backing still pinned")
@@ -203,6 +215,7 @@ class TestReleaseWithoutFutureQuery(unittest.TestCase):
             wr_pa = weakref.ref(df["s"].array._pa_array)
             str(conn.query("SELECT count(), max(s) FROM Python(df)", "CSV"))
             del df
+            refresh_frame_locals()
             gc.collect()
             self.assertIsNone(wr_pa())
         finally:
@@ -218,6 +231,7 @@ class TestReleaseWithoutFutureQuery(unittest.TestCase):
             next(iter(stream))  # consume one chunk, abandon the rest
             stream.close()
             del stream, df
+            refresh_frame_locals()
             gc.collect()
             self.assertIsNone(wr_pa(), "abandoned stream must release on close, not on a later query")
         finally:
@@ -232,6 +246,7 @@ class TestReleaseWithoutFutureQuery(unittest.TestCase):
             with self.assertRaises(Exception):
                 conn.query("SELECT throwIf(i64 = 5000, 'boom'), s FROM Python(df)", "CSV")
             del df
+            refresh_frame_locals()
             gc.collect()
             self.assertIsNone(wr_pa(), "error path must release without a follow-up query")
         finally:

--- a/tests/test_zero_copy_lifetime.py
+++ b/tests/test_zero_copy_lifetime.py
@@ -262,10 +262,13 @@ class TestRepeatedAndConcurrent(unittest.TestCase):
                 "SELECT s, count() AS c FROM Python(df) GROUP BY s ORDER BY c DESC, s LIMIT 5", "CSV"))
 
             def rss_kb():
+                if sys.platform != "linux":
+                    return None  # /proc is Linux-only; result stability is still checked
                 with open("/proc/self/status") as f:
                     for line in f:
                         if line.startswith("VmRSS:"):
                             return int(line.split()[1])
+                return None
 
             samples = []
             for i in range(100):
@@ -273,9 +276,10 @@ class TestRepeatedAndConcurrent(unittest.TestCase):
                     "SELECT s, count() AS c FROM Python(df) GROUP BY s ORDER BY c DESC, s LIMIT 5", "CSV"))
                 self.assertEqual(got, expected, f"iteration {i} diverged")
                 samples.append(rss_kb())
-            growth_kb = samples[-1] - samples[9]
-            self.assertLess(growth_kb, 200_000,
-                            f"RSS grew {growth_kb} KB over 90 repeated queries")
+            if samples[-1] is not None and samples[9] is not None:
+                growth_kb = samples[-1] - samples[9]
+                self.assertLess(growth_kb, 200_000,
+                                f"RSS grew {growth_kb} KB over 90 repeated queries")
         finally:
             conn.close()
 

--- a/tests/test_zero_copy_scan.py
+++ b/tests/test_zero_copy_scan.py
@@ -294,5 +294,32 @@ class TestZeroCopyEscapeHatch(unittest.TestCase):
         self.assertEqual(on, off)
 
 
+class TestBorrowReleaseWithoutNextQuery(unittest.TestCase):
+    def test_dataframe_result_settles_guards_in_call(self):
+        import weakref
+
+        conn = chdb.connect(":memory:")
+        try:
+            df = pd.DataFrame({"x": np.arange(300_000, dtype=np.int64)})
+            view = df["x"].to_numpy(copy=False)
+            block = view.base if view.base is not None else view
+            wr = weakref.ref(block)
+            globals()["lifec_df"] = df
+            try:
+                res = conn.query("SELECT x FROM Python(lifec_df)", "dataframe")
+                self.assertEqual(len(res), 300_000)
+            finally:
+                del globals()["lifec_df"]
+            del df, view, block, res
+            gc.collect()
+            self.assertIsNone(
+                wr(),
+                "borrowed numeric buffer must be released by the query call itself, "
+                "not deferred to the next query",
+            )
+        finally:
+            conn.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_zero_copy_scan.py
+++ b/tests/test_zero_copy_scan.py
@@ -1,0 +1,298 @@
+#!python3
+
+import ctypes
+import ctypes.util
+import gc
+import mmap
+import os
+import subprocess
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import chdb
+
+PANDAS3 = int(pd.__version__.split(".")[0]) >= 3
+
+
+def big_df(nrows=200_000):
+    return pd.DataFrame(
+        {
+            "i64": np.arange(nrows, dtype=np.int64),
+            "i32": (np.arange(nrows, dtype=np.int32) % 1000),
+            "u16": (np.arange(nrows) % 500).astype(np.uint16),
+            "f64": np.arange(nrows, dtype=np.float64) / 7.0,
+            "s": [f"payload-{j % 997}-{'x' * (j % 23)}" for j in range(nrows)],
+            "t": [f"{j % 13}" for j in range(nrows)],
+        }
+    )
+
+
+class TestZeroCopyScan(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.conn = chdb.connect(":memory:")
+        cls.df = big_df()
+        cls.nrows = len(cls.df)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
+
+    def q(self, sql):
+        return str(self.conn.query(sql, "CSV")).strip()
+
+    def test_numeric_aggregates_exact(self):
+        df = self.df  # noqa: F841
+        n = self.nrows
+        self.assertEqual(
+            self.q("SELECT count(), sum(i64), sum(i32), sum(u16) FROM Python(df)"),
+            f"{n},{n * (n - 1) // 2},{sum(range(1000)) * (n // 1000)},{int(np.sum(np.arange(n) % 500))}",
+        )
+
+    def test_string_values_roundtrip(self):
+        df = self.df  # noqa: F841
+        self.assertEqual(
+            self.q("SELECT sum(length(s)) FROM Python(df)"), str(int(self.df["s"].str.len().sum()))
+        )
+        self.assertEqual(
+            self.q("SELECT s FROM Python(df) WHERE i64 = 42"), '"' + self.df["s"][42] + '"'
+        )
+        self.assertEqual(self.q("SELECT countDistinct(s) FROM Python(df)"), str(self.df["s"].nunique()))
+
+    def test_group_by_on_borrowed_strings(self):
+        df = self.df  # noqa: F841
+        pd_top = self.df.groupby("t").size().sort_values(ascending=False)
+        top_count = int(pd_top.iloc[0])
+        self.assertEqual(
+            self.q("SELECT count() AS c FROM Python(df) GROUP BY t ORDER BY c DESC LIMIT 1"),
+            str(top_count),
+        )
+
+    def test_order_by_limit_on_borrowed(self):
+        df = self.df  # noqa: F841
+        self.assertEqual(
+            self.q("SELECT i64, s FROM Python(df) ORDER BY i64 DESC LIMIT 2"),
+            f'{self.nrows - 1},"{self.df["s"].iloc[-1]}"\n{self.nrows - 2},"{self.df["s"].iloc[-2]}"',
+        )
+
+    def test_self_join_on_borrowed(self):
+        df = self.df  # noqa: F841
+        self.assertEqual(
+            self.q(
+                "SELECT count() FROM (SELECT i32 FROM Python(df) WHERE i64 < 1000) a "
+                "JOIN (SELECT i32 FROM Python(df) WHERE i64 < 1000) b ON a.i32 = b.i32"
+            ),
+            "1000",
+        )
+
+    def test_filter_where_on_borrowed(self):
+        df = self.df  # noqa: F841
+        expected = int((self.df["i32"] == 7).sum())
+        self.assertEqual(self.q("SELECT count() FROM Python(df) WHERE i32 = 7"), str(expected))
+        self.assertEqual(
+            self.q("SELECT sum(i64) FROM Python(df) WHERE i32 = 7"),
+            str(int(self.df.loc[self.df["i32"] == 7, "i64"].sum())),
+        )
+
+    def test_short_circuit_if_on_borrowed(self):
+        df = self.df  # noqa: F841
+        expected = int(np.where(np.arange(self.nrows) % 2 == 0, np.arange(self.nrows), 0).sum())
+        self.assertEqual(
+            self.q("SELECT sum(if(i64 % 2 = 0, i64, 0)) FROM Python(df)"), str(expected)
+        )
+
+    def test_with_totals_on_borrowed(self):
+        df = self.df  # noqa: F841
+        out = self.q("SELECT t, sum(i64) FROM Python(df) GROUP BY t WITH TOTALS ORDER BY t LIMIT 3")
+        self.assertIn(",", out)
+
+    def test_limit_by_on_borrowed(self):
+        df = self.df  # noqa: F841
+        self.assertEqual(
+            self.q("SELECT count() FROM (SELECT t, i64 FROM Python(df) ORDER BY i64 LIMIT 2 BY t)"),
+            str(13 * 2),
+        )
+
+    def test_multi_chunk_borrow(self):
+        parts = [big_df(60_000) for _ in range(3)]
+        mc = pd.concat(parts, ignore_index=True)
+        if PANDAS3:
+            self.assertGreater(mc["s"].array._pa_array.num_chunks, 1)
+        globals()["mc_df"] = mc
+        try:
+            self.assertEqual(
+                self.q("SELECT count(), sum(length(s)) FROM Python(mc_df)"),
+                f"{len(mc)},{int(mc['s'].str.len().sum())}",
+            )
+            self.assertEqual(
+                self.q("SELECT sum(i64) FROM Python(mc_df)"), str(int(mc["i64"].sum()))
+            )
+        finally:
+            del globals()["mc_df"]
+
+    def test_nullable_string_fallback(self):
+        s = pd.Series([f"v{j}" for j in range(50_000)], dtype="str" if PANDAS3 else object)
+        s[10] = None
+        dfn = pd.DataFrame({"s": s, "v": np.arange(50_000, dtype=np.int64)})
+        globals()["dfn"] = dfn
+        try:
+            self.assertEqual(self.q("SELECT count() FROM Python(dfn) WHERE s IS NULL"), "1")
+            self.assertEqual(
+                self.q("SELECT sum(length(s)) FROM Python(dfn)"),
+                str(int(dfn["s"].dropna().str.len().sum())),
+            )
+        finally:
+            del globals()["dfn"]
+
+    def test_result_outlives_dataframe(self):
+        local_df = big_df(100_000)
+        globals()["tmp_owner_df"] = local_df
+        try:
+            ret = self.conn.query("SELECT i64, s FROM Python(tmp_owner_df) ORDER BY i64 DESC LIMIT 5", "CSV")
+        finally:
+            del globals()["tmp_owner_df"]
+        del local_df
+        gc.collect()
+        self.q("SELECT 1")
+        gc.collect()
+        text = str(ret)
+        self.assertIn("99999", text)
+        self.assertIn(f"payload-{99999 % 997}-", text)
+
+    def test_repeated_queries_no_leak(self):
+        df = self.df  # noqa: F841
+        for _ in range(30):
+            self.q("SELECT sum(i64), max(length(s)) FROM Python(df)")
+        gc.collect()
+
+    def test_arrow_direct_predicate_still_works(self):
+        df = self.df  # noqa: F841
+        expected = int(self.df["s"].str.contains("payload-7-", regex=False).sum())
+        self.assertEqual(
+            self.q("SELECT count() FROM Python(df) WHERE s LIKE '%payload-7-%'"), str(expected)
+        )
+
+
+PROT_READ_SCRIPT = r"""
+import ctypes, mmap, sys
+import numpy as np, pandas as pd, pyarrow as pa, chdb
+
+PAGE = 4096
+libc = ctypes.CDLL(None, use_errno=True)
+
+def mmap_readonly_arrow_string(values):
+    arr = pa.array(values, type=pa.string())
+    buffers = arr.buffers()
+    offsets_np = np.frombuffer(buffers[1], dtype=np.int32)
+    data_bytes = buffers[2].to_pybytes() if buffers[2] is not None else b""
+
+    def alloc_ro(payload, extra_tail=64):
+        n = (len(payload) + extra_tail + PAGE - 1) // PAGE * PAGE
+        m = mmap.mmap(-1, n)
+        m.write(payload)
+        addr = ctypes.addressof(ctypes.c_char.from_buffer(m))
+        assert libc.mprotect(ctypes.c_void_p(addr), ctypes.c_size_t(n), 1) == 0  # PROT_READ
+        return m, addr
+
+    m_off, off_addr = alloc_ro(offsets_np.tobytes())
+    m_dat, dat_addr = alloc_ro(data_bytes)
+    off_buf = pa.foreign_buffer(off_addr, len(offsets_np) * 4, m_off)
+    dat_buf = pa.foreign_buffer(dat_addr, len(data_bytes), m_dat)
+    ro = pa.StringArray.from_buffers(len(arr), off_buf, dat_buf)
+    assert ro.to_pylist() == values[: len(values)]
+    return ro, dat_addr, (m_off, m_dat)
+
+nrows = 100_000
+values = [f"guarded-{j % 101}-{'y' * (j % 17)}" for j in range(nrows)]
+# Deterministic tail position: keep the payload end well inside a page so the
+# borrow-side same-page check passes and the mount actually happens.
+total = sum(len(v) for v in values)
+pad = (2048 - total) % PAGE
+values[-1] = values[-1] + "z" * pad
+ro_arr, dat_addr, keep = mmap_readonly_arrow_string(values)
+s = pd.arrays.ArrowStringArray(pa.chunked_array([ro_arr]))
+df = pd.DataFrame({"s": s, "v": np.arange(nrows, dtype=np.int64)})
+# The harness is void if pandas copied the buffers: assert identity.
+got_addr = df["s"].array._pa_array.chunk(0).buffers()[2].address
+assert got_addr == dat_addr, (got_addr, dat_addr)
+
+conn = chdb.connect(":memory:")
+queries = [
+    "SELECT sum(length(s)) FROM Python(df)",
+    "SELECT countDistinct(s) FROM Python(df)",
+    "SELECT count() FROM Python(df) WHERE s LIKE '%guarded-7-%'",
+    "SELECT s FROM Python(df) ORDER BY v DESC LIMIT 3",
+    "SELECT t.s, count() FROM (SELECT s FROM Python(df)) t GROUP BY t.s ORDER BY count() DESC LIMIT 2",
+    "SELECT count() FROM (SELECT s, v FROM Python(df) ORDER BY v LIMIT 1 BY s)",
+    "SELECT sum(if(v % 2 = 0, length(s), 0)) FROM Python(df)",
+]
+expected_len = sum(len(v) for v in values)
+r0 = str(conn.query(queries[0], "CSV")).strip()
+assert r0 == str(expected_len), (r0, expected_len)
+for q in queries[1:]:
+    conn.query(q, "CSV")
+conn.close()
+print("PROT_READ_HARNESS_OK")
+"""
+
+
+class TestZeroCopyProtRead(unittest.TestCase):
+    @unittest.skipUnless(PANDAS3 and sys.platform == "linux", "needs pandas 3 + linux mprotect")
+    def test_engine_never_writes_borrowed_buffers(self):
+        env = dict(os.environ)
+        res = subprocess.run(
+            [sys.executable, "-c", PROT_READ_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=300,
+            check=False,
+        )
+        self.assertEqual(res.returncode, 0, f"stdout={res.stdout[-500:]} stderr={res.stderr[-3000:]}")
+        self.assertIn("PROT_READ_HARNESS_OK", res.stdout)
+
+
+EQUIV_SCRIPT = r"""
+import numpy as np, pandas as pd, chdb
+conn = chdb.connect(':memory:')
+df = pd.DataFrame({
+    'i64': np.arange(100_000, dtype=np.int64),
+    's': [f'e{j % 321}' for j in range(100_000)],
+})
+out = []
+for q in [
+    'SELECT sum(i64), sum(length(s)), countDistinct(s) FROM Python(df)',
+    "SELECT count() FROM Python(df) WHERE s = 'e7'",
+    'SELECT s FROM Python(df) ORDER BY i64 DESC LIMIT 1',
+]:
+    out.append(str(conn.query(q, 'CSV')).strip())
+print('|'.join(out))
+"""
+
+
+class TestZeroCopyEscapeHatch(unittest.TestCase):
+    def run_mode(self, extra_env):
+        env = dict(os.environ)
+        env.update(extra_env)
+        res = subprocess.run(
+            [sys.executable, "-c", EQUIV_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=300,
+            check=False,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr[-2000:])
+        return res.stdout.strip().splitlines()[-1]
+
+    def test_zero_copy_off_equivalence(self):
+        on = self.run_mode({})
+        off = self.run_mode({"CHDB_ZERO_COPY": "0"})
+        self.assertEqual(on, off)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zero_copy_scan.py
+++ b/tests/test_zero_copy_scan.py
@@ -17,6 +17,15 @@ import chdb
 PANDAS3 = int(pd.__version__.split(".")[0]) >= 3
 
 
+def refresh_frame_locals():
+    """chdb's variable lookup walks every stack frame's f_locals; on
+    Python <= 3.12 (pre-PEP 667) that access materializes a cached snapshot
+    dict on the frame which holds strong references and is NOT updated by
+    `del`. Re-reading f_locals refreshes the snapshot and drops deleted
+    entries, so weakref-release assertions see the true liveness."""
+    sys._getframe(1).f_locals  # noqa: B018
+
+
 def big_df(nrows=200_000):
     return pd.DataFrame(
         {
@@ -311,6 +320,7 @@ class TestBorrowReleaseWithoutNextQuery(unittest.TestCase):
             finally:
                 del globals()["lifec_df"]
             del df, view, block, res
+            refresh_frame_locals()
             gc.collect()
             self.assertIsNone(
                 wr(),


### PR DESCRIPTION
Cuts the per-query overhead of `Python(df)` table scans. Replaces #170 (same commits rebased onto main after #165, minus the benchmarking-only CI restriction).

## What

- **Session metadata cache**: schema/columns/dtypes of a scanned DataFrame are cached and revalidated per query with cheap identity witnesses (weakrefs, object identity, dtype pointers) instead of re-deriving them under the GIL every query. String backings are held via weakref only, so the cache never extends payload lifetime. Disable with `CHDB_PANDAS_META_CACHE=0`.
- **Zero-copy buffer mounts**: eligible numeric numpy columns and single-chunk Arrow string columns are mounted into `ColumnVector`/`ColumnString` by borrowing the Python-owned buffers instead of memcpying them. Any mutating column entry point (COW `mutate`, in-place `filter`/`expand`, all insert/reserve paths) materializes an owned copy first. Disable with `CHDB_ZERO_COPY=0`.
- **jemalloc background threads**: restore compile-time support (dropped since the 23.6 fork) and enable them at server startup; synchronous dirty-page purging serialized aggregation on high-core-count machines.
- **Lifetime hardening**: per-query Python references are released at query end (not at the next query), result conversion paths are exception-safe, and dead cache entries are swept eagerly.

## Results (ClickBench hits, hot total)

- c6a.metal (192 vCPU), full dataset: 16.79s → 8.78s, ahead of polars' current official result (10.18s).
- 16 threads, half dataset: 9.61s → 7.82s (polars: 13.87s).

## Tests

37 new unit tests (`test_pandas_meta_cache.py`, `test_zero_copy_scan.py`), including an mmap `PROT_READ` harness that segfaults on any write-through to borrowed buffers, mutation-visibility checks, and immediate-release lifetime checks.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up pandas DataFrame scans with zero-copy buffer mounts, metadata caching, and jemalloc background threads
> - `ColumnVector<T>` and `ColumnString` gain `borrowData`/`borrowChars` APIs to alias external numpy/Arrow buffers without copying; mutations trigger a copy-out via `materializeBorrowedStorage()` added to `IColumn`.
> - `PythonTableCache` gains a pandas metadata cache (`PandasTableMeta`) that stores schema, column sizes, and `ArrowWrapperMaster` entries across queries, validated per-epoch via weakrefs on the backing `_pa_array`.
> - `PythonSource` and `PandasScan` use the cached metadata and borrow guards to mount Arrow string and numeric columns zero-copy, with block boundaries aligned to Arrow chunk edges.
> - Jemalloc background purge threads are compiled in on Linux x86_64 and aarch64 and optionally enabled at startup via `jemalloc_enable_background_threads` / `jemalloc_max_background_threads_num` settings.
> - `SinkToStorage.onConsume` materializes any borrowed columns before writing to prevent aliased buffer writes into storage engines.
> - Risk: zero-copy mounts rely on page-boundary safety checks (`borrowTailReadable`) and deferred GIL-free decrefs via a queue; incorrect usage ordering could cause use-after-free on Python interpreter shutdown, mitigated by intentional leaks when the interpreter is finalized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22589ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Behavior notes

- Zero-copy scans read the **live** buffer: an in-place numpy write from another thread during query execution is observed by that query (previously values were copied block-by-block under the GIL, a narrower but still racy window). Tables built from `Python(df)` (`CREATE TABLE ... AS SELECT`, `INSERT INTO ... SELECT`) still store owned snapshots.
- Kill switches: `CHDB_ZERO_COPY=0` and `CHDB_PANDAS_META_CACHE=0` (read once at first query; set them before connecting).
