### PR TITLE
Add chdb_shutdown() to stop the engine's thread pools

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -302,6 +302,7 @@ jobs:
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
+          bash -x ./examples/runShutdownTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -287,6 +287,7 @@ jobs:
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
+          bash -x ./examples/runShutdownTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -325,6 +325,7 @@ jobs:
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
+          bash -x ./examples/runShutdownTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -326,6 +326,7 @@ jobs:
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
+          bash -x ./examples/runShutdownTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.gitignore
+++ b/.gitignore
@@ -283,6 +283,7 @@ test_main
 /examples/chdbStreamErrorTest
 /examples/chdbStreamInsertTest
 /examples/chdbStreamQueryEofTest
+/examples/chdbShutdownTest
 libchdb.so
 *.gz
 *.bz2

--- a/chdb/build/go-example/chdb_go_example.go
+++ b/chdb/build/go-example/chdb_go_example.go
@@ -341,5 +341,16 @@ func main() {
 		result.Destroy()
 	}
 
+	// Stop the engine while the Go runtime is still intact. Without this, chDB's
+	// thread pools keep running into the runtime's own exit sequence, and a pool
+	// thread waking up there is a signal delivered on a thread Go does not own.
+	// Close() is idempotent, so the deferred call above turns into a no-op.
+	conn.Close()
+	if C.chdb_shutdown() != C.CHDBSuccess {
+		fmt.Println("❌ chdb_shutdown() failed")
+		os.Exit(1)
+	}
+	fmt.Println("\n✓ Engine shut down")
+
 	fmt.Println("\n=== All examples completed successfully! ===")
 }

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -75,6 +75,9 @@
         chdb_set_signal_handlers_enabled;
         chdb_reset_signal_handlers;
 
+        /* Engine Shutdown */
+        chdb_shutdown;
+
     local:
         *;
 };

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -65,3 +65,5 @@ _AdbcDriverInit
 
 _chdb_set_signal_handlers_enabled
 _chdb_reset_signal_handlers
+
+_chdb_shutdown

--- a/examples/chdbShutdownTest.c
+++ b/examples/chdbShutdownTest.c
@@ -13,6 +13,10 @@
  *   3. Once the last connection is closed, chdb_shutdown() succeeds and zero
  *      engine threads remain.
  *   4. A second chdb_shutdown() is a successful no-op.
+ *   5. Concurrent chdb_shutdown() calls are serialized: every one of them reports
+ *      success, exactly one does the joining, and none of them crashes.
+ *   6. chdb_connect() after a shutdown fails instead of handing back a connection
+ *      on a dead engine.
  *
  * Build (against an already-built libchdb.so):
  *   clang examples/chdbShutdownTest.c -I./programs/local \
@@ -26,9 +30,10 @@
 
 #include "chdb.h"
 
+#include <pthread.h>
+
 #if defined(__APPLE__)
 #    include <mach/mach.h>
-#    include <pthread.h>
 #else
 #    include <dirent.h>
 #endif
@@ -125,6 +130,13 @@ static void report(const char * tag)
     printf("  %-24s pool threads: %d, total threads: %d\n", tag, pool, total);
 }
 
