### PR TITLE
Fix many-core scaling and speed up DataFrame scans

### DIFF
--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -82,11 +82,7 @@ elif [ "$(uname)" == "Linux" ]; then
         LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=1"
     else
         CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
-        if [ "$(uname -m)" == "aarch64" ]; then
-            LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=0"
-        else
-            LLVM="-DENABLE_EMBEDDED_COMPILER=0 -DENABLE_DWARF_PARSER=0"
-        fi
+        LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=0"
     fi
     # -DENABLE_WASMTIME=1 enables the WebAssembly UDF runtime; it must be set
     # explicitly because ENABLE_LIBRARIES=0 would otherwise leave it OFF.

--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -73,13 +73,16 @@ elif [ "$(uname)" == "Linux" ]; then
     JEMALLOC="-DENABLE_JEMALLOC=1"
     ICU="-DENABLE_ICU=1"
     SED_INPLACE="sed -i"
-    # only x86_64, enable AVX, enable embedded compiler
+    # x86_64: AVX + embedded compiler. aarch64: embedded compiler too — the
+    # regexp JIT (min_count_to_compile_regular_expression) and compiled
+    # expressions need LLVM, and official ClickHouse aarch64 builds enable it;
+    # keeping it off left ARM without the regexp JIT entirely.
     if [ "$(uname -m)" == "x86_64" ]; then
         CPU_FEATURES="-DENABLE_AVX=1 -DENABLE_AVX2=0"
         LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=1"
     else
         CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
-        LLVM="-DENABLE_EMBEDDED_COMPILER=0 -DENABLE_DWARF_PARSER=0"
+        LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=0"
     fi
     # -DENABLE_WASMTIME=1 enables the WebAssembly UDF runtime; it must be set
     # explicitly because ENABLE_LIBRARIES=0 would otherwise leave it OFF.

--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -82,7 +82,11 @@ elif [ "$(uname)" == "Linux" ]; then
         LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=1"
     else
         CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
-        LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=0"
+        if [ "$(uname -m)" == "aarch64" ]; then
+            LLVM="-DENABLE_EMBEDDED_COMPILER=1 -DENABLE_DWARF_PARSER=0"
+        else
+            LLVM="-DENABLE_EMBEDDED_COMPILER=0 -DENABLE_DWARF_PARSER=0"
+        fi
     fi
     # -DENABLE_WASMTIME=1 enables the WebAssembly UDF runtime; it must be set
     # explicitly because ENABLE_LIBRARIES=0 would otherwise leave it OFF.

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -202,19 +202,25 @@ extern const int UNKNOWN_FORMAT;
 }
 
 #if defined(OS_LINUX)
-/// Number of CPUs in the largest NUMA node, or 0 when the topology is unknown
-/// or there is a single node. Parses /sys cpulist files ("0-47,96-143").
+/// Number of CPUs in the largest CPU-bearing NUMA node, or 0 when the
+/// topology is unknown or only one node has CPUs. Enumerates the node
+/// directories (ids can be sparse) and skips memory-only nodes (CXL/HBM
+/// expanders have an empty cpulist); parses cpulist files ("0-47,96-143").
 static size_t getMaxCPUsOfSingleNUMANode()
 {
     size_t max_cpus = 0;
-    size_t num_nodes = 0;
-    for (size_t node = 0;; ++node)
+    size_t cpu_nodes = 0;
+    std::error_code ec;
+    for (const auto & entry : std::filesystem::directory_iterator("/sys/devices/system/node", ec))
     {
-        std::ifstream f(fmt::format("/sys/devices/system/node/node{}/cpulist", node));
+        const std::string name = entry.path().filename().string();
+        if (name.size() <= 4 || name.compare(0, 4, "node") != 0
+            || name.find_first_not_of("0123456789", 4) != std::string::npos)
+            continue;
+        std::ifstream f(entry.path() / "cpulist");
         std::string line;
         if (!f.is_open() || !std::getline(f, line) || line.empty())
-            break;
-        ++num_nodes;
+            continue;
         size_t cpus = 0;
         std::vector<std::string> ranges;
         boost::split(ranges, line, boost::is_any_of(","));
@@ -228,9 +234,12 @@ static size_t getMaxCPUsOfSingleNUMANode()
             else if (sscanf(range.c_str(), "%zu", &lo) == 1) // NOLINT(cert-err34-c)
                 cpus += 1;
         }
+        if (cpus == 0)
+            continue;
+        ++cpu_nodes;
         max_cpus = std::max(max_cpus, cpus);
     }
-    return num_nodes > 1 ? max_cpus : 0;
+    return cpu_nodes > 1 ? max_cpus : 0;
 }
 #endif
 
