### PR TITLE
Destroy EmbeddedServer in the atexit hook when a connection is left open

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -365,8 +365,11 @@ jobs:
         shell: bash
       - name: Setup core dump collection
         run: |
-          mkdir -p tmp/core
-          echo "tmp/core/core.%p" | sudo tee /proc/sys/kernel/core_pattern
+          # core_pattern must be absolute: the kernel resolves a relative
+          # pattern against the crashing process's cwd, so cores from test
+          # subprocesses (different cwd) were silently dropped.
+          sudo mkdir -p /tmp/core && sudo chmod 1777 /tmp/core
+          echo "/tmp/core/core.%p" | sudo tee /proc/sys/kernel/core_pattern
           ulimit -c unlimited
       - name: Start MinIO for S3 streaming-insert tests
         continue-on-error: true
@@ -663,14 +666,14 @@ jobs:
       - name: Check and upload core files if present
         if: always()
         run: |
-          if ls tmp/core/core.* >/dev/null 2>&1; then
+          if ls /tmp/core/core.* >/dev/null 2>&1; then
             echo "CORE_FILES_FOUND=true" >> $GITHUB_ENV
-            tar -czvf core-files-linux-aarch64.tar.gz tmp/core/core.*
+            tar -czvf core-files-linux-aarch64.tar.gz -C /tmp core
             echo "Core files tar created: core-files-linux-aarch64.tar.gz"
             ls -lh core-files-linux-aarch64.tar.gz
           else
             echo "CORE_FILES_FOUND=false" >> $GITHUB_ENV
-            echo "No core files found in tmp/core"
+            echo "No core files found in /tmp/core"
           fi
         continue-on-error: true
       - name: Keep killall ccache and wait for ccache to finish

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -369,6 +369,9 @@ jobs:
           # pattern against the crashing process's cwd, so cores from test
           # subprocesses (different cwd) were silently dropped.
           sudo mkdir -p /tmp/core && sudo chmod 1777 /tmp/core
+          # Runners are persistent and /tmp/core is shared: drop stale cores
+          # so the collection step only ever reports this run's crashes.
+          sudo rm -f /tmp/core/core.*
           echo "/tmp/core/core.%p" | sudo tee /proc/sys/kernel/core_pattern
           ulimit -c unlimited
       - name: Start MinIO for S3 streaming-insert tests
@@ -514,6 +517,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          ulimit -c unlimited
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.11
@@ -648,6 +652,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          ulimit -c unlimited
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.11
@@ -668,7 +673,7 @@ jobs:
         run: |
           if ls /tmp/core/core.* >/dev/null 2>&1; then
             echo "CORE_FILES_FOUND=true" >> $GITHUB_ENV
-            tar -czvf core-files-linux-aarch64.tar.gz -C /tmp core
+            tar -czvf core-files-linux-aarch64.tar.gz /tmp/core/core.*
             echo "Core files tar created: core-files-linux-aarch64.tar.gz"
             ls -lh core-files-linux-aarch64.tar.gz
           else

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -349,8 +349,11 @@ jobs:
         shell: bash
       - name: Setup core dump collection
         run: |
-          mkdir -p tmp/core
-          echo "tmp/core/core.%p" | sudo tee /proc/sys/kernel/core_pattern
+          # core_pattern must be absolute: the kernel resolves a relative
+          # pattern against the crashing process's cwd, so cores from test
+          # subprocesses (different cwd) were silently dropped.
+          sudo mkdir -p /tmp/core && sudo chmod 1777 /tmp/core
+          echo "/tmp/core/core.%p" | sudo tee /proc/sys/kernel/core_pattern
           ulimit -c unlimited
       - name: Start MinIO for S3 streaming-insert tests
         continue-on-error: true
@@ -648,14 +651,14 @@ jobs:
       - name: Check and upload core files if present
         if: always()
         run: |
-          if ls tmp/core/core.* >/dev/null 2>&1; then
+          if ls /tmp/core/core.* >/dev/null 2>&1; then
             echo "CORE_FILES_FOUND=true" >> $GITHUB_ENV