+/* Calls chdb_shutdown() and reports the state through the thread's argument. */
+static void * shutdown_thread(void * arg)
+{
+    *(chdb_state *)arg = chdb_shutdown();
+    return NULL;
+}
+
 int main(void)
 {
     char * argv[] = {(char *)"chdb", (char *)"--path=:memory:", NULL};
@@ -185,6 +197,33 @@ int main(void)
     state = chdb_shutdown();
     CHECK(state == CHDBSuccess, "a second chdb_shutdown is a successful no-op");
     CHECK(count_pool_threads(&total) == 0, "still no engine thread after the second call");
+
+    /* 5. Concurrent callers are serialized rather than all joining. */
+    {
+        enum { RACERS = 4 };
+        pthread_t racers[RACERS];
+        chdb_state states[RACERS];
+        int i;
+
+        for (i = 0; i < RACERS; ++i) {
+            states[i] = CHDBError;
+            if (pthread_create(&racers[i], NULL, shutdown_thread, &states[i]) != 0) {
+                CHECK(0, "pthread_create for the concurrent shutdown case");
+                break;
+            }
+        }
+        for (--i; i >= 0; --i) {
+            pthread_join(racers[i], NULL);
+            CHECK(states[i] == CHDBSuccess, "every concurrent chdb_shutdown reports success");
+        }
+        CHECK(count_pool_threads(&total) == 0, "no engine thread after concurrent shutdowns");
+    }
+
+    /* 6. The engine stays closed. */
+    conn = chdb_connect(2, argv);
+    CHECK(conn == NULL, "chdb_connect fails once the engine is shut down");
+    if (conn)
+        chdb_close_conn(conn);
 
     if (g_failed_assertions == 0) {
         printf("PASS\n");

--- a/examples/chdbShutdownTest.c
+++ b/examples/chdbShutdownTest.c
@@ -1,0 +1,195 @@
+/**
+ * chdbShutdownTest.c
+ *
+ * chdb_shutdown() contract: once it returns, chDB has no thread of its own left
+ * running, so a host is free to run its own exit sequence (global destructors, a
+ * finalizing runtime, a sanitizer exit handler) without racing the engine.
+ *
+ * Verifies:
+ *   1. A query starts engine thread-pool threads, and they are still running
+ *      after every connection is closed — closing connections is not a shutdown.
+ *   2. chdb_shutdown() refuses to run while a connection is still open, and
+ *      leaves the engine untouched when it refuses.
+ *   3. Once the last connection is closed, chdb_shutdown() succeeds and zero
+ *      engine threads remain.
+ *   4. A second chdb_shutdown() is a successful no-op.
+ *
+ * Build (against an already-built libchdb.so):
+ *   clang examples/chdbShutdownTest.c -I./programs/local \
+ *         -L. -lchdb -o examples/chdbShutdownTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbShutdownTest
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chdb.h"
+
+#if defined(__APPLE__)
+#    include <mach/mach.h>
+#    include <pthread.h>
+#else
+#    include <dirent.h>
+#endif
+
+/* Name every thread of a ClickHouse thread pool carries while idle. */
+#define POOL_THREAD_NAME "ThreadPool"
+
+static int g_failed_assertions = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "  ASSERT FAIL: %s (%s:%d)\n",                 \
+                    (msg), __FILE__, __LINE__);                            \
+            g_failed_assertions += 1;                                      \
+        }                                                                  \
+    } while (0)
+
+/* Number of live threads named POOL_THREAD_NAME. Out-params report the total
+ * thread count so a failure says how far off the process is. */
+#if defined(__APPLE__)
+static int count_pool_threads(int * total_out)
+{
+    thread_act_array_t threads;
+    mach_msg_type_number_t count = 0;
+    int pool = 0;
+
+    if (task_threads(mach_task_self(), &threads, &count) != KERN_SUCCESS) {
+        fprintf(stderr, "  task_threads() failed\n");
+        *total_out = -1;
+        return -1;
+    }
+
+    for (mach_msg_type_number_t i = 0; i < count; ++i) {
+        pthread_t handle = pthread_from_mach_thread_np(threads[i]);
+        char name[64] = "";
+        if (handle && pthread_getname_np(handle, name, sizeof(name)) == 0
+            && strcmp(name, POOL_THREAD_NAME) == 0)
+            pool += 1;
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
+    vm_deallocate(mach_task_self(), (vm_address_t)threads, count * sizeof(thread_t));
+
+    *total_out = (int)count;
+    return pool;
+}
+#else
+static int count_pool_threads(int * total_out)
+{
+    DIR * dir = opendir("/proc/self/task");
+    struct dirent * entry;
+    int pool = 0;
+    int total = 0;
+
+    if (!dir) {
+        fprintf(stderr, "  cannot open /proc/self/task\n");
+        *total_out = -1;
+        return -1;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        char path[320];
+        char name[64] = "";
+        FILE * comm;
+
+        if (entry->d_name[0] == '.')
+            continue;
+        total += 1;
+
+        snprintf(path, sizeof(path), "/proc/self/task/%s/comm", entry->d_name);
+        comm = fopen(path, "r");
+        if (!comm)
+            continue;
+        if (fgets(name, sizeof(name), comm)) {
+            char * newline = strchr(name, '\n');
+            if (newline)
+                *newline = '\0';
+            if (strcmp(name, POOL_THREAD_NAME) == 0)
+                pool += 1;
+        }
+        fclose(comm);
+    }
+    closedir(dir);
+
+    *total_out = total;
+    return pool;
+}
+#endif
+
+static void report(const char * tag)
+{
+    int total = 0;
+    int pool = count_pool_threads(&total);
+    printf("  %-24s pool threads: %d, total threads: %d\n", tag, pool, total);
+}
+
+int main(void)
+{
+    char * argv[] = {(char *)"chdb", (char *)"--path=:memory:", NULL};
+    chdb_connection * conn = NULL;
+    chdb_result * res = NULL;
+    const char * err = NULL;
+    int pool_after_query = 0;
+    int pool_after_close = 0;
+    int pool_after_shutdown = 0;
+    int total = 0;
+    chdb_state state;
+
+    printf("=== chdb_shutdown() ===\n");
+    report("before connect");
+
+    conn = chdb_connect(2, argv);
+    CHECK(conn != NULL, "chdb_connect succeeds");
+    if (!conn)
+        return 1;
+
+    res = chdb_query(*conn, "SELECT count() FROM numbers(1000000)", "CSV");
+    err = chdb_result_error(res);
+    CHECK(err == NULL, "query succeeds");
+    if (err)
+        fprintf(stderr, "  query error: %s\n", err);
+    chdb_destroy_query_result(res);
+
+    pool_after_query = count_pool_threads(&total);
+    report("after query");
+    CHECK(pool_after_query > 0, "a query starts engine thread-pool threads");
+
+    /* 2. Refuses to run while a connection is open, and changes nothing. */
+    state = chdb_shutdown();
+    CHECK(state == CHDBError, "chdb_shutdown fails while a connection is open");
+    report("after refused shutdown");
+    CHECK(count_pool_threads(&total) == pool_after_query,
+          "a refused chdb_shutdown leaves the engine threads running");
+
+    /* The connection still works after the refusal. */
+    res = chdb_query(*conn, "SELECT 1", "CSV");
+    CHECK(chdb_result_error(res) == NULL, "connection still usable after a refused shutdown");
+    chdb_destroy_query_result(res);
+
+    /* 1. Closing every connection is not a shutdown. */
+    chdb_close_conn(conn);
+    pool_after_close = count_pool_threads(&total);
+    report("after close_conn");
+    CHECK(pool_after_close > 0, "closing every connection leaves the engine threads running");
+
+    /* 3. Now it stops the engine. */
+    state = chdb_shutdown();
+    CHECK(state == CHDBSuccess, "chdb_shutdown succeeds once no connection is open");
+    pool_after_shutdown = count_pool_threads(&total);
+    report("after chdb_shutdown");
+    CHECK(pool_after_shutdown == 0, "no engine thread survives chdb_shutdown");
+
+    /* 4. Idempotent. */
+    state = chdb_shutdown();
+    CHECK(state == CHDBSuccess, "a second chdb_shutdown is a successful no-op");
+    CHECK(count_pool_threads(&total) == 0, "still no engine thread after the second call");
+
+    if (g_failed_assertions == 0) {
+        printf("PASS\n");
+        return 0;
+    }
+    fprintf(stderr, "FAIL: %d assertion(s)\n", g_failed_assertions);
+    return 1;
+}

--- a/examples/chdbShutdownTest.c
+++ b/examples/chdbShutdownTest.c
@@ -10,12 +10,11 @@
  *      after every connection is closed — closing connections is not a shutdown.
  *   2. chdb_shutdown() refuses to run while a connection is still open, and
  *      leaves the engine untouched when it refuses.
- *   3. Once the last connection is closed, chdb_shutdown() succeeds and zero
- *      engine threads remain.
- *   4. A second chdb_shutdown() is a successful no-op.
- *   5. Concurrent chdb_shutdown() calls are serialized: every one of them reports
- *      success, exactly one does the joining, and none of them crashes.
- *   6. chdb_connect() after a shutdown fails instead of handing back a connection
+ *   3. Once the last connection is closed chdb_shutdown() succeeds and zero engine
+ *      threads remain — raced by several threads at once, because the one real
+ *      transition a process gets is the only chance to exercise the contention.
+ *   4. A further chdb_shutdown() is a successful no-op.
+ *   5. chdb_connect() after a shutdown fails instead of handing back a connection
  *      on a dead engine.
  *
  * Build (against an already-built libchdb.so):
@@ -52,8 +51,11 @@ static int g_failed_assertions = 0;
         }                                                                  \
     } while (0)
 
