### PR TITLE
Make cancelling an exhausted stream a no-op, like fetching one

### DIFF
--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -489,6 +489,12 @@ void chdb_streaming_cancel_query(chdb_conn * conn, chdb_streaming_result * resul
     if (!result)
         return;
 
+    /// Same reason as chdb_stream_cancel_query below: a naturally-finished stream
+    /// has nothing to cancel, and its state is already retired.
+    auto * handle = reinterpret_cast<QueryResult *>(result);
+    if (handle->stream_exhausted.load(std::memory_order_acquire))
+        return;
+
     try
     {
         auto * client = static_cast<DB::ChdbClient *>(conn->server);
@@ -919,6 +925,16 @@ void chdb_stream_cancel_query(chdb_connection conn, chdb_result * result)
 
     auto * connection = reinterpret_cast<chdb_conn *>(conn);
     if (!checkConnectionValidity(connection))
+        return;
+
+    /// A naturally-finished stream has nothing left to cancel, and the state the
+    /// cancel path walks has already been retired. This is the flag
+    /// chdb_stream_fetch_result checks to make a post-EOF fetch idempotent, honoured
+    /// here for the same reason: draining a stream and then closing it is the
+    /// ordinary shape of a caller's cleanup, and it should not depend on whether
+    /// the last chunk was empty.
+    auto * handle = reinterpret_cast<QueryResult *>(result);
+    if (handle->stream_exhausted.load(std::memory_order_acquire))
         return;
 
     try


### PR DESCRIPTION
Fetching from a naturally-finished stream is already idempotent. Both fetch entry
points check `stream_exhausted` and answer with an empty result rather than reaching
into state the engine has retired — "idempotent EOF, like `read(2)`", as the comment
there puts it.

Cancelling does not check it. So a caller that drains a stream and then closes it —
the ordinary shape of a deferred cleanup, and the shape every binding uses — walks
the cancel path over that retired state. chdb-io/chdb-go#46: deterministic SIGSEGV
on linux/amd64 in `chdb_stream_cancel_query`, two runs, same frame, while
linux/arm64 and darwin/arm64 survive the identical call because the freed memory
still reads back the way it did.

## The existing guards do not cover it

`processStreamingQuery` rejects a missing context and a handle the context is not
tracking, and both throw into a catch-all in the cancel path, so those cases are
already safe. Neither fires here: after end of data the context is still present and
still tracking this handle. What has gone is what the cancel path then touches.

## The change

Both cancel entry points honour `stream_exhausted`, so cancel-after-EOF is inert the
same way fetch-after-EOF is. A cancel that arrives mid-stream, or after an error, is
untouched — only natural end of stream sets the flag.

A binding should not have to know whether the last chunk it read was empty in order
to close safely. chdb-io/chdb-go#49 stops calling cancel on a finished stream, which
fixes the crash from the caller's side and is verified green on the architecture that
faulted. This is the other half, so the C ABI stops turning a harmless call into a
fault for every binding — including the ones not written yet.

## What was not done

Not built locally; a full engine build is out of reach on this machine, so CI is the
first compile. The change is two copies of a check this file already makes three
lines away in the corresponding fetch function, so review should be able to judge it
on sight — but it has not run anywhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make cancelling an exhausted stream a no-op in `chdb_streaming_cancel_query` and `chdb_stream_cancel_query`
> Both cancel functions in [chdb.cpp](https://github.com/chdb-io/chdb-core/pull/180/files#diff-1e6f177972b741a03317763e7c2e41acac81949dabfd2913b21dd48dc0cf6e12) now check the `stream_exhausted` flag on the result handle before invoking `DB::ChdbClient::cancelStreamingQuery`. If the stream has naturally finished, the functions return early without calling the client cancel routine, matching the existing no-op behavior of fetching from an exhausted stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d814c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->