### PR TITLE
Make concurrent queries on one connection reliable

### DIFF
--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -232,9 +232,24 @@ void ChdbClient::clearQueryParameters()
 }
 
 #if USE_PYTHON
+#if USE_PYTHON
+namespace
+{
+/// The prefill (pybind side, GIL held) and the execute call it precedes run
+/// on the same thread; the token travels between them thread-locally so
+/// concurrent queries on one connection cannot clobber each other's record.
+thread_local UInt64 python_tables_bind_token = 0;
+
+UInt64 takePythonTablesBindToken()
+{
+    return std::exchange(python_tables_bind_token, 0);
+}
+}
+#endif
+
 void ChdbClient::findQueryableObjFromPyCache(const String & query_str) const
 {
-    python_table_cache->findQueryableObjFromQuery(query_str);
+    python_tables_bind_token = python_table_cache->findQueryableObjFromQuery(query_str);
 }
 #endif
 
@@ -275,14 +290,22 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
     const char * query, size_t query_len,
     const char * format, size_t format_len)
 {
+#if USE_PYTHON
+    const UInt64 py_tables_token = takePythonTablesBindToken();
+#endif
     std::lock_guard<std::mutex> lock(client_mutex);
 
     String query_str(query, query_len);
     String format_str(format, format_len);
 
     if (streaming_insert_context)
+    {
+#if USE_PYTHON
+        python_table_cache->releaseQueryableObjs(py_tables_token);
+#endif
         return std::make_unique<CHDB::MaterializedQueryResult>(
             "Cannot run a query while a streaming insert is active on this connection");
+    }
 
     try
     {
@@ -291,7 +314,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
         {
 #if USE_PYTHON
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-            python_table_cache->clear();
+            python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
             return std::make_unique<CHDB::MaterializedQueryResult>(getErrorMsg());
         }
@@ -315,7 +338,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
                 bytes_written);
 #if USE_PYTHON
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-            python_table_cache->clear();
+            python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
             return res;
         }
@@ -331,7 +354,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
             bytes_written);
 #if USE_PYTHON
         (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return res;
     }
@@ -340,7 +363,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
 #if USE_PYTHON
         if (connection)
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
@@ -349,7 +372,7 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
 #if USE_PYTHON
         if (connection)
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
@@ -359,31 +382,48 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
     const char * query, size_t query_len,
     const char * format, size_t format_len, bool dataframe_over_chunks)
 {
+#if USE_PYTHON
+    const UInt64 py_tables_token = takePythonTablesBindToken();
+#endif
     std::lock_guard<std::mutex> lock(client_mutex);
 
     String query_str(query, query_len);
     String format_str(format, format_len);
 
     if (streaming_insert_context)
+    {
+#if USE_PYTHON
+        python_table_cache->releaseQueryableObjs(py_tables_token);
+#endif
         return std::make_unique<CHDB::StreamQueryResult>(
             "Cannot start a streaming query while a streaming insert is active on this connection");
+    }
 
     try
     {
         DB::ThreadStatus thread_status;
 
+#if USE_PYTHON
+        /// Starting a new stream implicitly abandons an unfinished one; its
+        /// bindings must be released with it or they leak until close.
+        if (streaming_query_context)
+            python_table_cache->releaseQueryableObjs(streaming_query_context->python_tables_bind_token);
+#endif
         streaming_query_context = std::make_shared<StreamingQueryContext>();
         if (!parseQueryTextWithOutputFormat(query_str, format_str))
         {
             streaming_query_context.reset();
 #if USE_PYTHON
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-            python_table_cache->clear();
+            python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
             return std::make_unique<CHDB::StreamQueryResult>(getErrorMsg());
         }
         streaming_query_context->thread_group = DB::CurrentThread::getGroup();
         streaming_query_context->dataframe_over_chunks = dataframe_over_chunks;
+#if USE_PYTHON
+        streaming_query_context->python_tables_bind_token = py_tables_token;
+#endif
         auto result = std::make_unique<CHDB::StreamQueryResult>();
         streaming_query_context->streaming_result = result.get();
         return result;
@@ -394,7 +434,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
 #if USE_PYTHON
         if (connection)
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return std::make_unique<CHDB::StreamQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
@@ -404,7 +444,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingInit(
 #if USE_PYTHON
         if (connection)
             (static_cast<LocalConnection *>(connection.get()))->resetQueryContext();
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return std::make_unique<CHDB::StreamQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
@@ -510,13 +550,16 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
         if (is_end)
         {
             // End of stream reached or cancelled, cleanup
+#if USE_PYTHON
+            const UInt64 py_tables_token = streaming_query_context ? streaming_query_context->python_tables_bind_token : 0;
+#endif
             streaming_query_context.reset();
 #if USE_PYTHON
             if (connection)
             {
                 auto * local_connection = static_cast<LocalConnection *>(connection.get());
                 local_connection->resetQueryContext();
-                local_connection->getSession().getPythonTableCache()->clear();
+                local_connection->getSession().getPythonTableCache()->releaseQueryableObjs(py_tables_token);
             }
 #endif
         }
@@ -524,6 +567,9 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
     }
     catch (const Exception & e)
     {
+#if USE_PYTHON
+        const UInt64 py_tables_token = streaming_query_context ? streaming_query_context->python_tables_bind_token : 0;
+#endif
         streaming_query_context.reset();
 #if USE_PYTHON
         if (connection)
@@ -531,12 +577,15 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
             auto * local_connection = static_cast<LocalConnection *>(connection.get());
             local_connection->resetQueryContext();
         }
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return std::make_unique<CHDB::MaterializedQueryResult>(getExceptionMessage(e, print_stack_trace));
     }
     catch (...)
     {
+#if USE_PYTHON
+        const UInt64 py_tables_token = streaming_query_context ? streaming_query_context->python_tables_bind_token : 0;
+#endif
         streaming_query_context.reset();
 #if USE_PYTHON
         if (connection)
@@ -544,7 +593,7 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
             auto * local_connection = static_cast<LocalConnection *>(connection.get());
             local_connection->resetQueryContext();
         }
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         return std::make_unique<CHDB::MaterializedQueryResult>(getCurrentExceptionMessage(print_stack_trace));
     }