-/* Number of live threads named POOL_THREAD_NAME. Out-params report the total
- * thread count so a failure says how far off the process is. */
+/* Number of live threads named POOL_THREAD_NAME — the assertions are on this.
+ * The out-param reports the process-wide thread count so a failure says how far
+ * off the process is; it is not asserted on, because it also counts this test's
+ * own threads, and a joined pthread can still be visible for a moment while it
+ * finishes exiting. */
 #if defined(__APPLE__)
 static int count_pool_threads(int * total_out)
 {
@@ -186,40 +188,40 @@ int main(void)
     report("after close_conn");
     CHECK(pool_after_close > 0, "closing every connection leaves the engine threads running");
 
-    /* 3. Now it stops the engine. */
-    state = chdb_shutdown();
-    CHECK(state == CHDBSuccess, "chdb_shutdown succeeds once no connection is open");
+    /* 3. Now it stops the engine — and the only real transition this process gets
+     * is the one being raced, so the racers actually contend for beginShutdown()
+     * and the joins rather than returning through the already-stopped fast path. */
+    {
+        enum { RACERS = 4 };
+        pthread_t racers[RACERS];
+        chdb_state states[RACERS];
+        int started = 0;
+        int i;
+
+        for (i = 0; i < RACERS; ++i) {
+            states[i] = CHDBError;
+            if (pthread_create(&racers[i], NULL, shutdown_thread, &states[i]) != 0) {
+                CHECK(0, "pthread_create for the concurrent shutdown");
+                break;
+            }
+            started += 1;
+        }
+        for (i = 0; i < started; ++i) {
+            pthread_join(racers[i], NULL);
+            CHECK(states[i] == CHDBSuccess, "every concurrent chdb_shutdown reports success");
+        }
+        CHECK(started == RACERS, "all racers started");
+    }
     pool_after_shutdown = count_pool_threads(&total);
     report("after chdb_shutdown");
     CHECK(pool_after_shutdown == 0, "no engine thread survives chdb_shutdown");
 
     /* 4. Idempotent. */
     state = chdb_shutdown();
-    CHECK(state == CHDBSuccess, "a second chdb_shutdown is a successful no-op");
-    CHECK(count_pool_threads(&total) == 0, "still no engine thread after the second call");
+    CHECK(state == CHDBSuccess, "a further chdb_shutdown is a successful no-op");
+    CHECK(count_pool_threads(&total) == 0, "still no engine thread after the further call");
 
-    /* 5. Concurrent callers are serialized rather than all joining. */
-    {
-        enum { RACERS = 4 };
-        pthread_t racers[RACERS];
-        chdb_state states[RACERS];
-        int i;
-
-        for (i = 0; i < RACERS; ++i) {
-            states[i] = CHDBError;
-            if (pthread_create(&racers[i], NULL, shutdown_thread, &states[i]) != 0) {
-                CHECK(0, "pthread_create for the concurrent shutdown case");
-                break;
-            }
-        }
-        for (--i; i >= 0; --i) {
-            pthread_join(racers[i], NULL);
-            CHECK(states[i] == CHDBSuccess, "every concurrent chdb_shutdown reports success");
-        }
-        CHECK(count_pool_threads(&total) == 0, "no engine thread after concurrent shutdowns");
-    }
-
-    /* 6. The engine stays closed. */
+    /* 5. The engine stays closed. */
     conn = chdb_connect(2, argv);
     CHECK(conn == NULL, "chdb_connect fails once the engine is shut down");
     if (conn)

--- a/examples/runShutdownTest.sh
+++ b/examples/runShutdownTest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Compile and link"
+clang chdbShutdownTest.c -o chdbShutdownTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbShutdownTest
+
+echo "Run it:"
+./chdbShutdownTest

--- a/examples/runShutdownTest.sh
+++ b/examples/runShutdownTest.sh
@@ -19,7 +19,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 
 echo "Compile and link"
-clang chdbShutdownTest.c -o chdbShutdownTest -I../programs/local/ -L../ -lchdb
+clang chdbShutdownTest.c -o chdbShutdownTest -I../programs/local/ -L../ -lchdb -lpthread
 
 export ${LIB_PATH}=..
 ${LDD} chdbShutdownTest

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -1183,10 +1183,18 @@ void EmbeddedServer::applyCmdOptions(ContextMutablePtr context)
 std::unique_ptr<EmbeddedServer> EmbeddedServer::global_instance;
 std::mutex EmbeddedServer::instance_mutex;
 size_t EmbeddedServer::client_ref_count = 0;
+bool EmbeddedServer::engine_stopped = false;
 
 EmbeddedServer & EmbeddedServer::getInstance(int argc, char ** argv)
 {
     std::lock_guard<std::mutex> lock(instance_mutex);
+
+    /// The pools this instance needs have been joined and cannot be rebuilt, so a
+    /// new client would run on a dead engine. Refusing here is also what makes the
+    /// shutdown refusal contract hold under a concurrent connect: whichever of the
+    /// two takes this lock first, the other sees a decided state.
+    if (engine_stopped)
+        throw DB::Exception(ErrorCodes::BAD_ARGUMENTS, "chDB has been shut down and cannot be used again in this process");
 
     if (global_instance)
     {
@@ -1251,11 +1259,15 @@ void EmbeddedServer::releaseInstance()
     }
 }
 
-bool EmbeddedServer::hasActiveClients()
+bool EmbeddedServer::beginShutdown()
 {
     std::lock_guard<std::mutex> lock(instance_mutex);
 
-    return client_ref_count != 0;
+    if (client_ref_count != 0)
+        return false;
+
+    engine_stopped = true;
+    return true;
 }
 
 void EmbeddedServer::initializeWithArgs(int argc, char ** argv)

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -1251,6 +1251,13 @@ void EmbeddedServer::releaseInstance()
     }
 }
 