-            tar -czvf core-files-linux-x86_64.tar.gz tmp/core/core.*
+            tar -czvf core-files-linux-x86_64.tar.gz -C /tmp core
             echo "Core files tar created: core-files-linux-x86_64.tar.gz"
             ls -lh core-files-linux-x86_64.tar.gz
           else
             echo "CORE_FILES_FOUND=false" >> $GITHUB_ENV
-            echo "No core files found in tmp/core"
+            echo "No core files found in /tmp/core"
           fi
         continue-on-error: true
       - name: Keep killall ccache and wait for ccache to finish

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -353,6 +353,9 @@ jobs:
           # pattern against the crashing process's cwd, so cores from test
           # subprocesses (different cwd) were silently dropped.
           sudo mkdir -p /tmp/core && sudo chmod 1777 /tmp/core
+          # Runners are persistent and /tmp/core is shared: drop stale cores
+          # so the collection step only ever reports this run's crashes.
+          sudo rm -f /tmp/core/core.*
           echo "/tmp/core/core.%p" | sudo tee /proc/sys/kernel/core_pattern
           ulimit -c unlimited
       - name: Start MinIO for S3 streaming-insert tests
@@ -495,6 +498,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          ulimit -c unlimited
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.11
@@ -634,6 +638,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          ulimit -c unlimited
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.11
@@ -653,7 +658,7 @@ jobs:
         run: |
           if ls /tmp/core/core.* >/dev/null 2>&1; then
             echo "CORE_FILES_FOUND=true" >> $GITHUB_ENV
-            tar -czvf core-files-linux-x86_64.tar.gz -C /tmp core
+            tar -czvf core-files-linux-x86_64.tar.gz /tmp/core/core.*
             echo "Core files tar created: core-files-linux-x86_64.tar.gz"
             ls -lh core-files-linux-x86_64.tar.gz
           else

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <mutex>
 #include <Access/AccessControl.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <Core/UUID.h>
@@ -249,12 +250,18 @@ void EmbeddedServer::initialize(Poco::Util::Application & self)
         (void)std::atexit([]
         {
             g_memory_tracking_disabled.store(true, std::memory_order_relaxed);
-            /// If the embedded server is still alive at interpreter exit (connection left
-            /// open), its MemoryWorker thread must stop before the global pool teardown:
-            /// v26.7's worker loop logs through machinery that shutdown() destroys.
-            /// global_instance's own static destructor runs later (LIFO), too late.
-            if (global_instance && global_instance->memory_worker)
-                global_instance->memory_worker.reset();
+            /// If a connection is still open at interpreter exit, destroy the server
+            /// here, before the global pool teardown, while logging and the statics
+            /// its shutdown touches are still alive. Waiting for global_instance's
+            /// static destructor is too late: it interleaves with unrelated static
+            /// teardown (cross-TU destruction order is unspecified) while worker
+            /// threads are still live - the residual SIGSEGV window seen as the
+            /// DataStore-suite subprocess crashes on v26.7.
+            {
+                std::lock_guard<std::mutex> lock(instance_mutex);
+                client_ref_count = 0;
+                global_instance.reset();
+            }
             GlobalThreadPool::shutdown();
         });
 

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -257,11 +257,17 @@ void EmbeddedServer::initialize(Poco::Util::Application & self)
             /// teardown (cross-TU destruction order is unspecified) while worker
             /// threads are still live - the residual SIGSEGV window seen as the
             /// DataStore-suite subprocess crashes on v26.7.
+            /// Take ownership under the lock but destroy outside it: the
+            /// teardown must not run under instance_mutex, or a teardown
+            /// path taking the mutex would self-deadlock and a concurrent
+            /// close would block for the whole teardown.
+            std::unique_ptr<EmbeddedServer> instance_to_destroy;
             {
                 std::lock_guard<std::mutex> lock(instance_mutex);
                 client_ref_count = 0;
-                global_instance.reset();
+                instance_to_destroy = std::move(global_instance);
             }
+            instance_to_destroy.reset();
             GlobalThreadPool::shutdown();
         });
 

