### PR TITLE
Export ADBC entrypoints from Linux Python wheels

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -577,7 +577,11 @@ jobs:
             case "$loc"  in '??:0'|'??:?'|'') echo "FAIL: source location unresolved at $addr"; exit 1 ;; esac
           }
           verify chdb/_chdb.abi3.so PyInit__chdb _chdb.abi3.so.debug
+          verify chdb/_chdb.abi3.so chdb_adbc_init _chdb.abi3.so.debug
+          verify chdb/_chdb.abi3.so AdbcDriverInit _chdb.abi3.so.debug
           verify libchdb.so query_stable libchdb.so.debug
+          verify libchdb.so chdb_adbc_init libchdb.so.debug
+          verify libchdb.so AdbcDriverInit libchdb.so.debug
       - name: Package debug symbols
         run: |
           ls *.debug

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -557,7 +557,11 @@ jobs:
             case "$loc"  in '??:0'|'??:?'|'') echo "FAIL: source location unresolved at $addr"; exit 1 ;; esac
           }
           verify chdb/_chdb.abi3.so PyInit__chdb _chdb.abi3.so.debug
+          verify chdb/_chdb.abi3.so chdb_adbc_init _chdb.abi3.so.debug
+          verify chdb/_chdb.abi3.so AdbcDriverInit _chdb.abi3.so.debug
           verify libchdb.so query_stable libchdb.so.debug
+          verify libchdb.so chdb_adbc_init libchdb.so.debug
+          verify libchdb.so AdbcDriverInit libchdb.so.debug
       - name: Package debug symbols
         run: |
           ls *.debug

--- a/chdb/build.sh
+++ b/chdb/build.sh
@@ -308,7 +308,9 @@ if [ "$(uname)" == "Darwin" ]; then
     PYCHDB_CMD="${PYCHDB_CMD} -Wl,-exported_symbols_list,${CHDB_DIR}/pychdb_export_macos.txt"
 else
     PYCHDB_CMD=$(echo ${PYCHDB_CMD} | sed 's|-Wl,-rpath,/[^[:space:]]*/pybind11-cmake|-Wl,-rpath,\$ORIGIN|g')
-    PYCHDB_CMD="${PYCHDB_CMD} -Wl,--undefined=PyInit__chdb -Wl,--version-script=${CHDB_DIR}/pychdb_export.map"
+    # The version script exports these names; --undefined keeps their objects
+    # linked into the Python module when they come from static archives.
+    PYCHDB_CMD="${PYCHDB_CMD} -Wl,--undefined=PyInit__chdb -Wl,--undefined=chdb_adbc_init -Wl,--undefined=AdbcDriverInit -Wl,--version-script=${CHDB_DIR}/pychdb_export.map"
 fi
 
 # save the command to a file for debug
@@ -402,11 +404,15 @@ echo -e "\nPyInit in PYCHDB: ${PYCHDB}"
 ${NM} ${PYCHDB} | grep PyInit || true
 echo -e "\nquery_stable in PYCHDB: ${PYCHDB}"
 ${NM} ${PYCHDB} | grep query_stable || true
+echo -e "\nADBC entrypoints in PYCHDB: ${PYCHDB}"
+${NM} ${PYCHDB} | grep -E 'chdb_adbc_init|AdbcDriverInit' || true
 if [ "${CHDB_LITE}" != "1" ]; then
     echo -e "\nPyInit in LIBCHDB: ${LIBCHDB}"
     ${NM} ${LIBCHDB} | grep PyInit || echo "PyInit not found in ${LIBCHDB}, it's OK"
     echo -e "\nquery_stable in LIBCHDB: ${LIBCHDB}"
     ${NM} ${LIBCHDB} | grep query_stable || true
+    echo -e "\nADBC entrypoints in LIBCHDB: ${LIBCHDB}"
+    ${NM} ${LIBCHDB} | grep -E 'chdb_adbc_init|AdbcDriverInit' || true
 fi
 
 echo -e "\nAfter copy:"

--- a/tests/test_adbc_driver.py
+++ b/tests/test_adbc_driver.py
@@ -1053,5 +1053,41 @@ class TestAdbcPersistence(unittest.TestCase):
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcPythonInterop(unittest.TestCase):
+    def test_adbc_reuses_python_module_for_same_path_connection(self):
+        try:
+            import chdb
+        except Exception as exc:  # noqa: BLE001 - optional package in this suite
+            self.skipTest(f"chdb package not importable: {exc}")
+
+        py_so = getattr(getattr(chdb, "_chdb", None), "__file__", None)
+        if (
+            not py_so
+            or not _LIBCHDB_PATH
+            or os.path.realpath(py_so) != os.path.realpath(_LIBCHDB_PATH)
+        ):
+            self.skipTest("ADBC driver is not the installed chdb Python module")
+
+        tmp = tempfile.mkdtemp(prefix="chdb_adbc_python_")
+        native = None
+        try:
+            _release_memory_keepalive()
+            native = chdb.connect(tmp)
+            native.query(
+                "CREATE TABLE native_events (id UInt64) "
+                "ENGINE = MergeTree ORDER BY id"
+            )
+            native.query("INSERT INTO native_events VALUES (1), (2), (3)")
+
+            with _connect(tmp) as conn, conn.cursor() as cur:
+                cur.execute("SELECT sum(id) FROM native_events")
+                self.assertEqual(cur.fetchone()[0], 6)
+        finally:
+            if native is not None:
+                native.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_c_api_query_with_params.py
+++ b/tests/test_c_api_query_with_params.py
@@ -12,9 +12,9 @@ These call the same engine plumbing as Python's ``chdb.query(..., params={...})`
 they're the C-ABI siblings used by chdb-node / chdb-go / chdb-rust.
 
 Loads libchdb.so / libchdb.dylib directly via ctypes (those binaries export the
-C ABI; the Python wheel's ``_chdb.abi3.so`` only exports ``PyInit__chdb``). When
-no standalone library is found (e.g. running against an installed wheel without
-the source tree) the whole suite is skipped.
+full C ABI; the Python wheel's ``_chdb.abi3.so`` is not used for these ctypes
+tests). When no standalone library is found (e.g. running against an installed
+wheel without the source tree) the whole suite is skipped.
 """
 
 import ctypes

--- a/tests/test_c_api_stream_insert.py
+++ b/tests/test_c_api_stream_insert.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """C-ABI tests for the streaming INSERT surface (chdb_stream_insert family).
 