+bool EmbeddedServer::hasActiveClients()
+{
+    std::lock_guard<std::mutex> lock(instance_mutex);
+
+    return client_ref_count != 0;
+}
+
 void EmbeddedServer::initializeWithArgs(int argc, char ** argv)
 {
     db_path = ":memory:"; // Default path

--- a/programs/local/EmbeddedServer.h
+++ b/programs/local/EmbeddedServer.h
@@ -44,6 +44,10 @@ public:
 
     static void releaseInstance();
 
+    /// True while at least one client still holds the instance, i.e. the engine
+    /// is in use and must not be torn down.
+    static bool hasActiveClients();
+
     std::string getPath() const { return db_path; }
 
 private:

--- a/programs/local/EmbeddedServer.h
+++ b/programs/local/EmbeddedServer.h
@@ -44,9 +44,11 @@ public:
 
     static void releaseInstance();
 
-    /// True while at least one client still holds the instance, i.e. the engine
-    /// is in use and must not be torn down.
-    static bool hasActiveClients();
+    /// Claims the engine for teardown: succeeds only when no client holds the
+    /// instance, and then refuses every later getInstance() for the lifetime of
+    /// the process. Deciding and claiming under one lock is what keeps a
+    /// concurrent connect from slipping in behind the check.
+    static bool beginShutdown();
 
     std::string getPath() const { return db_path; }
 
@@ -60,6 +62,8 @@ private:
     static std::unique_ptr<EmbeddedServer> global_instance;
     static std::mutex instance_mutex;
     static size_t client_ref_count;
+    /// Set by beginShutdown(); guarded by instance_mutex.
+    static bool engine_stopped;
     std::string db_path;
     ServerSettings server_settings;
     std::optional<StatusFile> status;

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -11,9 +11,11 @@
 #if USE_PYTHON
 #    include <PythonTableCache.h>
 #endif
+#include <IO/SharedThreadPools.h>
 #include <Common/AsynchronousMetrics.h>
 #include <Common/MemoryTracker.h>
 #include <Common/SignalHandlers.h>
+#include <Common/ThreadPool.h>
 #include <Common/ThreadStatus.h>
 
 #if defined(USE_MUSL) && defined(__aarch64__)
@@ -30,6 +32,9 @@ void chdb_musl_compile_stub(int arg)
 #if USE_JEMALLOC
 #    include <Common/memory.h>
 #endif
+
+/// Defined in CurrentMemoryTracker.cpp.
+extern std::atomic<bool> g_memory_tracking_disabled;
 
 #ifdef CHDB_STATIC_LIBRARY_BUILD
 /// Force reference to ensure function registration object is linked
@@ -1357,6 +1362,45 @@ void chdb_set_signal_handlers_enabled(int enabled)
 
     if (!enabled)
         chdb_reset_signal_handlers();
+}
+
+chdb_state chdb_shutdown(void)
+{
+    /// Set only once the engine is fully stopped, so that a call which bailed
+    /// out below can be retried.
+    static std::atomic<bool> stopped{false};
+
+    if (stopped.load(std::memory_order_acquire))
+        return CHDBSuccess;
+
+    if (DB::EmbeddedServer::hasActiveClients())
+        return CHDBError;
+
+    try
+    {
+        /// Order matters: the shared pools run their workers on threads borrowed
+        /// from the global pool, so joining the global pool first would block on
+        /// a worker parked inside a shared pool.
+        DB::StaticThreadPool::shutdownAll();
+
+        /// Declines to join, and logs which pools are to blame, when a job still
+        /// holds a pool thread -- a pool owned by some static-lifetime object we
+        /// cannot reach, such as a filesystem cache. Those threads then outlive
+        /// this call, as they did before it existed, so report the failure.
+        if (!GlobalThreadPool::shutdownAndJoin())
+            return CHDBError;
+    }
+    catch (...)
+    {
+        DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+        return CHDBError;
+    }
+
+    /// Nothing is left to account for, and the trackers outlive this call.
+    g_memory_tracking_disabled.store(true, std::memory_order_relaxed);
+
+    stopped.store(true, std::memory_order_release);
+    return CHDBSuccess;
 }
 
 void chdb_reset_signal_handlers(void)

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -1366,14 +1366,23 @@ void chdb_set_signal_handlers_enabled(int enabled)
 
 chdb_state chdb_shutdown(void)
 {
-    /// Set only once the engine is fully stopped, so that a call which bailed
-    /// out below can be retried.
-    static std::atomic<bool> stopped{false};
+    /// Serializes the whole transition. Without it two first callers would both
+    /// reach the joins, and a second caller could be told the engine is stopped
+    /// while the first is still joining.
+    static std::mutex shutdown_mutex;
+    /// Set only once the engine is fully stopped, so a call that bailed out below
+    /// can be retried. Guarded by shutdown_mutex.
+    static bool stopped = false;
 
-    if (stopped.load(std::memory_order_acquire))
+    std::lock_guard<std::mutex> lock(shutdown_mutex);
+
+    if (stopped)
         return CHDBSuccess;
 
-    if (DB::EmbeddedServer::hasActiveClients())
+    /// Decides and claims under the instance lock, so a connect racing this either
+    /// gets in first and is counted here, or arrives later and is refused. From
+    /// here on the engine is closed for business even if a join below fails.
+    if (!DB::EmbeddedServer::beginShutdown())
         return CHDBError;
 
     try
@@ -1399,7 +1408,7 @@ chdb_state chdb_shutdown(void)
     /// Nothing is left to account for, and the trackers outlive this call.
     g_memory_tracking_disabled.store(true, std::memory_order_relaxed);
 
-    stopped.store(true, std::memory_order_release);
+    stopped = true;
     return CHDBSuccess;
 }
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -843,15 +843,20 @@ CHDB_EXPORT void chdb_reset_signal_handlers(void);
  * still open this does nothing and returns CHDBError, because tearing the engine
  * down under a live connection would leave it dangling.
  *