--- a/tests/test_exit_open_connection.py
+++ b/tests/test_exit_open_connection.py
@@ -1,0 +1,56 @@
+#!python3
+
+import subprocess
+import sys
+import unittest
+
+# Exiting the interpreter with a connection left open must not crash: the
+# EmbeddedServer atexit hook has to destroy the server while logging and the
+# statics its teardown touches are still alive. Regression test for the
+# DataStore-suite subprocess SIGSEGV (exit -11) on v26.7-based builds.
+
+CHILD_PLAIN = (
+    "import chdb\n"
+    "conn = chdb.connect(':memory:')\n"
+    "r = conn.query('SELECT 1', 'CSV')\n"
+    "assert '1' in str(r)\n"
+)
+
+# Mirrors how DataStore connects (settings in the connection string).
+CHILD_WITH_SETTINGS = (
+    "import chdb\n"
+    "conn = chdb.connect(':memory:?memory_worker_correct_memory_tracker=0')\n"
+    "r = conn.query(\n"
+    "    \"SELECT value FROM system.server_settings \"\n"
+    "    \"WHERE name = 'memory_worker_correct_memory_tracker'\",\n"
+    "    'CSV',\n"
+    ")\n"
+    "assert '0' in str(r)\n"
+)
+
+
+class TestExitWithOpenConnection(unittest.TestCase):
+    def _run_child(self, child, runs):
+        for i in range(runs):
+            result = subprocess.run(
+                [sys.executable, "-c", child],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"run {i}: exit {result.returncode}\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+
+    def test_exit_without_close(self):
+        self._run_child(CHILD_PLAIN, 5)
+
+    def test_exit_without_close_with_connection_settings(self):
+        self._run_child(CHILD_WITH_SETTINGS, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #177.

### What

When the interpreter exits with a connection still open, the atexit hook now destroys `global_instance` entirely (under `instance_mutex`, before `GlobalThreadPool::shutdown()`) instead of only stopping the MemoryWorker. This runs the same teardown as a normal `releaseInstance()`, but while logging and the statics it touches are still alive. Previously the full teardown was left to `global_instance`'s static destructor, which interleaves with unrelated static destruction (cross-TU order is unspecified) while unjoined worker threads are still live — the residual SIGSEGV window behind the DataStore-suite subprocess crashes on v26.7 (both x86_64 and arm64, see #177).

Also makes `kernel.core_pattern` absolute in the two Linux wheel workflows: the kernel resolves a relative pattern against the crashing process's cwd, so cores from test subprocesses were silently dropped — which is why this crash never left a usable core.

### Tests

- New `tests/test_exit_open_connection.py`: subprocesses exit without closing the connection (plain and with a DataStore-style connection-string setting) and must exit 0.
- Local stress on the built library via the C API: 150 exit-with-open-connection runs, 150 with `--memory_worker_correct_memory_tracker=0`, 50 proper-close controls — 350/350 clean exits.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a rare crash at interpreter exit when a connection is left open.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Destroy `EmbeddedServer` in the `atexit` hook when a connection is left open
> - Reworks the `atexit` hook in [`EmbeddedServer.cpp`](https://github.com/chdb-io/chdb-core/pull/178/files#diff-b40e2cd65195a45a5e28818eb8a4abb4f0b06a149aad063577c767414136191b) to fully destroy the global server instance before global static teardown: acquires `instance_mutex`, resets `client_ref_count` to 0, moves the instance out, releases the lock, then destroys it and calls `GlobalThreadPool::shutdown()`.
> - Adds [`tests/test_exit_open_connection.py`](https://github.com/chdb-io/chdb-core/pull/178/files#diff-019ca5223daba1424f455ec1d0610f22e6c70525b6f167dfe90771d22ac10724) to verify that processes exiting with an unclosed chdb connection exit cleanly (zero exit status).
> - Updates CI workflows to write core dumps to `/tmp/core` (with `1777` perms and stale-core cleanup) and enable `ulimit -c unlimited` before DataStore tests to capture any remaining crashes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 511f6c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->