@@ -256,8 +265,23 @@ static void applySettingsOverridesForLocal(ContextMutablePtr context)
     /// core of every socket. Cap the default at one NUMA node's core count;
     /// explicit max_threads settings are untouched.
     if (const size_t node_cpus = getMaxCPUsOfSingleNUMANode();
-        node_cpus > 0 && !settings[Setting::max_threads].changed && node_cpus < settings[Setting::max_threads])
-        settings[Setting::max_threads] = node_cpus;
+        node_cpus > 0 && !settings[Setting::max_threads].changed)
+    {
+        const size_t upstream_default = settings[Setting::max_threads];
+        /// Sub-NUMA clustering (AMD NPS2/NPS4, Intel SNC) splits one socket
+        /// into several nodes; capping to such a slice would over-restrict.
+        /// The validated data point is one socket of a two-socket machine,
+        /// so never cap below half of the upstream default.
+        const size_t cap = std::max(node_cpus, upstream_default / 2);
+        if (cap < upstream_default)
+        {
+            settings[Setting::max_threads] = cap;
+            /// This is an adjusted *default*, not a user choice: leave the
+            /// setting unmarked so it neither propagates to remote servers
+            /// in distributed queries nor masquerades as an explicit value.
+            settings[Setting::max_threads].changed = false;
+        }
+    }
 #endif
 
     context->setSettings(settings);

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -202,13 +202,13 @@ extern const int UNKNOWN_FORMAT;
 }
 
 #if defined(OS_LINUX)
-/// Number of CPUs in the largest CPU-bearing NUMA node, or 0 when the
-/// topology is unknown or only one node has CPUs. Enumerates the node
-/// directories (ids can be sparse) and skips memory-only nodes (CXL/HBM
-/// expanders have an empty cpulist); parses cpulist files ("0-47,96-143").
-static size_t getMaxCPUsOfSingleNUMANode()
+/// Total logical CPUs across NUMA nodes, or 0 when the topology is unknown
+/// or only one node has CPUs. Enumerates the node directories (ids can be
+/// sparse) and skips memory-only nodes (CXL/HBM expanders have an empty
+/// cpulist); parses cpulist files ("0-47,96-143").
+static size_t getLogicalCPUsIfMultiNUMA()
 {
-    size_t max_cpus = 0;
+    size_t total_cpus = 0;
     size_t cpu_nodes = 0;
     std::error_code ec;
     for (const auto & entry : std::filesystem::directory_iterator("/sys/devices/system/node", ec))
@@ -237,9 +237,9 @@ static size_t getMaxCPUsOfSingleNUMANode()
         if (cpus == 0)
             continue;
         ++cpu_nodes;
-        max_cpus = std::max(max_cpus, cpus);
+        total_cpus += cpus;
     }
-    return cpu_nodes > 1 ? max_cpus : 0;
+    return cpu_nodes > 1 ? total_cpus : 0;
 }
 #endif
 
@@ -264,16 +264,18 @@ static void applySettingsOverridesForLocal(ContextMutablePtr context)
     /// halves the count, but on no-SMT many-core CPUs the default lands on every
     /// core of every socket. Cap the default at one NUMA node's core count;
     /// explicit max_threads settings are untouched.
-    if (const size_t node_cpus = getMaxCPUsOfSingleNUMANode();
-        node_cpus > 0 && !settings[Setting::max_threads].changed)
+    if (const size_t logical_cpus = getLogicalCPUsIfMultiNUMA();
+        logical_cpus > 0 && !settings[Setting::max_threads].changed)
     {
         const size_t upstream_default = settings[Setting::max_threads];
-        /// Sub-NUMA clustering (AMD NPS2/NPS4, Intel SNC) splits one socket
-        /// into several nodes; capping to such a slice would over-restrict.
-        /// The validated data point is one socket of a two-socket machine,
-        /// so never cap below half of the upstream default.
-        const size_t cap = std::max(node_cpus, upstream_default / 2);
-        if (cap < upstream_default)
+        /// Half the *logical* CPUs, deliberately not "one node's CPUs": node
+        /// granularity depends on BIOS sub-NUMA settings (AMD NPS2/NPS4,
+        /// Intel SNC), while the measured optimum tracks logical/2 on both
+        /// validated shapes — 2-socket no-SMT 192-core (192 -> 96) and
+        /// 2-socket SMT 96-physical/192-logical (upstream default 96 is
+        /// already logical/2; unchanged).
+        const size_t cap = logical_cpus / 2;
+        if (cap > 0 && cap < upstream_default)
         {
             settings[Setting::max_threads] = cap;
             /// This is an adjusted *default*, not a user choice: leave the

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -256,7 +256,7 @@ static void applySettingsOverridesForLocal(ContextMutablePtr context)
     /// core of every socket. Cap the default at one NUMA node's core count;
     /// explicit max_threads settings are untouched.
     if (const size_t node_cpus = getMaxCPUsOfSingleNUMANode();
-        node_cpus > 0 && node_cpus < settings[Setting::max_threads])
+        node_cpus > 0 && !settings[Setting::max_threads].changed && node_cpus < settings[Setting::max_threads])
         settings[Setting::max_threads] = node_cpus;
 #endif
 

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <mutex>
 #include <Access/AccessControl.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
@@ -48,6 +49,8 @@
 #include <TableFunctions/registerTableFunctions.h>
 #include <base/argsToConfig.h>
 #include <base/getMemoryAmount.h>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <sys/resource.h>
 #include <Poco/Logger.h>
@@ -101,6 +104,7 @@ extern const SettingsBool allow_introspection_functions;
 extern const SettingsBool implicit_select;
 extern const SettingsLocalFSReadMethod storage_file_read_method;
 extern const SettingsBool output_format_arrow_use_native_writer;
+extern const SettingsMaxThreads max_threads;
 }
 
 namespace ServerSetting