- * After a successful call the library is finished for the lifetime of the
- * process: chdb_connect() and query_stable() must not be called again. Calling
- * this twice is harmless and returns CHDBSuccess.
+ * Once it starts, the library is closed for business for the rest of the process,
+ * whether or not it manages to stop every thread: chdb_connect() then fails and
+ * query_stable() must not be called. Calling this again is harmless -- it returns
+ * CHDBSuccess if the engine is already stopped, and otherwise retries.
+ *
+ * Safe to call from any thread and concurrently with itself and with
+ * chdb_connect(): callers are serialized, and a connect racing a shutdown either
+ * gets in first and is counted, or arrives later and is refused.
  *
  * Skipping it stays as safe as it has always been for a process that just exits:
  * the threads left running are reaped by process exit.
  *
- * @return CHDBSuccess once the engine is stopped, CHDBError if a connection is
- *         still open or the shutdown itself failed
+ * @return CHDBSuccess once no chDB thread is left running, CHDBError if a
+ *         connection is still open or some thread could not be stopped
  */
 CHDB_EXPORT chdb_state chdb_shutdown(void);
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -829,6 +829,32 @@ CHDB_EXPORT void chdb_set_signal_handlers_enabled(int enabled);
  */
 CHDB_EXPORT void chdb_reset_signal_handlers(void);
 
