### PR TITLE
tests: Arrow IPC gold-file read-conformance test (#625)

### DIFF
--- a/tests/test_arrow_ipc_gold_files.py
+++ b/tests/test_arrow_ipc_gold_files.py
@@ -23,12 +23,16 @@ bytes. ``.arrow_file`` uses the ``Arrow`` (IPC file) format; ``.stream`` uses
 
 Comparison is representation-tolerant on purpose: chDB maps Arrow ``binary`` to
 ``string`` and materializes dictionaries, so values are normalized (dictionaries
-decoded, binary/string compared as bytes) before comparison. Only genuine value
-differences fail — not type-label differences.
+decoded, binary/string compared as bytes) before comparison. It is also
+order-insensitive (the multiset of rows is compared) because chDB may read
+record batches in parallel. Only genuine value differences fail — not type-label
+or row-order differences.
 
 One test is generated per (version, file, framing). Types that chDB reads wrong
-today (chdb-io/chdb#625) are ``@unittest.skip``-ped so the suite is green; the
-correct ones run. Written in unittest so ``tests/run_all.py`` collects it.
+today (chdb-io/chdb#625) are marked ``@unittest.expectedFailure`` so they still
+run and the suite stays green; when chDB fixes one it shows up as an unexpected
+success (prompting removal of the marker). Written in unittest so
+``tests/run_all.py`` collects it.
 Fixtures are fetched on first use and cached; the network being unavailable
 skips (never fails) the affected case, matching ``hits_dataset.py``.
 """
@@ -79,9 +83,10 @@ VERSION_CASES = {
 FORMATS = {"arrow_file": "Arrow", "stream": "ArrowStream"}
 
 # Type cases known to be broken in chDB today, keyed by generated-file name.
-# Established empirically against chdb 4.3.0 (engine 26.7.2.1). Skipped so the
-# suite stays green while chdb-io/chdb#625 is open; drop an entry once fixed
-# (switch to unittest.expectedFailure if a regression signal is wanted instead).
+# Established empirically against chdb 4.3.0 (engine 26.7.2.1). Marked
+# expectedFailure so they still run and the suite stays green while
+# chdb-io/chdb#625 is open; a fix surfaces as an unexpected success -> drop the
+# entry. The string is used as the generated test's docstring.
 KNOWN_ISSUES = {
     # --- read fails outright (query raises) ---
     "null": "#625: Arrow null type -> Code 636 CANNOT_EXTRACT_TABLE_STRUCTURE",
@@ -171,6 +176,12 @@ def _normalize(col):
         return col.cast(pa.binary()).to_pylist()
 
 
+def _rows(table):
+    """The table's normalized rows as tuples (used for value comparison)."""
+    cols = [_normalize(table.column(i)) for i in range(table.num_columns)]
+    return [tuple(col[r] for col in cols) for r in range(table.num_rows)]
+
+
 @unittest.skipUnless(HAVE_PYARROW, "pyarrow not installed")
 class TestArrowIpcGoldFiles(unittest.TestCase):
     """One generated method per (version, file, framing). See module docstring."""
@@ -191,11 +202,13 @@ def _make_case(version, name, ext, fmt):
         self.assertEqual(got.num_rows, reference.num_rows, "row count mismatch")
         self.assertEqual(got.num_columns, reference.num_columns, "column count mismatch")
         self.assertEqual(got.column_names, reference.column_names, "column names mismatch")
-        for i in range(reference.num_columns):
-            self.assertEqual(
-                _normalize(got.column(i)), _normalize(reference.column(i)),
-                f"value mismatch in column {i} ({reference.column_names[i]!r})",
-            )
+        # chDB may read Arrow record batches in parallel, so row order is not
+        # guaranteed; compare the multiset of normalized rows, not their order.
+        self.assertEqual(
+            sorted(map(repr, _rows(got))),
+            sorted(map(repr, _rows(reference))),
+            "row values mismatch (order-insensitive)",
+        )
     return test
 
 
@@ -207,7 +220,8 @@ def _install_cases():
                 method = _make_case(version, name, ext, fmt)
                 method.__name__ = f"test_{slug_v}__{name}__{ext}"
                 if name in KNOWN_ISSUES:
-                    method = unittest.skip(KNOWN_ISSUES[name])(method)
+                    method.__doc__ = KNOWN_ISSUES[name]
+                    method = unittest.expectedFailure(method)
                 setattr(TestArrowIpcGoldFiles, method.__name__, method)
 
 

--- a/tests/test_arrow_ipc_gold_files.py
+++ b/tests/test_arrow_ipc_gold_files.py
@@ -26,6 +26,9 @@ Comparison is representation-tolerant on purpose: chDB maps Arrow ``binary`` to
 decoded, binary/string compared as bytes) before comparison. Only genuine value
 differences fail — not type-label differences.
 
+One test is generated per (version, file, framing). Types that chDB reads wrong
+today (chdb-io/chdb#625) are ``@unittest.skip``-ped so the suite is green; the
+correct ones run. Written in unittest so ``tests/run_all.py`` collects it.
 Fixtures are fetched on first use and cached; the network being unavailable
 skips (never fails) the affected case, matching ``hits_dataset.py``.
 """
@@ -33,15 +36,19 @@ skips (never fails) the affected case, matching ``hits_dataset.py``.
 import os
 import tempfile
 import time
+import unittest
 import urllib.error
 import urllib.request
 
-import pytest
+try:
+    import pyarrow as pa
+    import pyarrow.ipc  # noqa: F401
+    import pyarrow.types as pt
+    HAVE_PYARROW = True
+except ImportError:  # pragma: no cover - pyarrow is normally present in CI
+    HAVE_PYARROW = False
 
-pa = pytest.importorskip("pyarrow")
-import pyarrow.ipc  # noqa: E402
-import pyarrow.types as pt  # noqa: E402
-import chdb  # noqa: E402
+import chdb
 
 # --- Fixture source, pinned for reproducibility -----------------------------
 ARROW_TESTING_COMMIT = "9ff285c88565f0f6abc855918c6a342e70e4909c"
@@ -51,31 +58,30 @@ BASE_URL = (
 )
 CACHE_DIR = os.path.join(tempfile.gettempdir(), "chdb_arrow_ipc_gold_cache")
 
-# Gold-file version directories to exercise. Big-endian dirs are omitted: pyarrow
-# cannot decode cross-endian IPC on a little-endian host, so there is no
-# reference to validate against. More dirs (0.14.1, 0.17.1) can be appended.
-VERSIONS = ["1.0.0-littleendian", "2.0.0-compression"]
-
-# Generated type cases (superset across versions). A (version, name) that does
-# not exist is skipped automatically when the download 404s.
-CASES = [
-    # 1.0.0-littleendian
-    "primitive", "primitive_large_offsets", "primitive_no_batches",
-    "primitive_zerolength", "null", "null_trivial", "decimal", "decimal256",
-    "datetime", "interval", "map", "map_non_canonical", "nested",
-    "nested_large_offsets", "dictionary", "dictionary_unsigned",
-    "nested_dictionary", "custom_metadata", "duplicate_fieldnames", "extension",
-    # 2.0.0-compression
-    "lz4", "zstd", "uncompressible_lz4", "uncompressible_zstd",
-]
+# Gold-file cases per version directory (only files that actually exist there).
+# Big-endian dirs are omitted: pyarrow cannot decode cross-endian IPC on a
+# little-endian host, so there is no reference to validate against. More dirs
+# (0.14.1, 0.17.1) can be appended. A file that later disappears upstream is
+# skipped automatically when the download 404s.
+VERSION_CASES = {
+    "1.0.0-littleendian": [
+        "primitive", "primitive_large_offsets", "primitive_no_batches",
+        "primitive_zerolength", "null", "null_trivial", "decimal", "decimal256",
+        "datetime", "interval", "map", "map_non_canonical", "nested",
+        "nested_large_offsets", "dictionary", "dictionary_unsigned",
+        "nested_dictionary", "custom_metadata", "duplicate_fieldnames",
+        "extension",
+    ],
+    "2.0.0-compression": ["lz4", "zstd", "uncompressible_lz4", "uncompressible_zstd"],
+}
 
 # .arrow_file -> IPC file format; .stream -> IPC streaming format.
 FORMATS = {"arrow_file": "Arrow", "stream": "ArrowStream"}
 
 # Type cases known to be broken in chDB today, keyed by generated-file name.
-# Established empirically against chdb 4.3.0 (engine 26.7.2.1). Kept as
-# xfail(strict=False) so the suite stays green while chdb-io/chdb#625 is open and
-# so a future fix surfaces as XPASS (prompting removal of the marker).
+# Established empirically against chdb 4.3.0 (engine 26.7.2.1). Skipped so the
+# suite stays green while chdb-io/chdb#625 is open; drop an entry once fixed
+# (switch to unittest.expectedFailure if a regression signal is wanted instead).
 KNOWN_ISSUES = {
     # --- read fails outright (query raises) ---
     "null": "#625: Arrow null type -> Code 636 CANNOT_EXTRACT_TABLE_STRUCTURE",
@@ -101,7 +107,8 @@ _RETRY_DELAYS = (2, 8)
 
 def _download(url, dest, retries=_RETRY_DELAYS):
     """Fetch ``url`` to ``dest``. Returns the path, ``None`` on HTTP 404 (file
-    absent for this version), or ``pytest.skip`` if the network stays down."""
+    absent for this version), or raises ``SkipTest`` if the network stays down
+    (an unreachable CDN skips rather than fails, matching ``hits_dataset.py``)."""
     last = None
     for attempt, delay in enumerate((0,) + tuple(retries)):
         if delay:
@@ -127,7 +134,7 @@ def _download(url, dest, retries=_RETRY_DELAYS):
             os.remove(dest + ".part")
         except OSError:
             pass
-    pytest.skip(f"{url} unreachable: {last}")
+    raise unittest.SkipTest(f"{url} unreachable: {last}")
 
 
 def _ensure_gold_file(version, name, ext):
@@ -138,7 +145,7 @@ def _ensure_gold_file(version, name, ext):
     os.makedirs(os.path.dirname(dest), exist_ok=True)
     result = _download(f"{BASE_URL}/{version}/{fname}", dest)
     if result is None:
-        pytest.skip(f"{version}/{fname} not present in arrow-testing")
+        raise unittest.SkipTest(f"{version}/{fname} not present in arrow-testing")
     return result
 
 
@@ -164,42 +171,48 @@ def _normalize(col):
         return col.cast(pa.binary()).to_pylist()
 
 
-def _params():
-    for version in VERSIONS:
-        for name in CASES:
-            marks = []
-            if name in KNOWN_ISSUES:
-                marks = [pytest.mark.xfail(reason=KNOWN_ISSUES[name], strict=False)]
+@unittest.skipUnless(HAVE_PYARROW, "pyarrow not installed")
+class TestArrowIpcGoldFiles(unittest.TestCase):
+    """One generated method per (version, file, framing). See module docstring."""
+
+
+def _make_case(version, name, ext, fmt):
+    def test(self):
+        path = _ensure_gold_file(version, name, ext)
+        # Reference decode of the identical bytes. If pyarrow itself cannot read
+        # the file there is nothing to validate against, so skip.
+        try:
+            reference = _read_reference(path, ext)
+        except Exception as exc:  # noqa: BLE001
+            self.skipTest(f"pyarrow cannot decode reference {path}: {exc}")
+
+        got = chdb.query(f"SELECT * FROM file('{path}', '{fmt}')", "ArrowTable")
+
+        self.assertEqual(got.num_rows, reference.num_rows, "row count mismatch")
+        self.assertEqual(got.num_columns, reference.num_columns, "column count mismatch")
+        self.assertEqual(got.column_names, reference.column_names, "column names mismatch")
+        for i in range(reference.num_columns):
+            self.assertEqual(
+                _normalize(got.column(i)), _normalize(reference.column(i)),
+                f"value mismatch in column {i} ({reference.column_names[i]!r})",
+            )
+    return test
+
+
+def _install_cases():
+    for version, names in VERSION_CASES.items():
+        slug_v = version.replace(".", "_").replace("-", "_")
+        for name in names:
             for ext, fmt in FORMATS.items():
-                yield pytest.param(
-                    version, name, ext, fmt,
-                    id=f"{version}-{name}.{ext}", marks=marks,
-                )
+                method = _make_case(version, name, ext, fmt)
+                method.__name__ = f"test_{slug_v}__{name}__{ext}"
+                if name in KNOWN_ISSUES:
+                    method = unittest.skip(KNOWN_ISSUES[name])(method)
+                setattr(TestArrowIpcGoldFiles, method.__name__, method)
 
 
-@pytest.mark.parametrize("version,name,ext,fmt", list(_params()))
-def test_arrow_ipc_gold_file(version, name, ext, fmt):
-    path = _ensure_gold_file(version, name, ext)
-
-    # Reference decode of the identical bytes. If pyarrow itself cannot read the
-    # file there is nothing to validate against, so skip rather than fail.
-    try:
-        reference = _read_reference(path, ext)
-    except Exception as exc:  # noqa: BLE001
-        pytest.skip(f"pyarrow cannot decode reference {path}: {exc}")
-
-    # chDB read (raises on the hard read failures tracked in KNOWN_ISSUES).
-    got = chdb.query(f"SELECT * FROM file('{path}', '{fmt}')", "ArrowTable")
-
-    assert got.num_rows == reference.num_rows, "row count mismatch"
-    assert got.num_columns == reference.num_columns, "column count mismatch"
-    assert got.column_names == reference.column_names, "column names mismatch"
-    for i in range(reference.num_columns):
-        assert _normalize(got.column(i)) == _normalize(reference.column(i)), (
-            f"value mismatch in column {i} ({reference.column_names[i]!r})"
-        )
+_install_cases()
 
 
 if __name__ == "__main__":
-    import sys
-    sys.exit(pytest.main([__file__, "-v"]))
+    unittest.main(verbosity=2)

--- a/tests/test_arrow_ipc_gold_files.py
+++ b/tests/test_arrow_ipc_gold_files.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Read Apache Arrow IPC "gold" integration files with chDB and validate the
+result against a trusted decode of the *same bytes* (pyarrow).
+
+Motivation: chdb-io/chdb#625 — chDB hit errors reading various Apache Arrow IPC
+data. The Arrow project publishes cross-implementation "gold" files (paired
+JSON + Arrow IPC, in both *file* and *stream* framing) in the
+``apache/arrow-testing`` repo under ``data/arrow-ipc-stream/integration``.
+These are the artifacts of Arrow's official ``archery integration`` conformance
+suite and are, per the Arrow docs, "assumed to be correct".
+
+chDB is a query engine, not an Arrow *library* implementation, so it cannot join
+Arrow's ``archery`` harness directly (that harness only accepts implementations
+that ship a JSON<->IPC integration executable). Instead this test borrows the
+official *fixtures* and the *validate* idea (equality against a reference
+decode): for each gold file we assert that
+
+    SELECT * FROM file(<path>, <format>)
+
+read by chDB has the same shape and values that pyarrow reads from the identical
+bytes. ``.arrow_file`` uses the ``Arrow`` (IPC file) format; ``.stream`` uses
+``ArrowStream`` (IPC streaming framing).
+
+Comparison is representation-tolerant on purpose: chDB maps Arrow ``binary`` to
+``string`` and materializes dictionaries, so values are normalized (dictionaries
+decoded, binary/string compared as bytes) before comparison. Only genuine value
+differences fail — not type-label differences.
+
+Fixtures are fetched on first use and cached; the network being unavailable
+skips (never fails) the affected case, matching ``hits_dataset.py``.
+"""
+
+import os
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+import pyarrow.ipc  # noqa: E402
+import pyarrow.types as pt  # noqa: E402
+import chdb  # noqa: E402
+
+# --- Fixture source, pinned for reproducibility -----------------------------
+ARROW_TESTING_COMMIT = "9ff285c88565f0f6abc855918c6a342e70e4909c"
+BASE_URL = (
+    "https://raw.githubusercontent.com/apache/arrow-testing/"
+    f"{ARROW_TESTING_COMMIT}/data/arrow-ipc-stream/integration"
+)
+CACHE_DIR = os.path.join(tempfile.gettempdir(), "chdb_arrow_ipc_gold_cache")
+
+# Gold-file version directories to exercise. Big-endian dirs are omitted: pyarrow
+# cannot decode cross-endian IPC on a little-endian host, so there is no
+# reference to validate against. More dirs (0.14.1, 0.17.1) can be appended.
+VERSIONS = ["1.0.0-littleendian", "2.0.0-compression"]
+
+# Generated type cases (superset across versions). A (version, name) that does
+# not exist is skipped automatically when the download 404s.
+CASES = [
+    # 1.0.0-littleendian
+    "primitive", "primitive_large_offsets", "primitive_no_batches",
+    "primitive_zerolength", "null", "null_trivial", "decimal", "decimal256",
+    "datetime", "interval", "map", "map_non_canonical", "nested",
+    "nested_large_offsets", "dictionary", "dictionary_unsigned",
+    "nested_dictionary", "custom_metadata", "duplicate_fieldnames", "extension",
+    # 2.0.0-compression
+    "lz4", "zstd", "uncompressible_lz4", "uncompressible_zstd",
+]
+
+# .arrow_file -> IPC file format; .stream -> IPC streaming format.
+FORMATS = {"arrow_file": "Arrow", "stream": "ArrowStream"}
+
+# Type cases known to be broken in chDB today, keyed by generated-file name.
+# Established empirically against chdb 4.3.0 (engine 26.7.2.1). Kept as
+# xfail(strict=False) so the suite stays green while chdb-io/chdb#625 is open and
+# so a future fix surfaces as XPASS (prompting removal of the marker).
+KNOWN_ISSUES = {
+    # --- read fails outright (query raises) ---
+    "null": "#625: Arrow null type -> Code 636 CANNOT_EXTRACT_TABLE_STRUCTURE",
+    "null_trivial": "#625: Arrow null type -> Code 636 CANNOT_EXTRACT_TABLE_STRUCTURE",
+    "datetime": "#625: date32 value out of chDB Date32 range -> Code 321",
+    "interval": "#625: Arrow interval type unsupported -> Code 636",
+    "dictionary": "#625: 'Arrow dictionary contains duplicate values' -> Code 117",
+    "dictionary_unsigned": "#625: 'Arrow dictionary contains duplicate values' -> Code 117",
+    "nested_dictionary": "#625: 'Arrow dictionary contains duplicate values' -> Code 117",
+    "extension": "#625: dict-backed extension -> Code 117 duplicate values",
+    "duplicate_fieldnames": "#625: empty/duplicate tuple element names -> Code 636",
+    # --- reads, but returns wrong values (silent) ---
+    "map": "#625: null map read as empty map (ClickHouse Map is non-nullable)",
+    "map_non_canonical": "#625: null map read as empty map (ClickHouse Map is non-nullable)",
+    "nested": "#625: null list read as empty list (ClickHouse Array is non-nullable)",
+    "nested_large_offsets": "#625: null list read as empty list (ClickHouse Array is non-nullable)",
+    "custom_metadata": "#625: null list read as empty list (ClickHouse Array is non-nullable)",
+}
+
+_USER_AGENT = "Mozilla/5.0 (compatible; chdb-tests)"
+_RETRY_DELAYS = (2, 8)
+
+
+def _download(url, dest, retries=_RETRY_DELAYS):
+    """Fetch ``url`` to ``dest``. Returns the path, ``None`` on HTTP 404 (file
+    absent for this version), or ``pytest.skip`` if the network stays down."""
+    last = None
+    for attempt, delay in enumerate((0,) + tuple(retries)):
+        if delay:
+            time.sleep(delay)
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+            tmp = dest + ".part"
+            with urllib.request.urlopen(req, timeout=120) as resp, open(tmp, "wb") as out:
+                while True:
+                    chunk = resp.read(1 << 20)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+            os.replace(tmp, dest)
+            return dest
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            last = exc
+        except Exception as exc:  # noqa: BLE001 - retry any transient failure
+            last = exc
+        try:
+            os.remove(dest + ".part")
+        except OSError:
+            pass
+    pytest.skip(f"{url} unreachable: {last}")
+
+
+def _ensure_gold_file(version, name, ext):
+    fname = f"generated_{name}.{ext}"
+    dest = os.path.join(CACHE_DIR, version, fname)
+    if os.path.exists(dest):
+        return dest
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    result = _download(f"{BASE_URL}/{version}/{fname}", dest)
+    if result is None:
+        pytest.skip(f"{version}/{fname} not present in arrow-testing")
+    return result
+
+
+def _read_reference(path, ext):
+    if ext == "arrow_file":
+        return pa.ipc.open_file(path).read_all()
+    return pa.ipc.open_stream(path).read_all()
+
+
+def _normalize(col):
+    """Decode-safe, representation-tolerant values for one column: dictionaries
+    are decoded and binary/string are compared as bytes, so only genuine value
+    differences (not chDB's type-label choices) show up."""
+    t = col.type
+    try:
+        if pt.is_dictionary(t):
+            col = col.cast(t.value_type)
+            t = col.type
+        if pt.is_string(t) or pt.is_large_string(t):
+            col = col.cast(pa.binary())
+        return col.to_pylist()
+    except Exception:  # noqa: BLE001 - last-resort decode-safe fallback
+        return col.cast(pa.binary()).to_pylist()
+
+
+def _params():
+    for version in VERSIONS:
+        for name in CASES:
+            marks = []
+            if name in KNOWN_ISSUES:
+                marks = [pytest.mark.xfail(reason=KNOWN_ISSUES[name], strict=False)]
+            for ext, fmt in FORMATS.items():
+                yield pytest.param(
+                    version, name, ext, fmt,
+                    id=f"{version}-{name}.{ext}", marks=marks,
+                )
+
+
+@pytest.mark.parametrize("version,name,ext,fmt", list(_params()))
+def test_arrow_ipc_gold_file(version, name, ext, fmt):
+    path = _ensure_gold_file(version, name, ext)
+
+    # Reference decode of the identical bytes. If pyarrow itself cannot read the
+    # file there is nothing to validate against, so skip rather than fail.
+    try:
+        reference = _read_reference(path, ext)
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"pyarrow cannot decode reference {path}: {exc}")
+
+    # chDB read (raises on the hard read failures tracked in KNOWN_ISSUES).
+    got = chdb.query(f"SELECT * FROM file('{path}', '{fmt}')", "ArrowTable")
+
+    assert got.num_rows == reference.num_rows, "row count mismatch"
+    assert got.num_columns == reference.num_columns, "column count mismatch"
+    assert got.column_names == reference.column_names, "column names mismatch"
+    for i in range(reference.num_columns):
+        assert _normalize(got.column(i)) == _normalize(reference.column(i)), (
+            f"value mismatch in column {i} ({reference.column_names[i]!r})"
+        )
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Adds `tests/test_arrow_ipc_gold_files.py`, which reads Apache Arrow's official cross-implementation **"gold" IPC files** (from [`apache/arrow-testing`](https://github.com/apache/arrow-testing/tree/master/data/arrow-ipc-stream/integration), pinned to a commit) with chDB and validates the result against a trusted decode of the **same bytes** (pyarrow) — for both IPC **file** (`Arrow`) and **stream** (`ArrowStream`) framing. This addresses the request in #625.

Comparison is representation-tolerant on purpose (dictionaries decoded, binary/string compared as bytes), so only *genuine* value differences fail — not chDB's type-label choices (e.g. Arrow `binary` -> `string`).

Fixtures are fetched on first use and cached; network failure **skips** rather than fails, matching `hits_dataset.py`.

> Note: chDB is a query engine, not an Arrow library implementation, so it can't join Arrow's `archery integration` harness directly (that requires a JSON<->IPC integration executable per implementation). This test borrows the official *fixtures* and the *validate* idea (equality vs a reference decode) instead.

## How the comparison works

Each gold file is checked against a trusted decode of the **same bytes**:

- **`_read_reference(path, ext)`** — builds the "correct answer" with pyarrow (the reference implementation): `.arrow_file` via `pa.ipc.open_file().read_all()`, `.stream` via `pa.ipc.open_stream().read_all()`. Returns a pyarrow `Table` used as the baseline.
- **`_normalize(col)`** — canonicalizes one column so only *genuine* value differences fail, not chDB's type-label choices. chDB maps Arrow `binary` → `string` and materializes dictionaries, so without normalization identical bytes would compare unequal (and decoding `binary`-as-`string` would raise on non-UTF-8 data). It decodes dictionaries to their underlying values, casts `string`/`large_string` to `binary` (compare raw bytes, which also sidesteps UTF-8 decode errors), then `to_pylist()`.

Per file the test then asserts equal `num_rows`, `num_columns`, `column_names`, and that the **multiset of normalized rows matches** — i.e. every row × every column is value-compared, order-insensitively (chDB reads record batches in parallel, so row order isn't guaranteed). That is what catches the *silent* value bugs (e.g. a nullable list read as an empty list) that a "does it read without error" check would miss.

## Problems this surfaces (chdb 4.3.0 / engine 26.7.2.1)

Currently-broken types are marked `@unittest.expectedFailure` referencing #625, so they still run and the suite stays green; when chDB fixes one it shows up as an *unexpected success*, prompting removal of the marker. **Nothing is fixed here** — this PR only documents/guards the behavior.

**Read fails outright (query raises):**
| type | error |
|---|---|
| `null`, `null_trivial` | Code 636 `CANNOT_EXTRACT_TABLE_STRUCTURE` (Arrow null type) |
| `datetime` | Code 321 date32 value out of chDB `Date32` range |
| `interval` | Code 636 (Arrow interval type) |
| `dictionary`, `dictionary_unsigned`, `nested_dictionary`, `extension` | Code 117 "Arrow dictionary contains duplicate values" |
| `duplicate_fieldnames` | Code 636 "Names of tuple elements cannot be empty" |

**Reads, but returns wrong values (silent):**
| type | difference |
|---|---|
| `map`, `map_non_canonical` | nullable Arrow map read as **empty map** (`{}`/`[]` instead of `NULL`) |
| `nested`, `nested_large_offsets`, `custom_metadata` | nullable Arrow list read as **empty list** (`[]` instead of `NULL`) |

The silent value diffs stem from ClickHouse's data model (Array/Map are non-nullable), so a top-level `NULL` container becomes empty on read.

**Reads correctly:** `primitive` (+ large_offsets / no_batches / zerolength), `decimal`, `decimal256`, and LZ4/ZSTD compression (`lz4`, `zstd`, `uncompressible_*`).

Local run (chdb 4.3.0 / engine 26.7.2.1), 5x consecutive (no flakiness): `48 tests — 20 passed, 28 expected failures, 0 failed`.

## CI

Written in `unittest` so it is collected by `tests/run_all.py` (which globs `test_*.py` and runs them under unittest) — the normal `make test` path in the wheel-build workflows will run the correct cases; the known-broken ones are expected-failures, so the suite stays green. `pr_ci.yaml` (the per-PR check) only runs `flake8 chdb`, so it does **not** run this test on PRs. File is flake8-clean (max-line 120).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Arrow IPC gold-file read-conformance tests against pyarrow
> - Introduces [test_arrow_ipc_gold_files.py](https://github.com/chdb-io/chdb-core/pull/190/files#diff-957b8ecfe816e7d455093f52b6a6eaf6938110442edf694091b9bb4e17fa1ddf), which downloads pinned Apache Arrow IPC fixtures from the arrow-testing repo, caches them locally, and compares chDB's `file(path, fmt)` output against pyarrow's reference decode.
> - Test methods are auto-generated from a `VERSION_CASES` × `FORMATS` matrix; each test checks row count, column count, column names, and order-insensitive row equality with normalization for dictionary-encoding and string-vs-binary differences.
> - The whole suite is skipped when `pyarrow` is unavailable; tests skip on 404 or when pyarrow cannot decode a reference file. Known-failing cases are marked with `unittest.expectedFailure` via the `KNOWN_ISSUES` map.
> - Risk: generated test names and the `KNOWN_ISSUES` list are hardcoded to a pinned arrow-testing commit; new fixture versions require updating `VERSION_CASES` and re-evaluating `KNOWN_ISSUES`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d549ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


