### PR TITLE
Remove the split-bundle (primary + deferred) test flow from wasm CI

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -244,57 +244,6 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-      # ---- wasm-split lazy-loading pipeline (tools/split/README.md). Runs AFTER
-      # the npm dist build + artifact upload: the relink turns the build trees'
-      # chdb.wasm into the profiling-INSTRUMENTED module (copy-artifacts refuses
-      # such a tree by design), so dist/ must be final before this point. Sits
-      # before the tag-publish steps on purpose — if split ever regresses, a
-      # release run goes red instead of shipping quietly. Adds ~25min: two
-      # relinks (objects are reused), profiling runs, two wasm-split invocations.
-      - name: Relink with WASM_SPLIT_MODULE=ON (both bundles)
-        run: |
-          source "${EMSDK}/emsdk_env.sh"
-          cmake -DWASM_SPLIT_MODULE=ON buildwasm >/dev/null
-          ninja -C buildwasm chdb_wasm
-          cmake -DWASM_SPLIT_MODULE=ON buildwasm-st >/dev/null
-          ninja -C buildwasm-st chdb_wasm
-          ls -la buildwasm/programs/wasm/chdb.wasm.orig buildwasm-st/programs/wasm/chdb.wasm.orig
-
-      # st first: its single instance sees the whole pipeline execute inline, so
-      # its hot set is complete; the mt split mixes it in via --extra-hot (mt
-      # pool workers park in Atomics.wait and are invisible to profiling).
-      - name: wasm-split pipeline (profile + split, st hot-set -> mt)
-        env:
-          ICEBERG_PY: ${{ github.workspace }}/.iceberg-venv/bin/python
-        run: |
-          export WASM_SPLIT="${EMSDK}/upstream/bin/wasm-split"
-          node packages/chdb-wasm/tools/split/split-wasm.mjs \
-            --build buildwasm-st/programs/wasm --out "${GITHUB_WORKSPACE}/split-out-st" \
-            --emit-hot-names "${GITHUB_WORKSPACE}/split-out-st/hot-names.txt"
-          node packages/chdb-wasm/tools/split/split-wasm.mjs \
-            --build buildwasm/programs/wasm --out "${GITHUB_WORKSPACE}/split-out-mt" \
-            --extra-hot "${GITHUB_WORKSPACE}/split-out-st/hot-names.txt"
-
-      - name: Split bundle tests
-        env:
-          CHDB_SPLIT_MT_DIR: ${{ github.workspace }}/split-out-mt
-          CHDB_SPLIT_ST_DIR: ${{ github.workspace }}/split-out-st
-        run: node packages/chdb-wasm/test/split.test.mjs
-
-      - name: Upload split wasm artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: chdb-wasm-split
-          path: |
-            split-out-mt/chdb.mjs
-            split-out-mt/chdb.wasm
-            split-out-mt/chdb.deferred.wasm
-            split-out-st/chdb.mjs
-            split-out-st/chdb.wasm
-            split-out-st/chdb.deferred.wasm
-          retention-days: 1
-          if-no-files-found: error
-
       # ---- chdb-cloudflare: a single-file bundle sized for Cloudflare Workers
       # (10 MiB gzipped Worker limit). Unlike the npm bundles above, this one is
       # compiled with CHDB_LITE=ON: the wasm default is the full function registry,


### PR DESCRIPTION
## What

Drops the full-split (primary + deferred) steps from `wasm.yml`:

- Relink with `WASM_SPLIT_MODULE=ON` (both bundles)
- wasm-split pipeline (profile + split, st hot-set -> mt)
- Split bundle tests
- Upload split wasm artifact (`chdb-wasm-split`)

## Why

The `hot-without-deferred` assertion in the split bundle tests requires the mt primary to be self-contained for every hot path. That completeness rests on profiling coverage, which is inherently incomplete for the mt bundle: pool workers park in `Atomics.wait` and are invisible to profiling, so the hot set is transferred from the st profile by name. A handful of functions at the edge of the hot set differ from run to run, and when one of them is exercised at runtime the primary-only probe traps — producing CI failures unrelated to the PR under test (most recently on #173, where the failing test never executes the changed code).

Cost/benefit: the block adds ~25 min of relink + profiling per run, and its only output was a 1-day inspection artifact — the split bundles are not part of the npm packages.

The chdb-cloudflare pipeline is unaffected: it has its own build tree, its own corpus (`profile-corpus-lite.sql`), force-keep list, and tests, and it keeps exercising the split tooling (`tools/split/split-wasm.mjs`, `patch-glue.mjs`) on every run. Its lite glue throws a clear error for out-of-corpus calls instead of relying on lazy loading, so it does not depend on the profiling-completeness property that made these tests flaky.

Trade-off: the lazy-load (deferred module) path loses CI coverage. `test/split.test.mjs` and the tooling stay in the repo and can still be run locally against split output dirs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove split-bundle test flow from wasm CI
> Removes the wasm-split lazy-loading pipeline from the [wasm.yml](https://github.com/chdb-io/chdb-core/pull/176/files#diff-7985cab97a05bfe5fc9e7b10f0a11e6889e2eddf3f937bb16f85e14409e3b35e) CI workflow. This includes the `WASM_SPLIT_MODULE=ON` relink steps, the `split-wasm.mjs` profiling/splitting invocations, the split bundle tests, and the upload of `chdb-wasm-split` artifacts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e14369f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->