+//===--------------------------------------------------------------------===//
+// Engine Shutdown
+//===--------------------------------------------------------------------===//
+
+/**
+ * Stops the engine: joins every thread chDB started, so that no chDB thread is
+ * alive once this returns. Call it before the host runs a teardown sequence of
+ * its own — global destructors, a finalizing language runtime, a sanitizer exit
+ * handler — which would otherwise race the still-running engine threads.
+ *
+ * Close every connection and destroy every result first. While a connection is
+ * still open this does nothing and returns CHDBError, because tearing the engine
+ * down under a live connection would leave it dangling.
+ *
+ * After a successful call the library is finished for the lifetime of the
+ * process: chdb_connect() and query_stable() must not be called again. Calling
+ * this twice is harmless and returns CHDBSuccess.
+ *
+ * Skipping it stays as safe as it has always been for a process that just exits:
+ * the threads left running are reaped by process exit.
+ *
+ * @return CHDBSuccess once the engine is stopped, CHDBError if a connection is
+ *         still open or the shutdown itself failed
+ */
+CHDB_EXPORT chdb_state chdb_shutdown(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -1271,6 +1271,40 @@ void GlobalThreadPool::shutdown()
     }
 }
 
+bool GlobalThreadPool::shutdownAndJoin()
+{
+    if (!the_instance)
+        return true;
+
+    /// A local `ThreadPoolImpl<ThreadFromGlobalPool*>` that still owns workers has
+    /// them parked on its own condition variable, and each one occupies a global-pool
+    /// thread that `finalize` below would try to join -- forever. Same for a bare
+    /// `ThreadFromGlobalPool` whose function has not returned; either way the job is
+    /// still counted by `active`. Name the local pools when there are any, then leave
+    /// the threads to process exit instead of hanging.
+    if (the_instance->active() != 0)
+    {
+        try
+        {
+            LOG_INFO(
+                &Poco::Logger::get("GlobalThreadPool"),
+                "shutdownAndJoin(): not joining, {} job(s) still hold a pool thread; live local pool workers: [{}]",
+                the_instance->active(),
+                snapshotLocalThreadPools());
+        }
+        catch (...) // NOLINT(bugprone-empty-catch) Ok: diagnostic must not change the outcome
+        {
+        }
+        return false;
+    }
+
+    the_instance->finalize();
+    /// Keep the finalized instance reachable. Destroying it would let `instance()`
+    /// lazily build a fresh pool -- with fresh threads -- for any late caller, which
+    /// is exactly what the join was supposed to rule out.
+    return true;
+}
+
 void startThreadFromGlobalPool(
     std::shared_ptr<ThreadFromGlobalPoolState> state,
     std::function<void()> func,

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -705,6 +705,41 @@ ThreadPoolImpl<Thread>::~ThreadPoolImpl()
 }
 
 template <typename Thread>