@@ -573,6 +622,9 @@ void ChdbClient::cancelStreamingQueryWithoutLock(void * streaming_result)
         }
 
         /// Ensure cleanup happens
+#if USE_PYTHON
+        const UInt64 py_tables_token = streaming_query_context->python_tables_bind_token;
+#endif
         streaming_query_context.reset();
 #if USE_PYTHON
         if (connection)
@@ -580,7 +632,7 @@ void ChdbClient::cancelStreamingQueryWithoutLock(void * streaming_result)
             auto * local_connection = static_cast<LocalConnection *>(connection.get());
             local_connection->resetQueryContext();
         }
-        python_table_cache->clear();
+        python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
     }
 }
@@ -911,7 +963,6 @@ CHDB::QueryResultPtr ChdbClient::executeInsertStreamingDone(void * insert_stream
     if (connection)
     {
         local_connection->resetQueryContext();
-        local_connection->getSession().getPythonTableCache()->clear();
     }
 #endif
 

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -232,7 +232,6 @@ void ChdbClient::clearQueryParameters()
 }
 
 #if USE_PYTHON
-#if USE_PYTHON
 namespace
 {
 /// The prefill (pybind side, GIL held) and the execute call it precedes run
@@ -245,10 +244,13 @@ UInt64 takePythonTablesBindToken()
     return std::exchange(python_tables_bind_token, 0);
 }
 }
-#endif
 
 void ChdbClient::findQueryableObjFromPyCache(const String & query_str) const
 {
+    /// A leftover token means the previous prefill's execute never ran (e.g.
+    /// the connection was invalidated in between); release its bindings
+    /// instead of leaking them until connection close.
+    python_table_cache->releaseQueryableObjs(std::exchange(python_tables_bind_token, 0));
     python_tables_bind_token = python_table_cache->findQueryableObjFromQuery(query_str);
 }
 #endif
@@ -559,8 +561,8 @@ CHDB::QueryResultPtr ChdbClient::executeStreamingIterate(void * streaming_result
             {
                 auto * local_connection = static_cast<LocalConnection *>(connection.get());
                 local_connection->resetQueryContext();
-                local_connection->getSession().getPythonTableCache()->releaseQueryableObjs(py_tables_token);
             }
+            python_table_cache->releaseQueryableObjs(py_tables_token);
 #endif
         }
         return res;

--- a/programs/local/ChdbClient.h
+++ b/programs/local/ChdbClient.h
@@ -74,6 +74,9 @@ public:
     void clearQueryParameters();
 
 #if USE_PYTHON
+    /// Prefill Python(name) bindings for a query issued on this thread; the
+    /// returned token is stashed thread-locally and consumed by the execute
+    /// call that follows on the same thread (takePythonTablesBindToken).
     void findQueryableObjFromPyCache(const String & query_str) const;
 #endif
 

--- a/programs/local/PyBorrowGuard.cpp
+++ b/programs/local/PyBorrowGuard.cpp
@@ -43,32 +43,32 @@ static int drainPendingCallTrampoline(void *)
     return 0;
 }
 
+/// The caller may run on a server thread with no GIL and no upcoming chdb
+/// API call (e.g. a table with borrowed columns dropped in the background).
+/// Schedule a drain on the interpreter's pending-call queue so the release
+/// point is bounded and query-independent; the drains at query boundaries
+/// remain as belt-and-braces.
+void enqueuePyDecref(PyObject * obj)
+{
+    {
+        std::lock_guard lock(pendingDecrefsMutex());
+        pendingDecrefs().push_back(obj);
+    }
+    if (!Py_IsInitialized())
+        return; /// finalization: queued refs are intentionally leaked
+
+    if (!drain_scheduled.test_and_set(std::memory_order_acq_rel))
+    {
+        if (Py_AddPendingCall(drainPendingCallTrampoline, nullptr) != 0)
+            drain_scheduled.clear(std::memory_order_release);
+    }
+}
+
 std::shared_ptr<void> makePyBorrowGuard(PyObject * obj)
 {
     py::gil_assert();
     Py_INCREF(obj);
-    return {static_cast<void *>(obj), [](void * ptr)
-    {
-        {
-            std::lock_guard lock(pendingDecrefsMutex());
-            pendingDecrefs().push_back(static_cast<PyObject *>(ptr));
-        }
-        /// The deleter may run on a server thread with no GIL and no upcoming
-        /// chdb API call (e.g. a table with borrowed columns dropped in the
-        /// background). Schedule a drain on the interpreter's pending-call
-        /// queue so the release point is bounded and query-independent;
-        /// the drains at query boundaries remain as belt-and-braces.
-        /// During/after finalization the pending-call machinery is gone:
-        /// leave the queued refs intentionally leaked instead of crashing.
-        if (!Py_IsInitialized())
-            return;
-
-        if (!drain_scheduled.test_and_set(std::memory_order_acq_rel))
-        {
-            if (Py_AddPendingCall(drainPendingCallTrampoline, nullptr) != 0)
-                drain_scheduled.clear(std::memory_order_release);
-        }
-    }};
+    return {static_cast<void *>(obj), [](void * ptr) { enqueuePyDecref(static_cast<PyObject *>(ptr)); }};
 }
 
 void drainPyBorrowGuardQueue()