-Loads libchdb.so directly via ctypes (the standalone library exports the C ABI;
-the Python wheel's _chdb.abi3.so only exports PyInit__chdb). Skipped when no
-standalone library is found; set CHDB_LIB_PATH to point at one.
+Loads libchdb.so directly via ctypes (the standalone library exports the full C
+ABI; the Python wheel's _chdb.abi3.so is not used for these ctypes tests).
+Skipped when no standalone library is found; set CHDB_LIB_PATH to point at one.
 
 Exercises: full lifecycle (insert -> append -> done -> rows_written -> destroy),
 binary-safe length-respecting append, init error reporting, and cancel + safe

--- a/tests/test_c_api_stream_query.py
+++ b/tests/test_c_api_stream_query.py
@@ -11,9 +11,9 @@ back to defaults before the output format was created at fetch time, so a
 ISO form ``2025-12-19T13:52:04.496187Z``.
 
 Loads libchdb.so / libchdb.dylib directly via ctypes (those binaries export
-the C ABI; the Python wheel's ``_chdb.abi3.so`` only exports
-``PyInit__chdb``). When no standalone library is found (e.g. running against
-an installed wheel without the source tree) the whole suite is skipped.
+the full C ABI; the Python wheel's ``_chdb.abi3.so`` is not used for these
+ctypes tests). When no standalone library is found (e.g. running against an
+installed wheel without the source tree) the whole suite is skipped.
 """
 
 import ctypes


### PR DESCRIPTION
## Summary
- Keep the ADBC driver entrypoints linked into Linux _chdb.abi3.so wheels.
- Add Linux CI symbol checks for chdb_adbc_init and AdbcDriverInit in both _chdb.abi3.so and libchdb.so.
- Add a Python API plus ADBC same-path interop regression test when ADBC loads the installed Python module.

## Why
Linux chdb[adbc] wheels could fail through adbc_driver_chdb because _chdb.abi3.so did not export chdb_adbc_init, even though the export map allowed it. The linker still needed the symbol marked undefined so the object containing the ADBC entrypoints is retained in the Python module.

## Testing
- git diff --check origin/main..HEAD
- bash -n chdb/build.sh
- Python syntax compile for tests/test_adbc_driver.py, tests/test_c_api_stream_query.py, tests/test_c_api_stream_insert.py, and tests/test_c_api_query_with_params.py

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `chdb_adbc_init` and `AdbcDriverInit` from Linux Python wheels
> - Adds `--undefined=chdb_adbc_init` and `--undefined=AdbcDriverInit` to the non-macOS linker command in [build.sh](https://github.com/chdb-io/chdb-core/pull/189/files#diff-954aaac221cbc2a5091bcec6b98b647e7e91fc003cbe9fad12186c909aa4be35) so the symbols are retained from static archives and exported via the version script.
> - Adds `nm`-based diagnostics in [build.sh](https://github.com/chdb-io/chdb-core/pull/189/files#diff-954aaac221cbc2a5091bcec6b98b647e7e91fc003cbe9fad12186c909aa4be35) and CI verification steps in [build_linux_x86_wheels.yml](https://github.com/chdb-io/chdb-core/pull/189/files#diff-9d0bd289ed24cc0ae2c924282f7dd56b386d2c02b95ee8ad062596fc46f7f186) and [build_linux_arm64_wheels-gh.yml](https://github.com/chdb-io/chdb-core/pull/189/files#diff-fd24c962953455ae96b49526dd5a9f87b30c58a054fa3be36afa304ba1f55359) to confirm the symbols are present in `_chdb.abi3.so` and `libchdb.so`.
> - Adds [test_adbc_driver.py](https://github.com/chdb-io/chdb-core/pull/189/files#diff-1ffd0fb08b222190955369dab8b91b55bde505df1b53326ec01e2466fd1346a2) to verify interop between the native chdb connection and an ADBC connection on the same path.
> - Risk: CI jobs will now fail if either `chdb_adbc_init` or `AdbcDriverInit` is missing from the built artifacts; changes apply only to non-macOS Linux builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fe2f81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->