+bool ThreadPoolImpl<Thread>::finalizeIfIdle()
+{
+    {
+        std::lock_guard lock(mutex);
+
+        /// Already shut down, by us earlier or by another caller right now. Either
+        /// way the join below is not ours to run: `threads` belongs to whoever set
+        /// the flag, and joining the same std::thread twice is undefined.
+        if (shutdown)
+            return true;
+
+        /// Deciding this outside the lock is what makes a plain `active() == 0`
+        /// test useless: a job admitted between the test and `shutdown = true`
+        /// would still be there for the join to wait on, possibly forever.
+        if (scheduled_jobs != 0)
+            return false;
+
+        remaining_pool_capacity.store(-MAX_THEORETICAL_THREAD_COUNT, std::memory_order_relaxed);
+        threads_remove_themselves = false;
+        shutdown = true;
+
+        wakeUpAllIdleThreadsNoLock();
+    }
+
+    for (auto & thread_ptr : threads)
+    {
+        if (thread_ptr)
+            thread_ptr->join();
+    }
+
+    threads.clear();
+    return true;
+}
+
+template <typename Thread>
 void ThreadPoolImpl<Thread>::finalize()
 {
     {
@@ -1276,20 +1311,18 @@ bool GlobalThreadPool::shutdownAndJoin()
     if (!the_instance)
         return true;
 
-    /// A local `ThreadPoolImpl<ThreadFromGlobalPool*>` that still owns workers has
-    /// them parked on its own condition variable, and each one occupies a global-pool
-    /// thread that `finalize` below would try to join -- forever. Same for a bare
-    /// `ThreadFromGlobalPool` whose function has not returned; either way the job is
-    /// still counted by `active`. Name the local pools when there are any, then leave
-    /// the threads to process exit instead of hanging.
-    if (the_instance->active() != 0)
+    /// Refuses under the same lock that shuts the pool down when a job still
+    /// occupies a thread. That job belongs to a pool we cannot reach -- one owned
+    /// by a static-lifetime object such as a filesystem cache -- and joining its
+    /// parked worker would block forever, so name the pools and leave those
+    /// threads to process exit.
+    if (!the_instance->finalizeIfIdle())
     {
         try
         {
             LOG_INFO(
                 &Poco::Logger::get("GlobalThreadPool"),
-                "shutdownAndJoin(): not joining, {} job(s) still hold a pool thread; live local pool workers: [{}]",
-                the_instance->active(),
+                "shutdownAndJoin(): not joining, a job still holds a pool thread; live local pool workers: [{}]",
                 snapshotLocalThreadPools());
         }
         catch (...) // NOLINT(bugprone-empty-catch) Ok: diagnostic must not change the outcome
@@ -1298,7 +1331,6 @@ bool GlobalThreadPool::shutdownAndJoin()
         return false;
     }
 
-    the_instance->finalize();
     /// Keep the finalized instance reachable. Destroying it would let `instance()`
     /// lazily build a fresh pool -- with fresh threads -- for any late caller, which
     /// is exactly what the join was supposed to rule out.

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -315,6 +315,18 @@ public:
 
     static GlobalThreadPool & instance();
     static void shutdown();
+
+    /// Joins every pool thread, so that no thread of the pool is alive once this
+    /// returns. shutdown() only abandons the instance, which leaves the idle
+    /// threads parked until the process dies -- fine for a process that is about
+    /// to exit, not fine for a host that runs a teardown sequence of its own.
+    ///
+    /// Call only once the global Context is destroyed and every pool that draws its
+    /// threads from here has been finalized. Any job still holding a pool thread
+    /// would make the join block forever, so in that case this joins nothing,
+    /// reports which pools are still alive and returns false. On true the pool is
+    /// left unusable: scheduling on it throws.
+    static bool shutdownAndJoin();
 };
 
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -260,6 +260,14 @@ private:
     void wakeUpExcessIdleThreadsNoLock();
 
     void finalize();
+
+    /// finalize(), but it refuses when a job still occupies a thread instead of
+    /// joining it, and it decides that under the same lock that sets `shutdown`
+    /// so no job can be admitted in between. Returns false only in that case.
+    /// A caller that finds the pool already shut down returns true without
+    /// joining: the join runs once, on whoever set the flag.
+    bool finalizeIfIdle();
+
     void onDestroy();
 };
 
