### PR TITLE
Ship world-readable chdb.h in libchdb release tarballs

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -735,12 +735,14 @@ jobs:
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf linux-aarch64-libchdb.tar.gz libchdb.so chdb.h chdb.hpp
       - name: Package libchdb.a
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf linux-aarch64-libchdb-static.tar.gz libchdb.a chdb.h chdb.hpp
       - name: Upload libchdb.so to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -720,12 +720,14 @@ jobs:
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf linux-x86_64-libchdb.tar.gz libchdb.so chdb.h chdb.hpp
       - name: Package libchdb.a
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf linux-x86_64-libchdb-static.tar.gz libchdb.a chdb.h chdb.hpp
       - name: Upload libchdb.so to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -704,12 +704,14 @@ jobs:
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf macos-arm64-libchdb.tar.gz libchdb.so chdb.h chdb.hpp
       - name: Package libchdb.a
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf macos-arm64-libchdb-static.tar.gz libchdb.a chdb.h chdb.hpp
       - name: Upload libchdb.so to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -704,12 +704,14 @@ jobs:
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf macos-x86_64-libchdb.tar.gz libchdb.so chdb.h chdb.hpp
       - name: Package libchdb.a
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         run: |
           cp programs/local/chdb.h chdb.h
           cp programs/local/chdb.hpp chdb.hpp
+          chmod 0644 chdb.h chdb.hpp
           tar -czvf macos-x86_64-libchdb-static.tar.gz libchdb.a chdb.h chdb.hpp
       - name: Upload libchdb.so to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/chdb/vars.sh
+++ b/chdb/vars.sh
@@ -54,6 +54,10 @@ popd > /dev/null
 CHDB_HEADER="${PROJ_DIR}/programs/local/chdb.h"
 if [ -n "${CHDB_VERSION}" ] && [ -f "${CHDB_HEADER}" ]; then
     CHDB_HEADER_TMP=$(mktemp)
+    # mktemp creates the file 0600 and mv preserves that mode, which would leak
+    # a root-only chdb.h into the release tarballs (and onto users' machines
+    # via sudo installs). Restore world-readable perms before the rename.
+    chmod 0644 "${CHDB_HEADER_TMP}"
     sed -E 's|^#define CHDB_VERSION ".*"|#define CHDB_VERSION "'"${CHDB_VERSION}"'"|' \
         "${CHDB_HEADER}" > "${CHDB_HEADER_TMP}" && mv "${CHDB_HEADER_TMP}" "${CHDB_HEADER}"
 fi


### PR DESCRIPTION
Fixes #194.

The CHDB_VERSION stamping added in 3873762a579 rewrites `programs/local/chdb.h` via `mktemp` + `mv`. `mktemp` creates its file 0600 and `mv` preserves that mode, so `chdb.h` inside every v26.7.0 `*-libchdb*.tar.gz` asset is `-rw-------`, and `curl -sL https://lib.chdb.io | sudo -E bash` leaves `/usr/local/include/chdb.h` readable only by root (`fatal error: chdb.h: Permission denied` for non-root builds; reported through pg_chdb).

Two layers:

- `chdb/vars.sh`: `chmod 0644` the mktemp file before the rename — the root cause.
- The eight libchdb packaging steps in the four wheel workflows: `chmod 0644 chdb.h chdb.hpp` before `tar -czvf`, so a stray restrictive mode in the workspace can never reach a release tarball again.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `0644` permissions on `chdb.h` and `chdb.hpp` in libchdb release tarballs
> Adds `chmod 0644 chdb.h chdb.hpp` before archiving in all four wheel-build workflows so the headers are world-readable inside the tarballs instead of inheriting restrictive modes. Also fixes `chdb/vars.sh` to `chmod 0644` the mktemp intermediate before moving it over `programs/local/chdb.h`, preventing the default `0600` from persisting after version updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e16950.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->