--- a/programs/local/PyBorrowGuard.h
+++ b/programs/local/PyBorrowGuard.h
@@ -18,6 +18,11 @@ bool zeroCopyEnabled();
 /// executor thread and structurally free of GIL deadlocks.
 std::shared_ptr<void> makePyBorrowGuard(PyObject * obj);
 
+/// Queue a reference for a deferred Py_DECREF and schedule a drain on the
+/// interpreter's pending-call queue. Safe to call from any thread, with or
+/// without the GIL.
+void enqueuePyDecref(PyObject * obj);
+
 /// Decref all queued objects. GIL must be held.
 void drainPyBorrowGuardQueue();
 

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -67,13 +67,23 @@ PythonTableCache::~PythonTableCache()
     {
         auto * leaked = new std::list<PandasTableMetaPtr>(std::move(meta_lru));
         (void)leaked;
+        for (auto & [name, entry] : py_table_cache)
+            entry.obj.release();
         return;
     }
     try
     {
         py::gil_scoped_acquire acquire;
-        std::lock_guard lock(state_mutex);
-        meta_lru.clear();
+        std::list<PandasTableMetaPtr> metas;
+        std::unordered_map<String, NamedEntry> bindings;
+        {
+            std::lock_guard lock(state_mutex);
+            metas.swap(meta_lru);
+            bindings.swap(py_table_cache);
+            bound_names_by_token.clear();
+        }
+        metas.clear();
+        bindings.clear();
         drainPyBorrowGuardQueue();
     }
     catch (...)
@@ -126,7 +136,27 @@ static py::object findQueryableObj(const String & var_name)
     return py::none();
 }
 