@@ -195,6 +199,39 @@ extern const int FILE_ALREADY_EXISTS;
 extern const int UNKNOWN_FORMAT;
 }
 
+#if defined(OS_LINUX)
+/// Number of CPUs in the largest NUMA node, or 0 when the topology is unknown
+/// or there is a single node. Parses /sys cpulist files ("0-47,96-143").
+static size_t getMaxCPUsOfSingleNUMANode()
+{
+    size_t max_cpus = 0;
+    size_t num_nodes = 0;
+    for (size_t node = 0;; ++node)
+    {
+        std::ifstream f(fmt::format("/sys/devices/system/node/node{}/cpulist", node));
+        std::string line;
+        if (!f.is_open() || !std::getline(f, line) || line.empty())
+            break;
+        ++num_nodes;
+        size_t cpus = 0;
+        std::vector<std::string> ranges;
+        boost::split(ranges, line, boost::is_any_of(","));
+        for (auto & range : ranges)
+        {
+            boost::trim(range);
+            size_t lo = 0;
+            size_t hi = 0;
+            if (sscanf(range.c_str(), "%zu-%zu", &lo, &hi) == 2) // NOLINT(cert-err34-c)
+                cpus += hi - lo + 1;
+            else if (sscanf(range.c_str(), "%zu", &lo) == 1) // NOLINT(cert-err34-c)
+                cpus += 1;
+        }
+        max_cpus = std::max(max_cpus, cpus);
+    }
+    return num_nodes > 1 ? max_cpus : 0;
+}
+#endif
+
 static void applySettingsOverridesForLocal(ContextMutablePtr context)
 {
     Settings settings = context->getSettingsCopy();
@@ -206,6 +243,20 @@ static void applySettingsOverridesForLocal(ContextMutablePtr context)
     /// x86_64 cross-build (pyarrow reads zeros or garbage); default to the mature
     /// libarrow writer until that is root-caused. Users can still opt in.
     settings[Setting::output_format_arrow_use_native_writer] = false;
+
+#if defined(OS_LINUX)
+    /// On multi-socket machines a default of "one thread per core" backfires:
+    /// per-thread aggregation states multiply the merge work and the merge runs
+    /// across sockets (e.g. COUNT(DISTINCT) GROUP BY is ~5x slower with 192
+    /// threads than with 96 on a 2-socket EPYC, and clickhouse-local shows the
+    /// same). Upstream is shielded on SMT x86 where "physical cores" already
+    /// halves the count, but on no-SMT many-core CPUs the default lands on every
+    /// core of every socket. Cap the default at one NUMA node's core count;
+    /// explicit max_threads settings are untouched.
+    if (const size_t node_cpus = getMaxCPUsOfSingleNUMANode();
+        node_cpus > 0 && node_cpus < settings[Setting::max_threads])
+        settings[Setting::max_threads] = node_cpus;
+#endif
 
     context->setSettings(settings);
 }

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -63,6 +63,7 @@
 #include <Common/CurrentMetrics.h>
 #if USE_JEMALLOC
 #include <Common/Jemalloc.h>
+#include <Common/JemallocMergeTreeArena.h>
 #endif
 #include <Common/ErrorHandlers.h>
 #include <Common/EventNotifier.h>
@@ -164,6 +165,7 @@ extern const ServerSettingsUInt64 max_thread_pool_size;
 extern const ServerSettingsUInt64 max_unexpected_parts_loading_thread_pool_size;
 extern const ServerSettingsBool jemalloc_enable_background_threads;
 extern const ServerSettingsUInt64 jemalloc_max_background_threads_num;
+extern const ServerSettingsUInt64 jemalloc_merge_tree_arenas;
 extern const ServerSettingsUInt64 mmap_cache_size;
 extern const ServerSettingsBool show_addresses_in_stack_traces;
 extern const ServerSettingsUInt64 thread_pool_queue_size;
@@ -305,6 +307,11 @@ void EmbeddedServer::initialize(Poco::Util::Application & self)
     Jemalloc::setBackgroundThreads(server_settings[ServerSetting::jemalloc_enable_background_threads]);
     if (auto max_background_threads = server_settings[ServerSetting::jemalloc_max_background_threads_num])
         Jemalloc::setMaxBackgroundThreads(max_background_threads);
