### PR TITLE
Prefer chdb.deploy's extended @func when present

### DIFF
--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -283,6 +283,16 @@ ExceptionHandling = _chdb.ExceptionHandling
 
 from . import dbapi, session, udf, utils  # noqa: E402
 from .udf import func  # noqa: E402
+
+# The chdb wrapper wheel (PyPI package `chdb`) may ship chdb/deploy.py into
+# this same package directory, extending the decorator with remote-deploy
+# support (`@func(deploy=..., permanent=...)`). Prefer it when present; a
+# plain chdb-core install falls back to the decorator imported above.
+try:
+    from .deploy import func  # noqa: E402, F811
+except ImportError:
+    pass
+
 from .state import connect  # noqa: E402
 
 __all__ = [

--- a/tests/test_deploy_hook.py
+++ b/tests/test_deploy_hook.py
@@ -1,0 +1,74 @@
+#!python3
+
+"""Tests for the chdb.deploy extension hook in chdb/__init__.py.
+
+The chdb wrapper wheel (PyPI package `chdb`) may ship chdb/deploy.py into the
+same package directory as chdb-core; the __init__.py hook prefers that
+extended decorator when it is importable and falls back to chdb.udf.func
+otherwise. Each case runs in a subprocess so the import-time behavior is
+exercised from a clean slate.
+"""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+def _run(code: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    return result.stdout
+
+
+class TestDeployHook(unittest.TestCase):
+    def test_falls_back_to_plain_decorator_without_deploy_module(self):
+        out = _run(
+            """
+            import chdb
+            import chdb.udf
+
+            assert chdb.func is chdb.udf.func, (
+                "without chdb/deploy.py, chdb.func must be chdb.udf.func"
+            )
+            print("fallback-ok")
+            """
+        )
+        self.assertIn("fallback-ok", out)
+
+    def test_prefers_deploy_module_when_importable(self):
+        # Pre-seeding sys.modules["chdb.deploy"] is equivalent to the wrapper
+        # wheel having shipped chdb/deploy.py: the hook's `from .deploy
+        # import func` resolves against sys.modules first.
+        out = _run(
+            """
+            import sys
+            import types
+
+            stub = types.ModuleType("chdb.deploy")
+
+            def _extended_func(*args, **kwargs):
+                raise NotImplementedError
+
+            stub.func = _extended_func
+            sys.modules["chdb.deploy"] = stub
+
+            import chdb
+
+            assert chdb.func is stub.func, (
+                "with chdb.deploy importable, chdb.func must be its func"
+            )
+            print("prefers-deploy-ok")
+            """
+        )
+        self.assertIn("prefers-deploy-ok", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #186. Companion to chdb-io/chdb#629.

Adds a guarded `try: from .deploy import func` after the existing `from .udf import func`, so `chdb.func` resolves to the wrapper wheel's extended decorator (deploy/permanent support) whenever `chdb/deploy.py` is importable — regardless of which wheel wrote the shared `__init__.py` last. A plain chdb-core install hits the ImportError branch and keeps the existing decorator: zero behavior change.

**Tests** (`tests/test_deploy_hook.py`, subprocess-per-case so import-time behavior is exercised from a clean slate):
- without `chdb.deploy`, `chdb.func is chdb.udf.func` (fallback);
- with `chdb.deploy` importable, `chdb.func` is its `func` (preference).

Also verified locally end to end: this patched `__init__.py` plus the wrapper's actual `chdb/deploy.py` in the same package directory yields `from chdb import func` with the `deploy`/`permanent` parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer `chdb.deploy.func` over `chdb.udf.func` when `chdb.deploy` is importable
> In [chdb/__init__.py](https://github.com/chdb-io/chdb-core/pull/187/files#diff-89be2637be1bc580d250d2e5a04d6bbcc6603fcc0c931fbeca1ce413fa8d6a25), `chdb.func` now resolves to `chdb.deploy.func` if the `chdb.deploy` module is present, falling back to `chdb.udf.func` when it is not. Tests in [tests/test_deploy_hook.py](https://github.com/chdb-io/chdb-core/pull/187/files#diff-ea1be3f3134064da31afc4499af19a2a686d8da5f4276da10b3ea0539e0c9c56) verify both the fallback and override paths via subprocess isolation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdc8ebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->