-void PythonTableCache::findQueryableObjFromQuery(const String & query_str)
+/// Unique Python(...) table names referenced by the query, in match order.
+/// The object name is extracted from the query string, referenced as
+/// Python(var_name) / Python('var_name') / python("var_name").
+static std::vector<String> extractPythonTableNames(const String & query_str)
+{
+    // RE2 pattern to match Python()/python() patterns with single/double quotes or no quotes
+    static const RE2 pattern(R"([Pp]ython\s*\(\s*(?:['"]([^'"]+)['"]|([a-zA-Z_][a-zA-Z0-9_]*))\s*\))");
+
+    std::vector<String> names;
+    re2::StringPiece input(query_str);
+    std::string quoted_match, unquoted_match;
+    while (RE2::FindAndConsume(&input, pattern, &quoted_match, &unquoted_match))
+    {
+        const auto & matched = !quoted_match.empty() ? quoted_match : unquoted_match;
+        if (!matched.empty() && std::find(names.begin(), names.end(), matched) == names.end())
+            names.push_back(matched);
+    }
+    return names;
+}
+
+UInt64 PythonTableCache::findQueryableObjFromQuery(const String & query_str)
 {
     // Find the queriable object in the Python environment
     // return nullptr if no Python obj is referenced in query string
@@ -143,55 +173,121 @@ void PythonTableCache::findQueryableObjFromQuery(const String & query_str)
 
     py::gil_assert();
 
-    std::lock_guard lock(state_mutex);
+    const auto names = extractPythonTableNames(query_str);
 
-    /// New query: cached-metadata witnesses must be re-checked once per query.
-    ++query_epoch;
+    /// Nothing under state_mutex may run Python bytecode: a query thread can
+    /// block on the mutex while holding the GIL, so a mutex holder yielding
+    /// the GIL mid-bytecode would deadlock. Dead metadata entries are only
+    /// unlinked under the lock (weakref liveness via the C API, no bytecode)
+    /// and destroyed after it is released.
+    std::list<PandasTableMetaPtr> dead_meta;
+    {
+        std::lock_guard lock(state_mutex);
+
+        /// New query: cached-metadata witnesses must be re-checked once per query.
+        ++query_epoch;
+
+        /// Unlink entries whose DataFrame died, so cached backing arrays are
+        /// not kept alive longer than one query boundary.
+        for (auto it = meta_lru.begin(); it != meta_lru.end();)
+        {
+            PyObject * wr = (*it)->weak_ref.ptr();
+            if (wr != nullptr && PyWeakref_GetObject(wr) == Py_None)
+                dead_meta.splice(dead_meta.end(), meta_lru, it++);
+            else
+                ++it;
+        }
+    }
+    dead_meta.clear();
     drainPyBorrowGuardQueue();
 
-    /// Evict entries whose DataFrame died, so cached backing arrays (string
-    /// payloads) are not kept alive longer than one query boundary.
-    meta_lru.remove_if([](const PandasTableMetaPtr & e)
+    if (names.empty())
+        return 0;
+
+    std::vector<String> bound;
+    bound.reserve(names.size());
+    for (const auto & matched : names)
     {
-        try
         {
-            return e->weak_ref.ptr() != nullptr && e->weak_ref().is_none();
+            /// A name another in-flight query already bound is reused (and
+            /// kept alive by its refcount); the expensive inspect frame walk
+            /// only runs for names not currently bound.
+            std::lock_guard lock(state_mutex);
+            if (auto it = py_table_cache.find(matched); it != py_table_cache.end())
+            {
+                ++it->second.refcount;
+                bound.push_back(matched);
+                continue;
+            }
         }
-        catch (...)
-        {
-            return false;
-        }
-    });
 
-    // RE2 pattern to match Python()/python() patterns with single/double quotes or no quotes
-    static const RE2 pattern(R"([Pp]ython\s*\(\s*(?:['"]([^'"]+)['"]|([a-zA-Z_][a-zA-Z0-9_]*))\s*\))");
-
-    re2::StringPiece input(query_str);
-    std::string quoted_match, unquoted_match;
-
-    // Try to match and extract the groups
-    while (RE2::FindAndConsume(&input, pattern, &quoted_match, &unquoted_match))
-    {
-        // Skip the (expensive) inspect frame walk when the name is already cached;
-        // emplace never overwrites an existing entry anyway.
-        const auto & matched = !quoted_match.empty() ? quoted_match : unquoted_match;
-        if (matched.empty() || py_table_cache.contains(matched))
+        auto obj = findQueryableObj(matched); /// frame walk: GIL only, no lock
+        if (obj.is_none())
             continue;
 
-        auto handle = findQueryableObj(matched);
-        if (!handle.is_none())
-            py_table_cache.emplace(matched, handle);
+        std::lock_guard lock(state_mutex);
+        if (auto it = py_table_cache.find(matched); it != py_table_cache.end())
+            ++it->second.refcount; /// another thread bound it meanwhile
+        else
+            py_table_cache.emplace(matched, NamedEntry{std::move(obj), 1});
+        bound.push_back(matched);
     }
+
+    if (bound.empty())
+        return 0;
+
+    /// Process-global: a stale thread-local token (prefill whose execute never
+    /// ran, e.g. connection closed in between) can be consumed by a later
+    /// query on another connection; distinct values make that a no-op instead
+    /// of releasing an unrelated in-flight query's bindings.
+    static std::atomic<UInt64> global_bind_token{0};
+
+    std::lock_guard lock(state_mutex);
+    const UInt64 token = ++global_bind_token;
+    bound_names_by_token.emplace(token, std::move(bound));
+    return token;
 }
 
-py::handle PythonTableCache::getQueryableObj(const String & table_name)
+void PythonTableCache::releaseQueryableObjs(UInt64 token)
+{
+    if (token == 0)
+        return;
+
+    /// No GIL here: erased references go through the deferred-decref queue,
+    /// so this is safe from any exit path regardless of lock/GIL context.
+    std::vector<py::object> released;
+    {
+        std::lock_guard lock(state_mutex);
+        auto rec = bound_names_by_token.find(token);
+        if (rec == bound_names_by_token.end())
+            return;
+        for (const auto & name : rec->second)
+        {
+            auto it = py_table_cache.find(name);
+            if (it == py_table_cache.end())
+                continue;
+            if (it->second.refcount <= 1)
+            {
+                released.push_back(std::move(it->second.obj));
+                py_table_cache.erase(it);
+            }
+            else
+                --it->second.refcount;
+        }
+        bound_names_by_token.erase(rec);
+    }
+    for (auto & obj : released)
+        enqueuePyDecref(obj.release().ptr());
+}
+
+py::object PythonTableCache::getQueryableObj(const String & table_name)
 {
     std::lock_guard lock(state_mutex);
 
     auto iter = py_table_cache.find(table_name);
 
     if (iter != py_table_cache.end())
-        return iter->second;
+        return iter->second.obj; /// copy increfs under the lock (C API only)
 
     return py::none();
 }
@@ -199,20 +295,36 @@ py::handle PythonTableCache::getQueryableObj(const String & table_name)
 void PythonTableCache::clear()
 {
     try
-	{
+    {
         py::gil_scoped_acquire acquire;
-        std::lock_guard lock(state_mutex);
-        py_table_cache.clear();
+        std::unordered_map<String, NamedEntry> dropped;
+        {
+            std::lock_guard lock(state_mutex);
+            dropped.swap(py_table_cache);
+            bound_names_by_token.clear();
+        }
+        dropped.clear();
         drainPyBorrowGuardQueue();
-	}
-	catch (...)
-	{
-	}
+    }
+    catch (...)
+    {
+    }
 }
 
 void PythonTableCache::dropMeta(PyObject * df_ptr)
 {
-    meta_lru.remove_if([&](const PandasTableMetaPtr & e) { return e->df_ptr == df_ptr; });
+    std::list<PandasTableMetaPtr> dropped;
+    {
+        std::lock_guard lock(state_mutex);
+        for (auto it = meta_lru.begin(); it != meta_lru.end();)
+        {
+            if ((*it)->df_ptr == df_ptr)
+                dropped.splice(dropped.end(), meta_lru, it++);
+            else
+                ++it;
+        }
+    }
+    dropped.clear(); /// entry destructors run outside the lock
 }
 
 PandasTableMetaPtr PythonTableCache::findValidatedPandasMeta(const py::handle & df)
@@ -222,19 +334,25 @@ PandasTableMetaPtr PythonTableCache::findValidatedPandasMeta(const py::handle & 
 
     py::gil_assert();
 
-    std::lock_guard lock(state_mutex);
-
-    auto it = std::find_if(meta_lru.begin(), meta_lru.end(), [&](const PandasTableMetaPtr & e) { return e->df_ptr == df.ptr(); });
-    if (it == meta_lru.end())
-        return nullptr;
-
-    auto entry = *it;
-    if (entry->validated_epoch == query_epoch)
+    PandasTableMetaPtr entry;
+    UInt64 epoch_at_validation = 0;
     {
-        meta_lru.splice(meta_lru.begin(), meta_lru, it);
-        return entry;
+        std::lock_guard lock(state_mutex);
+        auto it = std::find_if(meta_lru.begin(), meta_lru.end(), [&](const PandasTableMetaPtr & e) { return e->df_ptr == df.ptr(); });
+        if (it == meta_lru.end())
+            return nullptr;
+        entry = *it;
+        if (entry->validated_epoch == query_epoch)
+        {
+            meta_lru.splice(meta_lru.begin(), meta_lru, it);
+            return entry;
+        }
+        epoch_at_validation = query_epoch;
     }
 
+    /// Witness checks call into Python (pandas properties), so they must run
+    /// without state_mutex: a mutex holder yielding the GIL mid-bytecode
+    /// would deadlock against a GIL-holding thread blocked on the mutex.
     bool valid = false;
     try
     {
@@ -290,13 +408,19 @@ PandasTableMetaPtr PythonTableCache::findValidatedPandasMeta(const py::handle & 
         valid = false;
     }
 
+    std::lock_guard lock(state_mutex);
+    auto it = std::find_if(meta_lru.begin(), meta_lru.end(), [&](const PandasTableMetaPtr & e) { return e.get() == entry.get(); });
+    if (it == meta_lru.end())
+        return nullptr; /// concurrently invalidated while we validated
     if (!valid)
     {
         meta_lru.erase(it);
         return nullptr;
     }
 
-    entry->validated_epoch = query_epoch;
+    /// Stamp the epoch the witnesses were checked against, not the current
+    /// one: a prefill may have bumped it while validation ran unlocked.
+    entry->validated_epoch = epoch_at_validation;
     meta_lru.splice(meta_lru.begin(), meta_lru, it);
     return entry;
 }
@@ -308,10 +432,10 @@ void PythonTableCache::storePandasMeta(const py::handle & df, const DB::ColumnsD
 
     py::gil_assert();
 
-    std::lock_guard lock(state_mutex);
-
     try
     {
+        /// Built entirely outside state_mutex: witness construction calls
+        /// into Python (see findValidatedPandasMeta for the lock rule).
         auto entry = std::make_shared<PandasTableMeta>();
         entry->df_ptr = df.ptr();
         entry->schema = schema;
@@ -347,12 +471,25 @@ void PythonTableCache::storePandasMeta(const py::handle & df, const DB::ColumnsD
         }
 
         entry->weak_ref = makeWeakref(df);
-        entry->validated_epoch = query_epoch;
 
-        dropMeta(df.ptr());
-        meta_lru.push_front(std::move(entry));
-        while (meta_lru.size() > max_meta_entries)
-            meta_lru.pop_back();
+        std::list<PandasTableMetaPtr> displaced;
+        {
+            std::lock_guard lock(state_mutex);
+            entry->validated_epoch = query_epoch;
+            for (auto it = meta_lru.begin(); it != meta_lru.end();)
+            {
+                if ((*it)->df_ptr == df.ptr())
+                    displaced.splice(displaced.end(), meta_lru, it++);
+                else
+                    ++it;
+            }
+            meta_lru.push_front(std::move(entry));
+            while (meta_lru.size() > max_meta_entries)
+            {
+                displaced.splice(displaced.end(), meta_lru, std::prev(meta_lru.end()));
+            }
+        }
+        displaced.clear(); /// destroyed outside the lock
     }
     catch (...)
     {

--- a/programs/local/PythonTableCache.cpp
+++ b/programs/local/PythonTableCache.cpp
@@ -191,6 +191,11 @@ UInt64 PythonTableCache::findQueryableObjFromQuery(const String & query_str)
         /// not kept alive longer than one query boundary.
         for (auto it = meta_lru.begin(); it != meta_lru.end();)
         {
+            /// PyWeakref_GetObject is deprecated in favour of PyWeakref_GetRef,
+            /// but the abi3 wheel is built against the 3.9 limited API where
+            /// GetRef (3.13+) does not exist. The borrowed pointer is only
+            /// COMPARED to Py_None under the GIL, never dereferenced, so the
+            /// borrowed-reference hazard does not apply here.
             PyObject * wr = (*it)->weak_ref.ptr();
             if (wr != nullptr && PyWeakref_GetObject(wr) == Py_None)
                 dead_meta.splice(dead_meta.end(), meta_lru, it++);
@@ -206,31 +211,41 @@ UInt64 PythonTableCache::findQueryableObjFromQuery(const String & query_str)
 
     std::vector<String> bound;
     bound.reserve(names.size());
-    for (const auto & matched : names)
+    try
     {
+        for (const auto & matched : names)
         {
-            /// A name another in-flight query already bound is reused (and
-            /// kept alive by its refcount); the expensive inspect frame walk
-            /// only runs for names not currently bound.
+            {
+                /// A name another in-flight query already bound is reused (and
+                /// kept alive by its refcount); the expensive inspect frame walk
+                /// only runs for names not currently bound.
+                std::lock_guard lock(state_mutex);
+                if (auto it = py_table_cache.find(matched); it != py_table_cache.end())
+                {
+                    ++it->second.refcount;
+                    bound.push_back(matched);
+                    continue;
+                }
+            }
+
+            auto obj = findQueryableObj(matched); /// frame walk: GIL only, no lock
+            if (obj.is_none())
+                continue;
+
             std::lock_guard lock(state_mutex);
             if (auto it = py_table_cache.find(matched); it != py_table_cache.end())
-            {
-                ++it->second.refcount;
-                bound.push_back(matched);
-                continue;
-            }
+                ++it->second.refcount; /// another thread bound it meanwhile
+            else
+                py_table_cache.emplace(matched, NamedEntry{std::move(obj), 1});
+            bound.push_back(matched);
         }
-
-        auto obj = findQueryableObj(matched); /// frame walk: GIL only, no lock
-        if (obj.is_none())
-            continue;
-
-        std::lock_guard lock(state_mutex);
-        if (auto it = py_table_cache.find(matched); it != py_table_cache.end())
-            ++it->second.refcount; /// another thread bound it meanwhile
-        else
-            py_table_cache.emplace(matched, NamedEntry{std::move(obj), 1});
-        bound.push_back(matched);
+    }
+    catch (...)
+    {
+        /// A frame-walk failure mid-loop must not strand the bumps already
+        /// made: no token would record them, pinning the objects until close.
+        releaseBoundNames(bound);
+        throw;
     }
 
     if (bound.empty())
@@ -248,20 +263,14 @@ UInt64 PythonTableCache::findQueryableObjFromQuery(const String & query_str)
     return token;
 }
 
-void PythonTableCache::releaseQueryableObjs(UInt64 token)
+void PythonTableCache::releaseBoundNames(const std::vector<String> & names)
 {
-    if (token == 0)
-        return;
-
-    /// No GIL here: erased references go through the deferred-decref queue,
-    /// so this is safe from any exit path regardless of lock/GIL context.
+    /// No GIL required: erased references go through the deferred-decref
+    /// queue, so this is safe from any exit path regardless of lock/GIL context.
     std::vector<py::object> released;
     {
         std::lock_guard lock(state_mutex);
-        auto rec = bound_names_by_token.find(token);
-        if (rec == bound_names_by_token.end())
-            return;
-        for (const auto & name : rec->second)
+        for (const auto & name : names)
         {
             auto it = py_table_cache.find(name);
             if (it == py_table_cache.end())
@@ -274,20 +283,40 @@ void PythonTableCache::releaseQueryableObjs(UInt64 token)
             else
                 --it->second.refcount;
         }
-        bound_names_by_token.erase(rec);
     }
     for (auto & obj : released)
         enqueuePyDecref(obj.release().ptr());
 }
 
+void PythonTableCache::releaseQueryableObjs(UInt64 token)
+{
+    if (token == 0)
+        return;
+
+    std::vector<String> names;
+    {
+        std::lock_guard lock(state_mutex);
+        auto rec = bound_names_by_token.find(token);
+        if (rec == bound_names_by_token.end())
+            return;
+        names = std::move(rec->second);
+        bound_names_by_token.erase(rec);
+    }
+    releaseBoundNames(names);
+}
+
 py::object PythonTableCache::getQueryableObj(const String & table_name)
 {
+    /// The returned copy increfs, which is only safe under the GIL - the
+    /// state_mutex serializes map access, not refcount manipulation.
+    py::gil_assert();
+
     std::lock_guard lock(state_mutex);
 
     auto iter = py_table_cache.find(table_name);
 
     if (iter != py_table_cache.end())
-        return iter->second.obj; /// copy increfs under the lock (C API only)
+        return iter->second.obj;
 
     return py::none();
 }

--- a/programs/local/PythonTableCache.h
+++ b/programs/local/PythonTableCache.h
@@ -95,6 +95,10 @@ private:
     /// Locks state_mutex internally; entry destructors run outside the lock.
     void dropMeta(PyObject * df_ptr);
 
+    /// Decrement/erase the given name bindings (shared by token release and
+    /// the bind-loop exception rollback). GIL not required.
+    void releaseBoundNames(const std::vector<String> & names);
+
     /// Guards py_table_cache, meta_lru and query_epoch. The GIL alone is not
     /// enough: the pybind-side prefill (before client_mutex is taken) can
     /// interleave with an in-flight query's storage-side lookups at GIL yield

--- a/programs/local/PythonTableCache.h
+++ b/programs/local/PythonTableCache.h
@@ -68,23 +68,31 @@ class PythonTableCache {
 public:
     ~PythonTableCache();
 
-    void findQueryableObjFromQuery(const String & query_str);
+    /// Bind every Python(name) the query references (or bump the refcount of
+    /// a binding another in-flight query already made) and return a token
+    /// identifying exactly the bindings this call created. 0 = nothing bound.
+    UInt64 findQueryableObjFromQuery(const String & query_str);
 
-    py::handle getQueryableObj(const String & table_name);
+    /// Drop the bindings the findQueryableObjFromQuery call that returned
+    /// `token` created (refcounted: a name stays bound while any in-flight
+    /// query on the connection references it). Safe without the GIL - erased
+    /// references are released through the deferred-decref queue. Called from
+    /// every query-exit path; clear() remains the connection-close full wipe.
+    void releaseQueryableObjs(UInt64 token);
+
+    /// Strong reference: the caller's use may outlive a concurrent release
+    /// of the binding (Py_INCREF under state_mutex is C API, no bytecode).
+    py::object getQueryableObj(const String & table_name);
 
     void clear();
 
     /// Pandas metadata cache. All methods must be called with the GIL held.
     PandasTableMetaPtr findValidatedPandasMeta(const py::handle & df);
     void storePandasMeta(const py::handle & df, const DB::ColumnsDescription & schema);
-    void invalidatePandasMeta(PyObject * df_ptr)
-    {
-        std::lock_guard lock(state_mutex);
-        dropMeta(df_ptr);
-    }
+    void invalidatePandasMeta(PyObject * df_ptr) { dropMeta(df_ptr); }
 
 private:
-    /// Must be called with state_mutex held.
+    /// Locks state_mutex internally; entry destructors run outside the lock.
     void dropMeta(PyObject * df_ptr);
 
     /// Guards py_table_cache, meta_lru and query_epoch. The GIL alone is not
@@ -94,7 +102,25 @@ private:
     /// order is GIL first, then state_mutex; no Python code that could
     /// re-enter this object runs while the mutex is held by the same thread.
     std::mutex state_mutex;
-    std::unordered_map<String, py::handle> py_table_cache;
+
+    /// Strong reference plus the number of in-flight queries that bound it.
+    /// A query must not clear another query's bindings: with one connection
+    /// shared by several threads, thread B's prefill runs while thread A's
+    /// query is still executing, and A's exit used to wipe B's entry. The
+    /// reference is owned so a binding reused by a later overlapping query
+    /// can never dangle when the user rebinds the Python variable meanwhile.
+    struct NamedEntry
+    {
+        py::object obj;
+        size_t refcount = 0;
+    };
+    std::unordered_map<String, NamedEntry> py_table_cache;
+
+    /// Names each outstanding findQueryableObjFromQuery call actually bound,
+    /// keyed by its token. Exact pairing: releasing one query can neither
+    /// under- nor over-release names bound by a concurrent query, even for
+    /// identical query texts with different per-thread name visibility.
+    std::unordered_map<UInt64, std::vector<String>> bound_names_by_token;
 
     static constexpr size_t max_meta_entries = 4;
     std::list<PandasTableMetaPtr> meta_lru;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -106,6 +106,11 @@ struct StreamingQueryContext
     /// concurrent streams on one client can differ.
     bool dataframe_over_chunks = true;
 
+    /// Token pairing this stream with the Python(name) bindings its prefill
+    /// created (chdb); released when the stream finishes, errors, or is
+    /// cancelled or abandoned.
+    UInt64 python_tables_bind_token = 0;
+
     StreamingQueryContext() = default;
 };
 

--- a/tests/test_zero_copy_lifetime.py
+++ b/tests/test_zero_copy_lifetime.py
@@ -213,9 +213,11 @@ class TestErrorPathStateReset(unittest.TestCase):
             qdf = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
             wr_df = weakref.ref(qdf)
             stream = conn.send_insert("INSERT INTO ins_t (x)", "CSV")
-            with self.assertRaises(Exception):
-                conn.query("SELECT sum(x) FROM Python(qdf)", "CSV")
-            stream.close()
+            try:
+                with self.assertRaisesRegex(Exception, "streaming insert is active"):
+                    conn.query("SELECT sum(x) FROM Python(qdf)", "CSV")
+            finally:
+                stream.close()
             del qdf
             gc.collect()
             self.assertIsNone(wr_df(), "rejected query leaked its name binding")
@@ -381,7 +383,7 @@ class TestRepeatedAndConcurrent(unittest.TestCase):
                         if got != exp[name]:
                             errors.append(f"{name}: {got} != {exp[name]}")
                     except Exception as e:  # noqa: BLE001
-                        errors.append(f"{name}: {type(e).__name__}")
+                        errors.append(f"{name}: {type(e).__name__}: {str(e)[:200]}")
 
             def joiner():
                 for _ in range(15):
@@ -392,7 +394,7 @@ class TestRepeatedAndConcurrent(unittest.TestCase):
                         if got != str(n2):
                             errors.append(f"join: {got} != {n2}")
                     except Exception as e:  # noqa: BLE001
-                        errors.append(f"join: {type(e).__name__}")
+                        errors.append(f"join: {type(e).__name__}: {str(e)[:200]}")
 
             threads = [threading.Thread(target=worker, args=(n,))
                        for n in ("udf1", "udf2", "udf1", "udf2")] + [threading.Thread(target=joiner)]

--- a/tests/test_zero_copy_lifetime.py
+++ b/tests/test_zero_copy_lifetime.py
@@ -183,6 +183,49 @@ class TestZeroCopyEligibility(unittest.TestCase):
 
 
 class TestErrorPathStateReset(unittest.TestCase):
+    @unittest.skipUnless(PANDAS3, "arrow-backed str dtype requires pandas 3")
+    def test_abandoned_stream_replaced_releases_bindings(self):
+        # Starting a new stream implicitly abandons an unfinished one; the old
+        # stream's name bindings must be released with it, not leak until close.
+        conn = chdb.connect(":memory:")
+        try:
+            global adf
+            adf = make_df(50_000)
+            wr_pa = weakref.ref(adf["s"].array._pa_array)
+            s1 = conn.send_query("SELECT i64, s FROM Python(adf)", "CSV")
+            next(iter(s1))  # consume one chunk, abandon without close
+            s2 = conn.send_query("SELECT count() FROM Python(adf)", "CSV")
+            list(s2)  # drain second stream to completion
+            del s1, s2, adf
+            gc.collect()
+            self.assertIsNone(wr_pa(), "abandoned stream leaked its name binding")
+        finally:
+            globals().pop("adf", None)
+            conn.close()
+
+    def test_query_rejected_during_insert_stream_releases_binding(self):
+        # A query rejected because a streaming insert is active must still
+        # release its prefilled binding (early-return path).
+        conn = chdb.connect(":memory:")
+        try:
+            conn.query("CREATE TABLE ins_t (x Int64) ENGINE = Memory", "CSV")
+            global qdf
+            qdf = pd.DataFrame({"x": np.arange(10, dtype=np.int64)})
+            wr_df = weakref.ref(qdf)
+            stream = conn.send_insert("INSERT INTO ins_t (x)", "CSV")
+            with self.assertRaises(Exception):
+                conn.query("SELECT sum(x) FROM Python(qdf)", "CSV")
+            stream.close()
+            del qdf
+            gc.collect()
+            self.assertIsNone(wr_df(), "rejected query leaked its name binding")
+            got = str(conn.query("SELECT count() FROM ins_t", "CSV")).strip()
+            self.assertEqual(got, "0")
+            conn.query("DROP TABLE ins_t", "CSV")
+        finally:
+            globals().pop("qdf", None)
+            conn.close()
+
     def test_streaming_init_error_then_rebind(self):
         # A failed send_query must not leave a stale df handle: rebinding the
         # name serves the new data, deleting it raises instead of hanging.
@@ -318,19 +361,17 @@ class TestRepeatedAndConcurrent(unittest.TestCase):
             del tdf1, tdf2
             conn.close()
 
-    def test_unsynchronized_threads_never_return_wrong_data(self):
-        """True concurrent submission on one connection is a pre-existing
-        weak spot (the stock 26.5 wheel fails most such queries with
-        PY_OBJECT_NOT_FOUND). Pin the safety property that matters: a query
-        either returns the exact correct result or raises - it must never
-        return wrong data, crash, or hang."""
+    def test_unsynchronized_threads_all_succeed(self):
+        """Concurrent submission on one connection: bindings are refcounted
+        per query, so one query's exit no longer clears another in-flight
+        query's name binding. Every query must return the exact result."""
         conn = chdb.connect(":memory:")
         try:
             n1, n2 = 50_000, 30_000
             global udf1, udf2
             udf1, udf2 = make_df(n1, "a"), make_df(n2, "b")
             exp = {"udf1": f"{n1},{(n1 - 1) * n1 // 2}", "udf2": f"{n2},{(n2 - 1) * n2 // 2}"}
-            wrong = []
+            errors = []
 
             def worker(name):
                 for _ in range(20):
@@ -338,17 +379,28 @@ class TestRepeatedAndConcurrent(unittest.TestCase):
                         got = str(conn.query(
                             f"SELECT count(), sum(i64) FROM Python({name})", "CSV")).strip()
                         if got != exp[name]:
-                            wrong.append(f"{name}: {got} != {exp[name]}")
-                    except Exception:  # noqa: BLE001 - acceptable failure mode
-                        pass
+                            errors.append(f"{name}: {got} != {exp[name]}")
+                    except Exception as e:  # noqa: BLE001
+                        errors.append(f"{name}: {type(e).__name__}")
+
+            def joiner():
+                for _ in range(15):
+                    try:
+                        got = str(conn.query(
+                            "SELECT count() FROM Python(udf1) a JOIN Python(udf2) b ON a.i64 = b.i64",
+                            "CSV")).strip()
+                        if got != str(n2):
+                            errors.append(f"join: {got} != {n2}")
+                    except Exception as e:  # noqa: BLE001
+                        errors.append(f"join: {type(e).__name__}")
 
             threads = [threading.Thread(target=worker, args=(n,))
-                       for n in ("udf1", "udf2", "udf1", "udf2")]
+                       for n in ("udf1", "udf2", "udf1", "udf2")] + [threading.Thread(target=joiner)]
             for t in threads:
                 t.start()
             for t in threads:
                 t.join()
-            self.assertEqual(wrong, [], "concurrent queries returned WRONG data")
+            self.assertEqual(errors, [])
         finally:
             del udf1, udf2
             conn.close()


### PR DESCRIPTION
Stacked on #174 (contains its commits; merge after it - this PR's own change is the top commit).

## Problem

With one connection shared by several Python threads, a query's exit wiped the whole `Python(name)` binding map, including entries a concurrent query had just prefilled. Most concurrent queries failed with `PY_OBJECT_NOT_FOUND`: the stock 26.5 wheel fails 79/80 in a 4-thread stress test.

## Fix

- Bindings are refcounted and **token-paired**: prefill records the names it actually bound under a token (thread-local handoff to the execute call; stored in `StreamingQueryContext` for streams), and release drops exactly that record. Every exit path releases its own token, including the previously leaking ones (query rejected during an active streaming insert, a new stream replacing an abandoned one, insert-streaming completion).
- Entries hold strong references, so a binding reused by an overlapping query cannot dangle when the user rebinds the variable; releases go through the deferred-decref queue, so no exit path needs the GIL.
- `state_mutex` critical sections no longer run Python bytecode (frame walk, witness validation and entry destruction happen unlocked), eliminating a GIL-handoff deadlock.

## Tests

Stress: 4 threads x 100 queries + concurrent two-table JOINs = 0 errors (previously 79/80 failures). New regression tests cover the abandoned-stream and insert-guard leak paths; full local matrix (zero-copy, meta-cache, streaming query/insert, UDF, query_py) green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make concurrent queries on one connection reliable by scoping Python table cache bindings to per-query tokens
> - Replaces global `PythonTableCache::clear()` calls with precise, token-scoped `releaseQueryableObjs(token)` so that concurrent or sequential queries on the same connection no longer clobber each other's `Python(name)` bindings.
> - Introduces a thread-local `python_tables_bind_token` in [ChdbClient.cpp](https://github.com/chdb-io/chdb-core/pull/175/files#diff-ef544362fd982f01e00b0616f9a734e627fbb618d6961e38d9e277315ec06685) that pairs each prefill call (`findQueryableObjFromPyCache`) with its subsequent execute, streaming init, or cancellation path.
> - Reworks `PythonTableCache` in [PythonTableCache.cpp](https://github.com/chdb-io/chdb-core/pull/175/files#diff-fe02c8f66ace9f737d64dc15633129ffc044ff4ee2d97adca62f1c71a28fdee7) to use refcounted `NamedEntry` structs and a `bound_names_by_token` map, returning a `UInt64` token from `findQueryableObjFromQuery` and releasing bindings via `releaseQueryableObjs`.
> - Adds `enqueuePyDecref` in [PyBorrowGuard.cpp](https://github.com/chdb-io/chdb-core/pull/175/files#diff-6f42875d5a3bd74054f8378e777fba4fd4f383d3b02e64980db545f5d2a7bc7e) to safely defer Python object decrefs from any thread without the GIL.
> - Adds `python_tables_bind_token` to `StreamingQueryContext` so streaming queries carry their binding token through to end, cancellation, or error cleanup.
> - Risk: All call sites that previously called `clear()` now call `releaseQueryableObjs`; any path that fails to capture the token before resetting context will silently leak bindings until connection close.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0669507.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->