### PR TITLE
Check the language bindings against every release

### DIFF
--- a/.github/workflows/check_bindings.yml
+++ b/.github/workflows/check_bindings.yml
@@ -1,0 +1,88 @@
+name: Check language bindings
+
+# A release publishes libchdb; the bindings consume it. Their C ABI is checked
+# nowhere else. chdb-go writes its purego signatures by hand and resolves
+# symbols by name at runtime, so nothing disagrees with a changed struct.
+# chdb-node's addon and chdb-rust's bindgen output only ever see the header
+# they were built against, and each repository builds against the engine it
+# pinned — so all three stay green through any change made here, until someone
+# bumps the pin months later and inherits the whole backlog at once.
+#
+# This asks each binding to run its own suite against the engine just published
+# and to open an issue in its own repository with the verdict. It gates nothing:
+# the release has already shipped by the time this starts. What it buys is
+# knowing on the day.
+#
+# BINDING_DISPATCH_TOKEN is a fine-grained PAT scoped to chdb-go, chdb-node and
+# chdb-rust with Contents: write. GITHUB_TOKEN cannot reach another repository.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      engine_version:
+        description: "chdb-core release tag to test the bindings against, e.g. v26.5.0"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  wait_for_assets:
+    runs-on: ubuntu-latest
+    # The tarballs are uploaded by the four wheel workflows, which start from
+    # this same release event and build ClickHouse from scratch. Dispatching
+    # before they land sends every binding to a 404. Waiting on the assets
+    # rather than on those workflows also means a manual re-upload counts.
+    timeout-minutes: 330
+    steps:
+      - name: Wait for every platform tarball
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENGINE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.engine_version }}
+        run: |
+          set -euo pipefail
+
+          want='linux-x86_64-libchdb.tar.gz linux-aarch64-libchdb.tar.gz macos-arm64-libchdb.tar.gz macos-x86_64-libchdb.tar.gz'
+
+          deadline=$(( $(date +%s) + 5 * 3600 ))
+          while :; do
+            have=$(gh release view "$ENGINE_VERSION" --repo "$GITHUB_REPOSITORY" \
+                     --json assets --jq '.assets[].name' 2>/dev/null || true)
+            missing=$(comm -23 <(printf '%s\n' $want | sort) <(echo "$have" | sort))
+            [ -z "$missing" ] && break
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::$ENGINE_VERSION still missing after five hours:"
+              echo "$missing"
+              exit 1
+            fi
+
+            echo "still missing, waiting:"
+            echo "$missing"
+            sleep 120
+          done
+
+          echo "all four tarballs are on $ENGINE_VERSION"
+
+  dispatch:
+    needs: wait_for_assets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: [chdb-go, chdb-node, chdb-rust]
+    steps:
+      - name: Ask ${{ matrix.repo }} to run its suite against this engine
+        env:
+          GH_TOKEN: ${{ secrets.BINDING_DISPATCH_TOKEN }}
+          ENGINE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.engine_version }}
+          REPO: ${{ matrix.repo }}
+        run: |
+          set -euo pipefail
+          gh api "repos/chdb-io/$REPO/dispatches" --input - <<EOF
+          {"event_type": "chdb-core-release", "client_payload": {"tag": "$ENGINE_VERSION"}}
+          EOF
+          echo "dispatched $ENGINE_VERSION to chdb-io/$REPO"


### PR DESCRIPTION
Each of chdb-go, chdb-node and chdb-rust builds against an engine version it
pinned for itself, so all three stay green through anything that changes here.
The break surfaces months later, when someone moves a pin and inherits the whole
backlog at once. chdb-go is the worst case: purego resolves symbols by name at
runtime and its Go-side signatures are written by hand, so a struct that loses a
field builds and links exactly as before and misreads memory instead.

That has already happened. `struct chdb_conn` lost its `queue` field before
v26.5.0 and `chdb-purego/types.go` still declares it. Nothing anywhere noticed;
it is inert only because the live path uses the opaque `chdb_connection`.

On every release this now asks the three of them to run their own suites against
the engine just published and to open an issue in their own repository with the
verdict, closed again when green. It gates nothing: the release has already
shipped by the time this starts. What it buys is finding out on the day, in the
repository that has to fix it.

The job waits for the four platform tarballs before dispatching. The wheel
workflows start from this same release event and build ClickHouse from scratch,
so dispatching immediately sends every binding to a 404. Waiting on the assets
rather than on those workflows also means a manual re-upload counts, and a
timeout points upstream rather than down.

Needs `BINDING_DISPATCH_TOKEN`, a fine-grained PAT limited to those three
repositories with Contents: write — the narrowest permission the dispatch
endpoint accepts, since `GITHUB_TOKEN` cannot reach another repository. Already
configured.

Receiving side, all three of which have to merge first:

- chdb-io/chdb-go#45
- chdb-io/chdb-node#76
- chdb-io/chdb-rust#33

None of it is testable before it is on main — `repository_dispatch` and
`workflow_dispatch` only ever execute the default branch's copy. Once merged,
`gh workflow run check_bindings.yml -f engine_version=v26.5.0` exercises the
whole path against a release whose assets have been complete for months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflow to check language bindings against every release
> - Adds [check_bindings.yml](.github/workflows/check_bindings.yml), a GitHub Actions workflow that triggers on release published or manual dispatch.
> - Waits up to five hours for four platform tarballs (`linux-x86_64`, `linux-aarch64`, `macos-arm64`, `macos-x86_64`) to appear on the release before proceeding.
> - Sends a `chdb-core-release` repository dispatch event (with the release tag) to `chdb-io/chdb-go`, `chdb-io/chdb-node`, and `chdb-io/chdb-rust` via a fine-grained `BINDING_DISPATCH_TOKEN`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16eeee7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->