+
+    /// Create the dedicated MergeTree metadata arena pool before any parts are loaded, same as
+    /// clickhouse-server and clickhouse-local. Without this the `jemalloc_merge_tree_arenas`
+    /// server setting is silently ignored in the embedded server.
+    JemallocMergeTreeArena::initialize(server_settings[ServerSetting::jemalloc_merge_tree_arenas]);
 #endif
 
     GlobalThreadPool::initialize(

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -229,7 +229,7 @@ static size_t getLogicalCPUsIfMultiNUMA()
             boost::trim(range);
             size_t lo = 0;
             size_t hi = 0;
-            if (sscanf(range.c_str(), "%zu-%zu", &lo, &hi) == 2) // NOLINT(cert-err34-c)
+            if (sscanf(range.c_str(), "%zu-%zu", &lo, &hi) == 2 && hi >= lo) // NOLINT(cert-err34-c)
                 cpus += hi - lo + 1;
             else if (sscanf(range.c_str(), "%zu", &lo) == 1) // NOLINT(cert-err34-c)
                 cpus += 1;

--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -418,6 +418,16 @@ void PandasDataFrame::fillColumn(
         /// DatetimeArray, TimedeltaArray use asi8 to get int64 representation
         array = py::array(underlying_array.attr("asi8"));
     }
+    else if (py::hasattr(underlying_array, "_ndarray"))
+    {
+        /// NumpyExtensionArray (plain numpy-backed int/float/bool columns).
+        /// Its to_numpy() runs an O(n) isna() scan on every call even when it
+        /// returns the underlying buffer unchanged; with a wide DataFrame that
+        /// serial per-column scan dominated SELECT * queries (the columns are
+        /// resolved under the GIL before the parallel scan starts). _ndarray
+        /// is that same underlying buffer without the scan.
+        array = underlying_array.attr("_ndarray");
+    }
     else
     {
         array = underlying_array.attr("to_numpy")();

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -865,8 +865,8 @@ static void evalArrowPredSegment(
     /// Per-row calls pay the searcher setup on every short haystack, which
     /// makes the scan several times slower than one pass over the buffer.
     /// Hits are attributed to rows through the offsets; a hit straddling a
-    /// row boundary is not a match. Null rows are zero-length and can never
-    /// contain a non-empty needle, so validity needs no separate check.
+    /// row boundary is not a match, and a hit inside a null slot is discarded
+    /// via the validity bitmap (checked only on hits).
     if (predicate == PandasScan::StringPredicate::LikeContains && !needle.empty())
     {
         memset(out, 0, n);
@@ -885,7 +885,12 @@ static void evalArrowPredSegment(
                 break;
             if (pos + static_cast<OffsetT>(needle.size()) <= off[row + 1])
             {
-                out[row] = 1;
+                /// Null slots usually have zero extent, but the Arrow spec only
+                /// requires monotonic offsets: a null slot may span arbitrary
+                /// bytes that could contain the needle. Check validity on hit.
+                const size_t bit = bit_base + row;
+                if (!validity || (validity[bit >> 3] & (1u << (bit & 7))))
+                    out[row] = 1;
                 p = data + off[row + 1];
                 ++row;
             }

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -895,7 +895,13 @@ static void evalArrowPredSegment(
                 ++row;
             }
             else
-                p = hit + 1;
+            {
+                /// A later occurrence starting in this row ends even later and
+                /// cannot fit either; skip straight to the next row. This also
+                /// avoids quadratic re-scanning on repetitive data.
+                p = data + off[row + 1];
+                ++row;
+            }
         }
         return;
     }

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -860,6 +860,41 @@ static void evalArrowPredSegment(
     const UInt8 * validity = chunk.validity;
     const size_t bit_base = chunk.offset + local_start;
 
+    /// Contains with a non-empty needle: one SIMD substring search over the
+    /// segment's contiguous byte range instead of one sz_find call per row.
+    /// Per-row calls pay the searcher setup on every short haystack, which
+    /// makes the scan several times slower than one pass over the buffer.
+    /// Hits are attributed to rows through the offsets; a hit straddling a
+    /// row boundary is not a match. Null rows are zero-length and can never
+    /// contain a non-empty needle, so validity needs no separate check.
+    if (predicate == PandasScan::StringPredicate::LikeContains && !needle.empty())
+    {
+        memset(out, 0, n);
+        const char * const end = data + off[n];
+        const char * p = data + off[0];
+        size_t row = 0;
+        while (p < end)
+        {
+            const char * hit = sz_find(p, static_cast<size_t>(end - p), needle.data(), needle.size());
+            if (!hit)
+                break;
+            const auto pos = static_cast<OffsetT>(hit - data);
+            while (row < n && off[row + 1] <= pos)
+                ++row;
+            if (row >= n)
+                break;
+            if (pos + static_cast<OffsetT>(needle.size()) <= off[row + 1])
+            {
+                out[row] = 1;
+                p = data + off[row + 1];
+                ++row;
+            }
+            else
+                p = hit + 1;
+        }
+        return;
+    }
+
     for (size_t i = 0; i < n; ++i)
     {
         const bool is_valid = !validity || (validity[(bit_base + i) >> 3] & (1u << ((bit_base + i) & 7)));
@@ -876,9 +911,9 @@ static void evalArrowPredSegment(
                     r = len == 0;
                     break;
                 case PandasScan::StringPredicate::LikeContains:
-                    r = needle.empty()
-                        || (len >= needle.size()
-                            && sz_find(data + off[i], len, needle.data(), needle.size()) != nullptr);
+                    /// Only the empty-needle case reaches here: LIKE '%%'
+                    /// matches every non-null row.
+                    r = 1;
                     break;
             }
         }

--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -130,8 +130,12 @@ void freeImpl(void * buf)
 #if USE_JEMALLOC
     if (unlikely(buf == nullptr))
         return;
-    int arena_ind = je_mallctl("arenas.lookup", nullptr, nullptr, &buf, sizeof(buf));
-    if (unlikely(arena_ind != 0))
+    /// Distinguish foreign pointers (glibc-internal allocations that bypass
+    /// the interposed malloc) via the lock-free rtree probe. The previous
+    /// mallctl("arenas.lookup") took jemalloc's single global ctl mutex on
+    /// EVERY free, which convoys catastrophically on many-core machines
+    /// (~90% of cycles in the kernel futex path at 192 threads).
+    if (unlikely(je_vsallocx(buf, 0) == 0))
     {
         __real_free(buf);
         return;

--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -127,23 +127,17 @@ void * allocImpl(size_t size, size_t alignment)
 
 void freeImpl(void * buf)
 {
-#if USE_JEMALLOC
-    if (unlikely(buf == nullptr))
-        return;
-    /// Distinguish foreign pointers (glibc-internal allocations that bypass
-    /// the interposed malloc) via the lock-free rtree probe. The previous
-    /// mallctl("arenas.lookup") took jemalloc's single global ctl mutex on
-    /// EVERY free, which convoys catastrophically on many-core machines
-    /// (~90% of cycles in the kernel futex path at 192 threads).
-    if (unlikely(je_vsallocx(buf, 0) == 0))
-    {
-        __real_free(buf);
-        return;
-    }
-    je_free(buf);
-#else
+    /// No foreign-pointer probe: Allocator only frees memory it allocated
+    /// itself through __real_malloc & friends, and under jemalloc builds
+    /// __real_free IS je_free (AllocationInterceptors.h), so the old
+    /// mallctl("arenas.lookup") probe called je_free on both branches while
+    /// taking jemalloc's single global ctl mutex on every free — a pure
+    /// overhead that convoyed catastrophically on many-core machines (~90%
+    /// of cycles in the kernel futex path at 192 threads). Foreign pointers
+    /// (glibc-internal allocations bypassing the interposed malloc) are the
+    /// job of the free() interposer in malloc.cpp, which probes with the
+    /// lock-free je_vsallocx.
     __real_free(buf);
-#endif
 }
 
 void checkSize(size_t size)

--- a/tests/test_perf_fix_correctness.py
+++ b/tests/test_perf_fix_correctness.py
@@ -153,10 +153,13 @@ class TestPandasColumnResolution(unittest.TestCase):
         })
         globals()["_dtype_df"] = df
         self.addCleanup(globals().pop, "_dtype_df", None)
+        # toUnixTimestamp keeps the assertion independent of the pandas
+        # datetime64 unit (ns in pandas 2.x, us in 3.x -> DateTime64 scale).
         got = _csv(self.conn,
-                   "SELECT sum(i16), sum(u32), sum(f64), countIf(b), max(dt), "
-                   "sum(ni64), max(obj) FROM Python(_dtype_df)")
-        self.assertEqual(got, '2,6,4.5,2,"1970-01-01 00:00:03",4,"z"')
+                   "SELECT sum(i16), sum(u32), sum(f64), countIf(b), "
+                   "toUnixTimestamp(max(dt)), sum(ni64), max(obj) "
+                   "FROM Python(_dtype_df)")
+        self.assertEqual(got, '2,6,4.5,2,3,4,"z"')
 
     def test_wide_frame_row_integrity(self):
         # Row-aligned values across many plain numpy columns: any dtype or

--- a/tests/test_perf_fix_correctness.py
+++ b/tests/test_perf_fix_correctness.py
@@ -47,6 +47,7 @@ class TestArrowLikePredicate(unittest.TestCase):
         df = pd.DataFrame({"s": np.array(vals, dtype=object),
                            "t": np.arange(n, dtype=np.int64)})
         globals()["_like_df"] = df
+        self.addCleanup(globals().pop, "_like_df", None)
 
         truth = sum("google" in v for v in vals)
         base = "SELECT count() FROM (SELECT * FROM Python(_like_df) WHERE s LIKE '%google%')"
@@ -71,11 +72,11 @@ class TestArrowLikePredicate(unittest.TestCase):
         offsets = pa.py_buffer(np.array([0, 19, 31, 44], dtype=np.int32).tobytes())
         validity = pa.py_buffer(bytes([0b101]))  # rows 0,2 valid; row 1 null
         arr = pa.Array.from_buffers(pa.utf8(), 3, [validity, offsets, pa.py_buffer(values)])
-        from pandas.core.arrays.string_arrow import ArrowStringArray
 
-        df = pd.DataFrame({"URL": ArrowStringArray(pa.chunked_array([arr])),
+        df = pd.DataFrame({"URL": pd.arrays.ArrowStringArray(pa.chunked_array([arr])),
                            "x": np.arange(3, dtype=np.int64)})
         globals()["_null_slot_df"] = df
+        self.addCleanup(globals().pop, "_null_slot_df", None)
 
         self.assertEqual(
             _csv(self.conn, "SELECT count() FROM (SELECT * FROM Python(_null_slot_df) "
@@ -86,10 +87,43 @@ class TestArrowLikePredicate(unittest.TestCase):
                             "WHERE URL LIKE '%google%')"),
             "0")
 
+    def test_sliced_and_multichunk_arrays(self):
+        # Non-zero chunk offsets and multi-chunk layouts stress the validity
+        # bit indexing (bit_base = chunk.offset + local_start) and per-chunk
+        # hit attribution of the buffer-wide scan.
+        vals1 = ["google one", None, "nope", "a google b", "xx"] * 40
+        vals2 = [None, "google tail", "yy", None] * 25
+        arr1 = pa.array(vals1, type=pa.utf8())
+        arr2 = pa.array(vals2, type=pa.utf8())
+        truth = sum(1 for v in vals1 + vals2 if v is not None and "google" in v)
+
+        multi = pd.DataFrame({
+            "s": pd.arrays.ArrowStringArray(pa.chunked_array([arr1, arr2])),
+        })
+        globals()["_multi_df"] = multi
+        self.addCleanup(globals().pop, "_multi_df", None)
+        self.assertEqual(
+            int(_csv(self.conn, "SELECT count() FROM (SELECT * FROM Python(_multi_df) "
+                                "WHERE s LIKE '%google%')")),
+            truth)
+
+        k = 7  # slice off a non-multiple-of-8 prefix so validity bits shift
+        sliced = pd.DataFrame({
+            "s": pd.arrays.ArrowStringArray(pa.chunked_array([arr1.slice(k)])),
+        })
+        globals()["_sliced_df"] = sliced
+        self.addCleanup(globals().pop, "_sliced_df", None)
+        truth_sliced = sum(1 for v in vals1[k:] if v is not None and "google" in v)
+        self.assertEqual(
+            int(_csv(self.conn, "SELECT count() FROM (SELECT * FROM Python(_sliced_df) "
+                                "WHERE s LIKE '%google%')")),
+            truth_sliced)
+
     def test_empty_needle_matches_every_valid_row(self):
         df = pd.DataFrame({"s": pd.array(["a", None, "", "b"], dtype="string[pyarrow]"),
                            "x": np.arange(4, dtype=np.int64)})
         globals()["_empty_needle_df"] = df
+        self.addCleanup(globals().pop, "_empty_needle_df", None)
         self.assertEqual(
             _csv(self.conn, "SELECT count() FROM (SELECT * FROM Python(_empty_needle_df) "
                             "WHERE s LIKE '%%')"),
@@ -118,6 +152,7 @@ class TestPandasColumnResolution(unittest.TestCase):
             "obj": np.array(["x", "y", "z"], dtype=object),
         })
         globals()["_dtype_df"] = df
+        self.addCleanup(globals().pop, "_dtype_df", None)
         got = _csv(self.conn,
                    "SELECT sum(i16), sum(u32), sum(f64), countIf(b), max(dt), "
                    "sum(ni64), max(obj) FROM Python(_dtype_df)")
@@ -131,6 +166,7 @@ class TestPandasColumnResolution(unittest.TestCase):
         data = {f"c{i}": rng.integers(0, 1_000_000, n) for i in range(40)}
         df = pd.DataFrame(data)
         globals()["_wide_df"] = df
+        self.addCleanup(globals().pop, "_wide_df", None)
         expr = " + ".join(f"sum(c{i})" for i in range(40))
         got = int(_csv(self.conn, f"SELECT {expr} FROM Python(_wide_df)"))
         self.assertEqual(got, int(sum(df[c].sum() for c in df.columns)))

--- a/tests/test_perf_fix_correctness.py
+++ b/tests/test_perf_fix_correctness.py
@@ -1,0 +1,160 @@
+#!python3
+
+"""Correctness tests for the many-core / DataFrame-scan performance fixes.
+
+Covers:
+- the buffer-wide arrow LIKE-contains predicate (PandasScan::evalArrowPredSegment):
+  row attribution, needle straddling a row boundary, hits inside null slots
+  (Arrow permits non-zero-extent null slots), empty-needle edge case, and
+  agreement with the generic non-PREWHERE execution path;
+- pandas column resolution through NumpyExtensionArray._ndarray (fillColumn):
+  the numeric/bool/datetime/nullable dtype matrix against pandas ground truth;
+- the multi-NUMA default max_threads cap: the adjusted default is not marked
+  as an explicitly-changed setting, and explicit user values are honoured.
+"""
+
+import unittest
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import chdb
+
+
+def _csv(conn, query):
+    return str(conn.query(query, "CSV")).strip()
+
+
+class TestArrowLikePredicate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.conn = chdb.connect(":memory:")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
+
+    def test_contains_matches_generic_path_and_python_truth(self):
+        # Adversarial layout: needle fragments, straddle candidates, empties,
+        # multi-hit rows, needles at row starts/ends.
+        frags = ["goo", "gle", "google", "gogole", "ggoogle", "xgooglex", "",
+                 "g", "googl", "oogle", "a google b google c", "GOOGLE",
+                 "http://google.com", "ends with goo", "gle starts"]
+        n = 100_000
+        vals = [frags[i % len(frags)] + ("!" if i % 7 == 0 else "") for i in range(n)]
+        rng = np.random.default_rng(42)
+        for i in rng.integers(0, n, 2000):
+            vals[i] = "".join(rng.choice(list("gogle!"), size=rng.integers(0, 12)))
+        df = pd.DataFrame({"s": np.array(vals, dtype=object),
+                           "t": np.arange(n, dtype=np.int64)})
+        globals()["_like_df"] = df
+
+        truth = sum("google" in v for v in vals)
+        base = "SELECT count() FROM (SELECT * FROM Python(_like_df) WHERE s LIKE '%google%')"
+        got_prewhere = int(_csv(self.conn, base))
+        got_generic = int(_csv(self.conn, base + " SETTINGS optimize_move_to_prewhere=0"))
+        self.assertEqual(got_prewhere, truth)
+        self.assertEqual(got_generic, truth)
+
+        # Same top-N rows on both paths (deterministic tie-break via s).
+        topn = ("SELECT s, t FROM (SELECT * FROM Python(_like_df) "
+                "WHERE s LIKE '%google%' ORDER BY t, s LIMIT 10)")
+        self.assertEqual(
+            str(self.conn.query(topn, "CSV")),
+            str(self.conn.query(topn + " SETTINGS optimize_move_to_prewhere=0", "CSV")),
+        )
+
+    def test_hit_inside_nonzero_extent_null_slot_is_discarded(self):
+        # The Arrow spec only requires monotonic offsets: a null slot may span
+        # bytes, and those bytes may contain the needle. Build such an array
+        # by hand; the null row must not leak through the LIKE filter.
+        values = b"http://google.com/xAAAgoogleBBBhttp://ok.io!"
+        offsets = pa.py_buffer(np.array([0, 19, 31, 44], dtype=np.int32).tobytes())
+        validity = pa.py_buffer(bytes([0b101]))  # rows 0,2 valid; row 1 null
+        arr = pa.Array.from_buffers(pa.utf8(), 3, [validity, offsets, pa.py_buffer(values)])
+        from pandas.core.arrays.string_arrow import ArrowStringArray
+
+        df = pd.DataFrame({"URL": ArrowStringArray(pa.chunked_array([arr])),
+                           "x": np.arange(3, dtype=np.int64)})
+        globals()["_null_slot_df"] = df
+
+        self.assertEqual(
+            _csv(self.conn, "SELECT count() FROM (SELECT * FROM Python(_null_slot_df) "
+                            "WHERE URL LIKE '%google%')"),
+            "1")
+        self.assertEqual(
+            _csv(self.conn, "SELECT x FROM (SELECT * FROM Python(_null_slot_df) "
+                            "WHERE URL LIKE '%google%')"),
+            "0")
+
+    def test_empty_needle_matches_every_valid_row(self):
+        df = pd.DataFrame({"s": pd.array(["a", None, "", "b"], dtype="string[pyarrow]"),
+                           "x": np.arange(4, dtype=np.int64)})
+        globals()["_empty_needle_df"] = df
+        self.assertEqual(
+            _csv(self.conn, "SELECT count() FROM (SELECT * FROM Python(_empty_needle_df) "
+                            "WHERE s LIKE '%%')"),
+            "3")
+
+
+class TestPandasColumnResolution(unittest.TestCase):
+    """The _ndarray fast path must yield the same values as pandas."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.conn = chdb.connect(":memory:")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
+
+    def test_dtype_matrix_against_pandas_ground_truth(self):
+        df = pd.DataFrame({
+            "i16": np.array([1, -2, 3], dtype=np.int16),
+            "u32": np.array([1, 2, 3], dtype=np.uint32),
+            "f64": np.array([1.5, np.nan, 3.0]),
+            "b": np.array([True, False, True]),
+            "dt": pd.to_datetime([1, 2, 3], unit="s"),
+            "ni64": pd.array([1, None, 3], dtype="Int64"),
+            "obj": np.array(["x", "y", "z"], dtype=object),
+        })
+        globals()["_dtype_df"] = df
+        got = _csv(self.conn,
+                   "SELECT sum(i16), sum(u32), sum(f64), countIf(b), max(dt), "
+                   "sum(ni64), max(obj) FROM Python(_dtype_df)")
+        self.assertEqual(got, '2,6,4.5,2,"1970-01-01 00:00:03",4,"z"')
+
+    def test_wide_frame_row_integrity(self):
+        # Row-aligned values across many plain numpy columns: any dtype or
+        # buffer mixup in column resolution shows up as a checksum mismatch.
+        n = 50_000
+        rng = np.random.default_rng(7)
+        data = {f"c{i}": rng.integers(0, 1_000_000, n) for i in range(40)}
+        df = pd.DataFrame(data)
+        globals()["_wide_df"] = df
+        expr = " + ".join(f"sum(c{i})" for i in range(40))
+        got = int(_csv(self.conn, f"SELECT {expr} FROM Python(_wide_df)"))
+        self.assertEqual(got, int(sum(df[c].sum() for c in df.columns)))
+
+
+class TestMaxThreadsDefault(unittest.TestCase):
+    def test_default_is_not_marked_changed_and_override_works(self):
+        conn = chdb.connect(":memory:")
+        try:
+            value, changed = _csv(
+                conn, "SELECT value, changed FROM system.settings "
+                      "WHERE name='max_threads'").rsplit(",", 1)
+            # The (possibly NUMA-capped) default must not masquerade as an
+            # explicitly-set value: it would otherwise propagate to remote
+            # servers in distributed queries.
+            self.assertEqual(changed, "0")
+            self.assertNotEqual(value, "")
+            # Explicit per-query values are always honoured.
+            self.assertEqual(
+                _csv(conn, "SELECT sum(number) FROM numbers(100) SETTINGS max_threads=3"),
+                "4950")
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Performance fixes distilled from the ClickBench many-core investigation (benchmark vehicle: #182). Each was root-caused with on-machine profiling and validated by same-instance A/B runs on c6a.metal, c7a.metal-48xl, c8g.metal-24xl and c8g.metal-48xl.

## Fixes

**Allocator: remove the per-free ownership probe** — `freeImpl` called `je_mallctl("arenas.lookup")` on every deallocation, serializing all frees on jemalloc's single process-global ctl mutex. On a 192-core machine ~90% of cycles during mid-size GROUP BY queries were spent in the kernel futex path. The probe was also provably dead code: under jemalloc builds `__real_free` *is* `je_free`, so both branches freed identically. Allocator only frees memory it allocated itself; foreign pointers remain the job of the `free()` interposer in malloc.cpp (which keeps its lock-free `je_vsallocx` probe).

**Default max_threads on multi-NUMA machines** — cap the *default* at half the logical CPUs when more than one NUMA node carries CPUs. With a thread per core across sockets, per-thread aggregation states multiply the merge work (COUNT(DISTINCT) GROUP BY is ~5x slower at 192 threads than at 96 on a 2-socket EPYC; official clickhouse-local shows the same). SMT x86 machines are already shielded by the physical-cores default and are unchanged; explicit user settings are always honoured; the adjusted default is not marked `changed`, so it does not propagate to remote servers in distributed queries.

**EmbeddedServer: initialize the MergeTree metadata arena pool** — clickhouse-server and clickhouse-local both call `JemallocMergeTreeArena::initialize` at startup; the embedded server never did, silently ignoring `jemalloc_merge_tree_arenas`.

**Arrow LIKE-contains predicate: one buffer-wide search** — the PREWHERE fast path called `sz_find` once per row, paying the searcher setup on every short haystack. Arrow string segments are contiguous bytes plus offsets, so run one SIMD substring search across the segment and attribute hits to rows through the offsets. Hits straddling a row boundary are rejected; hits inside null slots (Arrow permits non-zero-extent null slots) are discarded via the validity bitmap.

**Pandas column resolution via `_ndarray`** — pandas 3.x `NumpyExtensionArray.to_numpy()` runs an O(n) `isna()` scan on every call even when it returns the underlying buffer unchanged. Columns are resolved under the GIL before the parallel scan starts, so on a 105-column 100M-row frame this serial scan burned ~0.5s per `SELECT *` query. `_ndarray` is the same buffer without the scan.

**Enable the embedded compiler on linux aarch64** — it was off, which silently disabled the regexp JIT and compiled expressions on ARM; official ClickHouse aarch64 builds enable it. ClickBench Q28 (REGEXP_REPLACE over 100M rows) drops from ~1s to match the x86 equivalent on Graviton4.

## Results (ClickBench DataFrame track, hot sum, official harness)

| machine | before | after | polars (official master) |
|---|---|---|---|
| c7a.metal-48xl | 8.5s | **3.6s** | 4.90s |
| c6a.metal | — | **6.0s** | 12.21s |
| c8g.metal-24xl | 7.1s | **4.4s** | n/a (same-instance run: 4.36s) |
| c8g.metal-48xl | — | **3.3s** | 4.83s |

Native suite on c7a reaches 3.9s, matching official clickhouse-local 26.8 (~3.96s) on the same instance.

Correctness: adversarial review of every change (LIKE row attribution/straddling/null slots, dtype matrix through `_ndarray`, settings override semantics, allocator routing), plus new unit tests in `tests/test_perf_fix_correctness.py`, and a 50M-row ClickBench result diff against chdb-core 26.5.0 across the native and DataFrame tracks.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix many-core scaling and speed up DataFrame scans
> - On Linux multi-NUMA systems, caps the default `max_threads` to `logical_cpus/2` when not explicitly set, preventing over-subscription on many-core machines ([EmbeddedServer.cpp](https://github.com/chdb-io/chdb-core/pull/183/files#diff-b40e2cd65195a45a5e28818eb8a4abb4f0b06a149aad063577c767414136191b)).
> - Adds a SIMD fast path in `evalArrowPredSegment` for `LIKE '%needle%'` filtering on Arrow string columns, scanning the full buffer once instead of per-row ([PandasScan.cpp](https://github.com/chdb-io/chdb-core/pull/183/files#diff-34dee88935feb430810bb7c69f6af0a9c72cc2441c420d058d4826ea04e64b58)).
> - Skips the `O(n)` `isna()` scan in `fillColumn` for numpy-backed pandas columns by accessing `_ndarray` directly ([PandasDataFrame.cpp](https://github.com/chdb-io/chdb-core/pull/183/files#diff-a8ffa72d6f6751acb3a9bd819ef603ed01cdf902d2f4a92aa566114763d75f56)).
> - Removes the jemalloc `arenas.lookup` mutex probe from `Allocator::freeImpl`, delegating foreign-pointer detection to the `free()` interposer ([Allocator.cpp](https://github.com/chdb-io/chdb-core/pull/183/files#diff-b8794184b9a8bf73ed32d92cbfde967646c007190d6bdf1ac4f901fe6184ce78)).
> - Behavioral Change: default `max_threads` is now silently halved on multi-NUMA Linux hosts when not explicitly configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9870c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->