@@ -326,6 +334,10 @@ public:
     /// would make the join block forever, so in that case this joins nothing,
     /// reports which pools are still alive and returns false. On true the pool is
     /// left unusable: scheduling on it throws.
+    ///
+    /// Concurrent callers do not all join: the first one to win the pool lock does
+    /// the joining and the rest return true immediately, so a caller that needs
+    /// "no pool thread is alive now" must serialize the calls itself.
     static bool shutdownAndJoin();
 };
 


### PR DESCRIPTION
Closes #181.

`chdb_shutdown()` joins the engine's threads: `StaticThreadPool::shutdownAll()` first,
since the shared pools' workers run on threads borrowed from the global pool, then the
global pool itself. It refuses while any connection is open, and is a no-op once done.

`GlobalThreadPool::shutdownAndJoin()` is new rather than a change to `shutdown()`, whose
leak is right for a process that is about to exit. If a job still holds a pool thread it
joins nothing, names the pool via the existing `snapshotLocalThreadPools()` registry and
returns false — reported as `CHDBError`, so those threads outlive the call as they do
today instead of hanging the caller.

## Verified on macOS arm64

`examples/chdbShutdownTest.c` counts live pool threads around each step:

| step | pool threads |
| --- | --- |
| before connect | 0 |
| after query | 18 |
| after refused shutdown | 18 |
| after close_conn | 21 |
| after chdb_shutdown, raced by four threads | 0 |

Counts scale with core count; the issue's 33 is a larger Linux CI box. The race is
on the one real transition a process gets, since a shutdown that already succeeded
sends every later caller down the fast path without contending. Ten runs pass.

Also by hand: the refusal leaves the surviving connection usable, the call works after the
connectionless `chdb_query_cmdline` path, and a post-shutdown `chdb_connect` returns NULL
rather than crashing. The other eleven example tests pass; 63 exported symbols, so the
macOS allow-list is applied. The Go example calls it after closing, which exercises the
symbol through the static-library/cgo path too.

chdb-go's `race-test.sh` wrapper can go once this ships; its own comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chdb_shutdown()` to stop the chDB engine's thread pools
> - Adds a new `chdb_shutdown()` C API function in [chdb.cpp](https://github.com/chdb-io/chdb-core/pull/185/files#diff-1e6f177972b741a03317763e7c2e41acac81949dabfd2913b21dd48dc0cf6e12) that shuts down the global and shared thread pools, refusing if any connections remain open and becoming a no-op on subsequent calls.
> - Adds `finalizeIfIdle()` to `ThreadPoolImpl` and `GlobalThreadPool::shutdownAndJoin()` in [ThreadPool.cpp](https://github.com/chdb-io/chdb-core/pull/185/files#diff-58357c9febd25c282bf2d3ba4fc0ae7e6f134049f3d95ec7566058fc341c4057) to safely join threads only when no jobs are scheduled.
> - Adds `DB::EmbeddedServer::beginShutdown()` in [EmbeddedServer.cpp](https://github.com/chdb-io/chdb-core/pull/185/files#diff-b40e2cd65195a45a5e28818eb8a4abb4f0b06a149aad063577c767414136191b) to mark the engine stopped and block new `getInstance()` calls after shutdown.
> - Adds a C test program and shell script in [examples/](https://github.com/chdb-io/chdb-core/pull/185/files#diff-e763e76efa556abe41b8004d6141fbe4edab286e2770e16e318033ee6254193b) and extends all four CI workflows to run the shutdown test.
> - Risk: after `chdb_shutdown()` succeeds, subsequent `chdb_connect()` calls will fail with a `BAD_ARGUMENTS` exception; the engine cannot be restarted within the same process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64270f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->