### PR TITLE
Apply connection argv settings to the connection's own session

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -315,6 +315,7 @@ jobs:
           bash -x ./examples/runStreamInsertTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
+          bash -x ./examples/runConnSettingsTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -300,6 +300,7 @@ jobs:
           bash -x ./examples/runStreamInsertTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
+          bash -x ./examples/runConnSettingsTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -338,6 +338,7 @@ jobs:
           bash -x ./examples/runStreamInsertTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
+          bash -x ./examples/runConnSettingsTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -339,6 +339,7 @@ jobs:
           bash -x ./examples/runStreamInsertTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
+          bash -x ./examples/runConnSettingsTest.sh
           bash -x ./examples/runStackTraceTest.sh
           bash -x ./examples/runStreamErrorTest.sh
           bash -x ./examples/runQueryParamsTest.sh

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -1485,7 +1485,7 @@ def connect(connection_string: str = ":memory:") -> Connection:
             Query parameters are passed to ClickHouse engine as startup arguments.
             Special parameter handling:
 
-            - "mode=ro" becomes "--readonly=1" (read-only mode)
+            - "mode=ro" becomes "--readonly=2" (read-only: writes and DDL rejected, per-query settings still allowed)
             - "progress=tty" enables progress bar (TTY output)
             - "progress=err" enables progress bar (stderr output)
             - "progress=off" disables progress bar
@@ -1495,6 +1495,21 @@ def connect(connection_string: str = ":memory:") -> Connection:
             - "progress-table=off" disables progress table
             - "verbose" enables verbose logging
             - "log-level=test" sets logging level
+
+            **Query-level settings:**
+
+            Any parameter naming a ClickHouse query-level setting is applied to
+            this connection's session only, exactly as if the connection had
+            executed ``SET <setting> = <value>`` right after connecting:
+
+            - ":memory:?max_threads=4" - this connection uses at most 4 threads
+            - ":memory:?output_format_json_quote_denormals=1" - quote nan/inf
+              in this connection's JSON output
+            - ":memory:?final" - bare flags set boolean settings to 1
+
+            Connections to the same path do not share these settings — each
+            keeps its own. An invalid value for a known setting makes the
+            connection fail.
 
             For complete parameter list, see ``clickhouse local --help --verbose``
 

--- a/examples/chdbConnSettingsTest.c
+++ b/examples/chdbConnSettingsTest.c
@@ -7,16 +7,25 @@
  * connections to the same path keep isolated settings, exactly as if each
  * had executed SET right after connecting.
  *
- * Covers the forms only reachable from the raw C API (the Python DSN always
- * emits --key=value):
- *   - --key=value, incl. a value on an aliased/experimental setting
+ * Mirrors tests/test_connection_argv_settings.py case for case, plus the
+ * forms only reachable from the raw C API (the Python DSN always emits
+ * --key=value):
+ *   - --key=value, incl. negative values and an aliased/experimental
+ *     setting asserted functionally (Nullable(Tuple) usable), not just via
+ *     its reported value
  *   - two-token "--key value", incl. a negative value ("--key -1")
  *   - bare boolean flag ("--final")
- *   - isolation between two simultaneous connections on the same path
- *   - per-query SETTINGS clause still overriding the connection-level value
+ *   - isolation between two simultaneous connections on the same path,
+ *     and no inheritance by a later plain connection
+ *   - per-query SETTINGS clause overriding the connection-level value
+ *     without changing it
+ *   - SET on one connection persisting there and not leaking to another
+ *   - settings not surviving an engine restart (all connections closed)
+ *   - unknown --keys ignored (left to the server-option config layer)
  *   - invalid value: chdb_connect returns NULL, existing connections keep
  *     working, and the failed connect does not pin the engine's refcount
- *     (a later connect succeeds).
+ *   - --readonly=2 on a file-backed path: writes rejected, reads and
+ *     per-query SETTINGS still allowed (what the Python DSN mode=ro maps to)
  *
  * Build (against an already-built libchdb.so):
  *   clang examples/chdbConnSettingsTest.c -I./programs/local -L. -lchdb -o examples/chdbConnSettingsTest
@@ -39,19 +48,19 @@ static int g_failed = 0;
         }                                                                  \
     } while (0)
 
-/// Runs a query and copies its output (or "<ERR>" on error) into buf.
+/// Runs a query and copies its output (or "<ERR:message>" on error) into buf.
 static void query_into(chdb_connection conn, const char * sql, const char * fmt, char * buf, size_t buf_size)
 {
     buf[0] = '\0';
     chdb_result * r = chdb_query(conn, sql, fmt);
     if (!r)
     {
-        snprintf(buf, buf_size, "<ERR>");
+        snprintf(buf, buf_size, "<ERR:null result>");
         return;
     }
     const char * err = chdb_result_error(r);
     if (err)
-        snprintf(buf, buf_size, "<ERR>");
+        snprintf(buf, buf_size, "<ERR:%s>", err);
     else
     {
         size_t len = chdb_result_length(r);
@@ -66,55 +75,106 @@ static void query_into(chdb_connection conn, const char * sql, const char * fmt,
     chdb_destroy_query_result(r);
 }
 
-int main(void)
+static int is_error(const char * buf)
 {
-    char buf[256];
+    return strncmp(buf, "<ERR:", 5) == 0;
+}
 
-    /// Connection A: =-form values, an experimental (aliased) setting, and a
-    /// bare boolean flag.
+static int is_true(const char * buf)
+{
+    return strcmp(buf, "true") == 0 || strcmp(buf, "1") == 0;
+}
+
+/// value,changed of a setting as seen by this connection, e.g. "8,0".
+static void setting_row(chdb_connection conn, const char * name, char * buf, size_t buf_size)
+{
+    char sql[256];
+    snprintf(sql, sizeof(sql), "SELECT changed FROM system.settings WHERE name = '%s'", name);
+    query_into(conn, sql, "CSV", buf, buf_size);
+}
+
+/// Phase 1: everything on the shared default (:memory:) path.
+static void test_memory_path(void)
+{
+    char buf[512];
+
+    /// Connection A: =-form values (incl. a negative one), an experimental
+    /// (aliased) setting, and a bare boolean flag — the reporter's exact
+    /// flags from #191 among them.
     char * argv_a[] = {
         "clickhouse",
         "--output_format_json_quote_denormals=1",
         "--allow_experimental_nullable_tuple_type=1",
         "--max_threads=1",
+        "--max_partitions_to_read=-1",
         "--final"};
-    chdb_connection * a = chdb_connect(5, argv_a);
+    chdb_connection * a = chdb_connect(6, argv_a);
     CHECK(a != NULL, "connection A with settings argv connects");
     if (!a)
-        return 1;
+        return;
 
-    /// Connection B: two-token form with a negative value, on the same
-    /// (default) path while A is open.
+    /// Connection B: two-token form with a negative value, open on the same
+    /// path while A is open.
     char * argv_b[] = {"clickhouse", "--max_threads", "2", "--max_partitions_to_read", "-1"};
     chdb_connection * b = chdb_connect(5, argv_b);
     CHECK(b != NULL, "connection B with two-token argv connects");
     if (!b)
-        return 1;
+        return;
 
-    /// A's settings took effect...
-    query_into(*a, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
-    CHECK(strcmp(buf, "{\"x\":\"nan\"}") == 0, "A: output_format_json_quote_denormals=1 quotes nan");
-    query_into(*a, "SELECT getSetting('allow_experimental_nullable_tuple_type')", "CSV", buf, sizeof(buf));
-    CHECK(strcmp(buf, "true") == 0 || strcmp(buf, "1") == 0, "A: experimental setting applied");
+    /// A's settings took effect: reported values...
     query_into(*a, "SELECT getSetting('max_threads')", "CSV", buf, sizeof(buf));
     CHECK(strcmp(buf, "1") == 0, "A: max_threads=1 applied");
+    query_into(*a, "SELECT getSetting('max_partitions_to_read')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "-1") == 0, "A: =-form negative value applied as -1");
     query_into(*a, "SELECT getSetting('final')", "CSV", buf, sizeof(buf));
-    CHECK(strcmp(buf, "true") == 0 || strcmp(buf, "1") == 0, "A: bare --final means 1");
+    CHECK(is_true(buf), "A: bare --final means 1");
+    setting_row(*a, "output_format_json_quote_denormals", buf, sizeof(buf));
+    CHECK(strcmp(buf, "1") == 0, "A: setting is marked changed in system.settings");
 
-    /// ...and did not leak into B, whose own settings also took effect.
+    /// ...and actual query behavior.
+    query_into(*a, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
+    CHECK(strcmp(buf, "{\"x\":\"nan\"}") == 0, "A: output_format_json_quote_denormals=1 quotes nan");
+    query_into(*a, "SELECT CAST(NULL, 'Nullable(Tuple(Int32))') AS t", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "\\N") == 0, "A: experimental Nullable(Tuple) actually usable");
+
+    /// B has its own settings and inherited nothing from A.
     query_into(*b, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
     CHECK(strcmp(buf, "{\"x\":null}") == 0, "B: default JSON denormal rendering (no leak from A)");
     query_into(*b, "SELECT getSetting('max_threads')", "CSV", buf, sizeof(buf));
     CHECK(strcmp(buf, "2") == 0, "B: two-token --max_threads 2 applied");
     query_into(*b, "SELECT getSetting('max_partitions_to_read')", "CSV", buf, sizeof(buf));
     CHECK(strcmp(buf, "-1") == 0, "B: two-token negative value parsed as -1, not mangled to 1");
+    query_into(*b, "SELECT CAST(NULL, 'Nullable(Tuple(Int32))') AS t", "CSV", buf, sizeof(buf));
+    CHECK(is_error(buf), "B: experimental type still rejected without the setting");
 
-    /// Per-query SETTINGS clause still overrides the connection-level value,
+    /// A's isolated view is intact after B's queries.
+    query_into(*a, "SELECT getSetting('max_threads')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "1") == 0, "A: value unchanged after B ran queries");
+
+    /// Per-query SETTINGS clause overrides the connection-level value,
     /// without changing it.
     query_into(*a, "SELECT nan AS x SETTINGS output_format_json_quote_denormals = 0", "JSONEachRow", buf, sizeof(buf));
     CHECK(strcmp(buf, "{\"x\":null}") == 0, "A: per-query SETTINGS overrides connection argv");
     query_into(*a, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
     CHECK(strcmp(buf, "{\"x\":\"nan\"}") == 0, "A: connection-level value intact after the override");
+
+    /// SET persists on the issuing connection and stays isolated from others.
+    query_into(*b, "SET output_format_json_quote_denormals = 1", "CSV", buf, sizeof(buf));
+    CHECK(!is_error(buf), "B: SET accepted");
+    query_into(*b, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
+    CHECK(strcmp(buf, "{\"x\":\"nan\"}") == 0, "B: SET persists for later queries on the same connection");
+
+    /// Unknown --keys are ignored, not errors (they belong to the
+    /// server-option config layer).
+    char * argv_u[] = {"clickhouse", "--definitely_not_a_chdb_setting=42"};
+    chdb_connection * u = chdb_connect(2, argv_u);
+    CHECK(u != NULL, "unknown option is ignored, connect succeeds");
+    if (u)
+    {
+        query_into(*u, "SELECT 1", "CSV", buf, sizeof(buf));
+        CHECK(strcmp(buf, "1") == 0, "connection with unknown option works");
+        chdb_close_conn(u);
+    }
 
     /// An invalid value for a known setting must fail the connect...
     char * argv_c[] = {"clickhouse", "--max_threads=bogus"};
@@ -122,7 +182,7 @@ int main(void)
     CHECK(c == NULL, "invalid setting value is rejected at connect time");
 
     /// ...without harming live connections or pinning the engine's refcount
-    /// (a later connect must still succeed).
+    /// (a later connect must still succeed and inherit nothing).
     query_into(*a, "SELECT 1", "CSV", buf, sizeof(buf));
     CHECK(strcmp(buf, "1") == 0, "A still works after the rejected connect");
     char * argv_d[] = {"clickhouse"};
@@ -130,13 +190,67 @@ int main(void)
     CHECK(d != NULL, "a later plain connect succeeds (no refcount leak from the failure)");
     if (d)
     {
-        query_into(*d, "SELECT changed FROM system.settings WHERE name = 'max_threads'", "CSV", buf, sizeof(buf));
+        setting_row(*d, "max_threads", buf, sizeof(buf));
         CHECK(strcmp(buf, "0") == 0, "plain connection inherited neither A's nor B's max_threads");
         chdb_close_conn(d);
     }
 
     chdb_close_conn(b);
     chdb_close_conn(a);
+
+    /// All connections are gone, so the engine restarted: settings must not
+    /// survive into a fresh connection.
+    chdb_connection * e = chdb_connect(1, argv_d);
+    CHECK(e != NULL, "reconnect after full shutdown succeeds");
+    if (e)
+    {
+        setting_row(*e, "max_threads", buf, sizeof(buf));
+        CHECK(strcmp(buf, "0") == 0, "settings do not survive an engine restart");
+        setting_row(*e, "output_format_json_quote_denormals", buf, sizeof(buf));
+        CHECK(strcmp(buf, "0") == 0, "format setting does not survive an engine restart");
+        chdb_close_conn(e);
+    }
+}
+
+/// Phase 2: file-backed path (runs after phase 1 released the engine).
+/// --readonly=2 is what the Python DSN mode=ro maps to: writes and DDL are
+/// rejected, but reads and per-query settings tuning still work.
+static void test_readonly_file_path(void)
+{
+    char buf[512];
+    static const char * dir = "chdb_conn_settings_test_db"; /// cleaned by runConnSettingsTest.sh
+
+    char * argv_rw[] = {"clickhouse", "--path=chdb_conn_settings_test_db"};
+    chdb_connection * rw = chdb_connect(2, argv_rw);
+    CHECK(rw != NULL, "file-backed rw connection connects");
+    if (!rw)
+        return;
+    (void)dir;
+    query_into(*rw, "CREATE TABLE conn_settings_ro_t (x Int32) ENGINE = MergeTree() ORDER BY x", "CSV", buf, sizeof(buf));
+    CHECK(!is_error(buf), "rw: CREATE TABLE works");
+    query_into(*rw, "INSERT INTO conn_settings_ro_t VALUES (7)", "CSV", buf, sizeof(buf));
+    CHECK(!is_error(buf), "rw: INSERT works");
+    chdb_close_conn(rw);
+
+    char * argv_ro[] = {"clickhouse", "--path=chdb_conn_settings_test_db", "--readonly=2"};
+    chdb_connection * ro = chdb_connect(3, argv_ro);
+    CHECK(ro != NULL, "file-backed readonly connection connects");
+    if (!ro)
+        return;
+    query_into(*ro, "SELECT x FROM conn_settings_ro_t", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "7") == 0, "ro: reads work");
+    query_into(*ro, "SELECT x FROM conn_settings_ro_t SETTINGS max_threads = 1", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "7") == 0, "ro: per-query SETTINGS still allowed under readonly=2");
+    query_into(*ro, "INSERT INTO conn_settings_ro_t VALUES (8)", "CSV", buf, sizeof(buf));
+    CHECK(is_error(buf), "ro: writes are rejected");
+    chdb_close_conn(ro);
+}
+
+int main(void)
+{
+    test_memory_path();
+    if (!g_failed)
+        test_readonly_file_path();
 
     if (g_failed)
     {

--- a/examples/chdbConnSettingsTest.c
+++ b/examples/chdbConnSettingsTest.c
@@ -1,0 +1,148 @@
+/**
+ * chdbConnSettingsTest.c
+ *
+ * Connection-argv settings through the C API (chdb-io/chdb-core#191):
+ * arguments naming a query-level setting (--key=value, --key value, bare
+ * --key) must be applied to that connection's own session, so concurrent
+ * connections to the same path keep isolated settings, exactly as if each
+ * had executed SET right after connecting.
+ *
+ * Covers the forms only reachable from the raw C API (the Python DSN always
+ * emits --key=value):
+ *   - --key=value, incl. a value on an aliased/experimental setting
+ *   - two-token "--key value", incl. a negative value ("--key -1")
+ *   - bare boolean flag ("--final")
+ *   - isolation between two simultaneous connections on the same path
+ *   - per-query SETTINGS clause still overriding the connection-level value
+ *   - invalid value: chdb_connect returns NULL, existing connections keep
+ *     working, and the failed connect does not pin the engine's refcount
+ *     (a later connect succeeds).
+ *
+ * Build (against an already-built libchdb.so):
+ *   clang examples/chdbConnSettingsTest.c -I./programs/local -L. -lchdb -o examples/chdbConnSettingsTest
+ *   LD_LIBRARY_PATH=. ./examples/chdbConnSettingsTest
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "chdb.h"
+
+static int g_failed = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "  ASSERT FAIL: %s (%s:%d)\n",                 \
+                    (msg), __FILE__, __LINE__);                           \
+            g_failed = 1;                                                  \
+        }                                                                  \
+    } while (0)
+
+/// Runs a query and copies its output (or "<ERR>" on error) into buf.
+static void query_into(chdb_connection conn, const char * sql, const char * fmt, char * buf, size_t buf_size)
+{
+    buf[0] = '\0';
+    chdb_result * r = chdb_query(conn, sql, fmt);
+    if (!r)
+    {
+        snprintf(buf, buf_size, "<ERR>");
+        return;
+    }
+    const char * err = chdb_result_error(r);
+    if (err)
+        snprintf(buf, buf_size, "<ERR>");
+    else
+    {
+        size_t len = chdb_result_length(r);
+        if (len >= buf_size)
+            len = buf_size - 1;
+        memcpy(buf, chdb_result_buffer(r), len);
+        buf[len] = '\0';
+        /// Trim trailing newline for easy strcmp.
+        while (len > 0 && buf[len - 1] == '\n')
+            buf[--len] = '\0';
+    }
+    chdb_destroy_query_result(r);
+}
+
+int main(void)
+{
+    char buf[256];
+
+    /// Connection A: =-form values, an experimental (aliased) setting, and a
+    /// bare boolean flag.
+    char * argv_a[] = {
+        "clickhouse",
+        "--output_format_json_quote_denormals=1",
+        "--allow_experimental_nullable_tuple_type=1",
+        "--max_threads=1",
+        "--final"};
+    chdb_connection * a = chdb_connect(5, argv_a);
+    CHECK(a != NULL, "connection A with settings argv connects");
+    if (!a)
+        return 1;
+
+    /// Connection B: two-token form with a negative value, on the same
+    /// (default) path while A is open.
+    char * argv_b[] = {"clickhouse", "--max_threads", "2", "--max_partitions_to_read", "-1"};
+    chdb_connection * b = chdb_connect(5, argv_b);
+    CHECK(b != NULL, "connection B with two-token argv connects");
+    if (!b)
+        return 1;
+
+    /// A's settings took effect...
+    query_into(*a, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
+    CHECK(strcmp(buf, "{\"x\":\"nan\"}") == 0, "A: output_format_json_quote_denormals=1 quotes nan");
+    query_into(*a, "SELECT getSetting('allow_experimental_nullable_tuple_type')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "true") == 0 || strcmp(buf, "1") == 0, "A: experimental setting applied");
+    query_into(*a, "SELECT getSetting('max_threads')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "1") == 0, "A: max_threads=1 applied");
+    query_into(*a, "SELECT getSetting('final')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "true") == 0 || strcmp(buf, "1") == 0, "A: bare --final means 1");
+
+    /// ...and did not leak into B, whose own settings also took effect.
+    query_into(*b, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
+    CHECK(strcmp(buf, "{\"x\":null}") == 0, "B: default JSON denormal rendering (no leak from A)");
+    query_into(*b, "SELECT getSetting('max_threads')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "2") == 0, "B: two-token --max_threads 2 applied");
+    query_into(*b, "SELECT getSetting('max_partitions_to_read')", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "-1") == 0, "B: two-token negative value parsed as -1, not mangled to 1");
+
+    /// Per-query SETTINGS clause still overrides the connection-level value,
+    /// without changing it.
+    query_into(*a, "SELECT nan AS x SETTINGS output_format_json_quote_denormals = 0", "JSONEachRow", buf, sizeof(buf));
+    CHECK(strcmp(buf, "{\"x\":null}") == 0, "A: per-query SETTINGS overrides connection argv");
+    query_into(*a, "SELECT nan AS x", "JSONEachRow", buf, sizeof(buf));
+    CHECK(strcmp(buf, "{\"x\":\"nan\"}") == 0, "A: connection-level value intact after the override");
+
+    /// An invalid value for a known setting must fail the connect...
+    char * argv_c[] = {"clickhouse", "--max_threads=bogus"};
+    chdb_connection * c = chdb_connect(2, argv_c);
+    CHECK(c == NULL, "invalid setting value is rejected at connect time");
+
+    /// ...without harming live connections or pinning the engine's refcount
+    /// (a later connect must still succeed).
+    query_into(*a, "SELECT 1", "CSV", buf, sizeof(buf));
+    CHECK(strcmp(buf, "1") == 0, "A still works after the rejected connect");
+    char * argv_d[] = {"clickhouse"};
+    chdb_connection * d = chdb_connect(1, argv_d);
+    CHECK(d != NULL, "a later plain connect succeeds (no refcount leak from the failure)");
+    if (d)
+    {
+        query_into(*d, "SELECT changed FROM system.settings WHERE name = 'max_threads'", "CSV", buf, sizeof(buf));
+        CHECK(strcmp(buf, "0") == 0, "plain connection inherited neither A's nor B's max_threads");
+        chdb_close_conn(d);
+    }
+
+    chdb_close_conn(b);
+    chdb_close_conn(a);
+
+    if (g_failed)
+    {
+        fprintf(stderr, "chdbConnSettingsTest: FAILED\n");
+        return 1;
+    }
+    printf("chdbConnSettingsTest: OK\n");
+    return 0;
+}

--- a/examples/chdbConnSettingsTest.c
+++ b/examples/chdbConnSettingsTest.c
@@ -181,13 +181,15 @@ static void test_memory_path(void)
     chdb_connection * c = chdb_connect(2, argv_c);
     CHECK(c == NULL, "invalid setting value is rejected at connect time");
 
-    /// ...without harming live connections or pinning the engine's refcount
-    /// (a later connect must still succeed and inherit nothing).
+    /// ...without harming live connections; a later same-path connect must
+    /// succeed and inherit nothing. (A same-path connect cannot detect a
+    /// leaked engine reference — the discriminating check is phase 2's
+    /// different-path connect after full shutdown.)
     query_into(*a, "SELECT 1", "CSV", buf, sizeof(buf));
     CHECK(strcmp(buf, "1") == 0, "A still works after the rejected connect");
     char * argv_d[] = {"clickhouse"};
     chdb_connection * d = chdb_connect(1, argv_d);
-    CHECK(d != NULL, "a later plain connect succeeds (no refcount leak from the failure)");
+    CHECK(d != NULL, "a later plain connect succeeds while A/B stay open");
     if (d)
     {
         setting_row(*d, "max_threads", buf, sizeof(buf));
@@ -220,9 +222,13 @@ static void test_readonly_file_path(void)
     char buf[512];
     static const char * dir = "chdb_conn_settings_test_db"; /// cleaned by runConnSettingsTest.sh
 
+    /// This different-path connect doubles as the refcount-leak regression
+    /// check: phase 1's rejected connect (--max_threads=bogus) must have
+    /// released its engine reference, otherwise the engine is still pinned
+    /// to ':memory:' and connecting to this path throws BAD_ARGUMENTS.
     char * argv_rw[] = {"clickhouse", "--path=chdb_conn_settings_test_db"};
     chdb_connection * rw = chdb_connect(2, argv_rw);
-    CHECK(rw != NULL, "file-backed rw connection connects");
+    CHECK(rw != NULL, "different-path connect succeeds: the failed connect did not pin the engine");
     if (!rw)
         return;
     (void)dir;

--- a/examples/runConnSettingsTest.sh
+++ b/examples/runConnSettingsTest.sh
@@ -25,4 +25,6 @@ export ${LIB_PATH}=..
 ${LDD} chdbConnSettingsTest
 
 echo "Run it:"
+rm -rf chdb_conn_settings_test_db
 ./chdbConnSettingsTest
+rm -rf chdb_conn_settings_test_db

--- a/examples/runConnSettingsTest.sh
+++ b/examples/runConnSettingsTest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+echo "Compile and link"
+${CC:-clang} chdbConnSettingsTest.c -o chdbConnSettingsTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbConnSettingsTest
+
+echo "Run it:"
+./chdbConnSettingsTest

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -12,6 +12,7 @@
 #include <Common/Config/ConfigHelper.h>
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
+#include <Common/SettingsChanges.h>
 #include <Core/Settings.h>
 #include <Core/Block.h>
 #include <Formats/FormatFactory.h>
@@ -47,7 +48,7 @@ namespace Setting
     extern const SettingsUInt64 min_insert_block_size_bytes;
 }
 
-ChdbClient::ChdbClient(EmbeddedServer & server_ref)
+ChdbClient::ChdbClient(EmbeddedServer & server_ref, int argc, char ** argv)
     : ClientBase()
     , server(server_ref)
 {
@@ -72,6 +73,7 @@ ChdbClient::ChdbClient(EmbeddedServer & server_ref)
     global_context = session->makeSessionContext();
     global_context->setCurrentDatabase("default");
     global_context->setApplicationType(Context::ApplicationType::LOCAL);
+    applyCmdSettings(argc, argv);
     initClientContext(global_context);
     server_display_name = "chDB-embedded";
     query_processing_stage = QueryProcessingStage::Enum::Complete;
@@ -86,9 +88,69 @@ ChdbClient::ChdbClient(EmbeddedServer & server_ref)
     initKeystrokeInterceptor();
 }
 
-std::unique_ptr<ChdbClient> ChdbClient::create(EmbeddedServer & server_ref)
+std::unique_ptr<ChdbClient> ChdbClient::create(EmbeddedServer & server_ref, int argc, char ** argv)
 {
-    return std::make_unique<ChdbClient>(server_ref);
+    return std::make_unique<ChdbClient>(server_ref, argc, argv);
+}
+
+/// Forward every connection argument that names a query-level setting into
+/// this client's session context — the same place a `SET` statement writes —
+/// giving clickhouse-local's `--setting=value` semantics per connection.
+/// EmbeddedServer is a process-wide singleton that only reads argv when the
+/// first connection boots it, so without this, settings passed to
+/// chdb_connect() were silently swallowed into its config layer (#191); with
+/// it, every connection (not just the first) gets its own isolated settings,
+/// because each session context is a copy of the server context.
+/// Recognized forms mirror argsToConfig: --key=value, --key value, and bare
+/// --key meaning "1". Keys that are not built-in settings are left to the
+/// config layer (server options like --path); an invalid value for a known
+/// setting throws, failing the connection like clickhouse-local would.
+void ChdbClient::applyCmdSettings(int argc, char ** argv)
+{
+    if (argc <= 1 || !argv)
+        return;
+
+    SettingsChanges changes;
+    for (int i = 1; i < argc; ++i)
+    {
+        if (!argv[i])
+            continue;
+        std::string_view arg = argv[i];
+        if (!arg.starts_with("--") || arg.size() <= 2)
+            continue;
+        arg.remove_prefix(2);
+
+        String key;
+        String value;
+        if (auto pos = arg.find('='); pos != std::string_view::npos)
+        {
+            key = String(arg.substr(0, pos));
+            value = String(arg.substr(pos + 1));
+        }
+        else
+        {
+            key = String(arg);
+            /// Space-separated value; do not advance i — the value token is
+            /// harmless to re-scan since it does not start with "--".
+            /// A dash-leading token counts as the value only when it is a
+            /// negative number (e.g. --max_partitions_to_read -1); any other
+            /// dash-leading token is the next option, making this key a bare
+            /// boolean flag.
+            if (i + 1 < argc && argv[i + 1]
+                && (argv[i + 1][0] != '-'
+                    || (argv[i + 1][1] >= '0' && argv[i + 1][1] <= '9')
+                    || argv[i + 1][1] == '.'))
+                value = argv[i + 1];
+            else
+                value = "1";
+        }
+
+        if (!key.empty() && Settings::hasBuiltin(key))
+            changes.emplace_back(key, value);
+    }
+
+    if (!changes.empty())
+        global_context->applySettingsChanges(changes);
 }
 
 ChdbClient::~ChdbClient()

--- a/programs/local/ChdbClient.h
+++ b/programs/local/ChdbClient.h
@@ -26,9 +26,14 @@ class EmbeddedServer;
 class ChdbClient : public ClientBase
 {
 public:
-    static std::unique_ptr<ChdbClient> create(EmbeddedServer & server_ref);
+    /// argc/argv are the connection's command-line style arguments. Arguments
+    /// naming a query-level setting (--max_threads=4, --final, ...) are applied
+    /// to this client's session only, so concurrent connections to the same
+    /// path keep isolated settings; server-level options are consumed once by
+    /// EmbeddedServer when it boots.
+    static std::unique_ptr<ChdbClient> create(EmbeddedServer & server_ref, int argc = 0, char ** argv = nullptr);
 
-    explicit ChdbClient(EmbeddedServer & server_ref);
+    explicit ChdbClient(EmbeddedServer & server_ref, int argc = 0, char ** argv = nullptr);
     ~ChdbClient() override;
 
     CHDB::QueryResultPtr executeMaterializedQuery(const char * query, size_t query_len, const char * format, size_t format_len);
@@ -96,6 +101,7 @@ protected:
 
 private:
     void cleanup();
+    void applyCmdSettings(int argc, char ** argv);
     bool parseQueryTextWithOutputFormat(const String & query, const String & format);
     void cancelStreamingQueryWithoutLock(void * streaming_result);
 

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -306,7 +306,11 @@ connection_wrapper::build_clickhouse_args(const std::string & path, const std::m
             if (value == "ro")
             {
                 is_readonly = true;
-                argv.push_back("--readonly=1");
+                /// readonly=2, not 1: writes and DDL are rejected, but the
+                /// connection may still tune per-query settings (SET /
+                /// SETTINGS clauses), matching what a SQLite-style mode=ro
+                /// promises. readonly=1 would reject those too.
+                argv.push_back("--readonly=2");
             }
         }
         else if (key == "--")

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -206,7 +206,21 @@ chdb_connection * connect_chdb_with_exception(int argc, char ** argv)
     {
         DB::ThreadStatus thread_status;
         auto & server = DB::EmbeddedServer::getInstance(argc, argv);
-        auto client = DB::ChdbClient::create(server);
+        std::unique_ptr<DB::ChdbClient> client;
+        try
+        {
+            client = DB::ChdbClient::create(server, argc, argv);
+        }
+        catch (...)
+        {
+            /// getInstance() already counted this connection, and only a fully
+            /// constructed ChdbClient releases it from its destructor — without
+            /// this release a failed connect (e.g. an invalid --setting value)
+            /// would pin the engine alive forever, blocking any later connect
+            /// with a different path.
+            DB::EmbeddedServer::releaseInstance();
+            throw;
+        }
         if (!client)
         {
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Failed to create ChdbClient");

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -136,6 +136,14 @@ CHDB_EXPORT void free_result_v2(struct local_result_v2 * result);
  * same path may be open at once. Connecting with a different path requires
  * closing all existing connections first.
  *
+ * Arguments naming a ClickHouse query-level setting (--<setting>=<value>,
+ * e.g. --max_threads=4 or --output_format_json_quote_denormals=1) apply to
+ * this connection only, exactly as if it had executed SET <setting> = <value>:
+ * concurrent connections to the same path each keep their own settings.
+ * An invalid value for a known setting fails the connection. Server-level
+ * options (--path=..., --user_scripts_path=..., logging options, ...) are consumed by
+ * the connection that boots the engine and ignored afterwards.
+ *
  * @param argc Number of command-line arguments
  * @param argv Command-line arguments array (--path=<db_path> to specify database location)
  * @return Pointer to connection pointer, or NULL on failure
@@ -254,6 +262,14 @@ CHDB_EXPORT void chdb_streaming_cancel_query(struct chdb_conn * conn, chdb_strea
  * The engine uses one storage path per process: multiple connections to that
  * same path may be open at once. Connecting with a different path requires
  * closing all existing connections first.
+ *
+ * Arguments naming a ClickHouse query-level setting (--<setting>=<value>,
+ * e.g. --max_threads=4 or --output_format_json_quote_denormals=1) apply to
+ * this connection only, exactly as if it had executed SET <setting> = <value>:
+ * concurrent connections to the same path each keep their own settings.
+ * An invalid value for a known setting fails the connection. Server-level
+ * options (--path=..., --user_scripts_path=..., logging options, ...) are consumed by
+ * the connection that boots the engine and ignored afterwards.
  *
  * @param argc Number of command-line arguments
  * @param argv Command-line arguments array (--path=<db_path> to specify database location)

--- a/tests/test_connection_argv_settings.py
+++ b/tests/test_connection_argv_settings.py
@@ -94,10 +94,24 @@ class TestConnectionArgvSettings(unittest.TestCase):
             conn_b.close()
 
     def test_experimental_setting_via_connection_arg(self):
+        # Without the setting, Nullable(Tuple(...)) is rejected outright.
+        plain = connect(":memory:")
+        try:
+            with self.assertRaisesRegex(Exception, "Nullable Tuple type is not allowed"):
+                plain.query("SELECT CAST(NULL, 'Nullable(Tuple(Int32))') AS t", "CSV")
+        finally:
+            plain.close()
         conn = connect(":memory:?allow_experimental_nullable_tuple_type=1")
         try:
             self.assertEqual(
                 setting_row(conn, "allow_experimental_nullable_tuple_type"), ("1", 1)
+            )
+            # And the gated type actually works on this connection.
+            self.assertEqual(
+                str(
+                    conn.query("SELECT CAST(NULL, 'Nullable(Tuple(Int32))') AS t", "CSV")
+                ).strip(),
+                "\\N",
             )
         finally:
             conn.close()

--- a/tests/test_connection_argv_settings.py
+++ b/tests/test_connection_argv_settings.py
@@ -1,0 +1,214 @@
+#!python3
+
+import shutil
+import unittest
+
+from chdb.state.sqlitelike import connect
+
+
+def setting_row(conn, name):
+    """Return (value, changed) for a setting as seen by this connection."""
+    out = str(
+        conn.query(
+            f"SELECT value, changed FROM system.settings WHERE name = '{name}'",
+            "CSV",
+        )
+    ).strip()
+    value, changed = out.rsplit(",", 1)
+    return value.strip('"'), int(changed)
+
+
+class TestConnectionArgvSettings(unittest.TestCase):
+    """Settings passed as connection arguments (--<setting>=<value>) must be
+    applied to that connection's session, with clickhouse-local semantics:
+    visible in system.settings, effective on query behavior, and isolated
+    between connections sharing the same path (chdb-io/chdb-core#191)."""
+
+    def test_format_setting_via_connection_arg_reflected_in_system_settings(self):
+        conn = connect(":memory:?output_format_json_quote_denormals=1")
+        try:
+            self.assertEqual(
+                setting_row(conn, "output_format_json_quote_denormals"), ("1", 1)
+            )
+        finally:
+            conn.close()
+
+    def test_format_setting_via_connection_arg_affects_output(self):
+        conn = connect(":memory:?output_format_json_quote_denormals=1")
+        try:
+            out = str(conn.query("SELECT nan AS x", "JSONEachRow")).strip()
+            self.assertEqual(out, '{"x":"nan"}')
+        finally:
+            conn.close()
+
+    def test_connection_without_arg_keeps_default_behavior(self):
+        conn = connect(":memory:")
+        try:
+            self.assertEqual(
+                setting_row(conn, "output_format_json_quote_denormals"), ("0", 0)
+            )
+            out = str(conn.query("SELECT nan AS x", "JSONEachRow")).strip()
+            self.assertEqual(out, '{"x":null}')
+        finally:
+            conn.close()
+
+    def test_two_connections_same_path_have_isolated_settings(self):
+        conn_a = connect(":memory:?max_threads=1")
+        conn_b = connect(":memory:?max_threads=2")
+        try:
+            self.assertEqual(setting_row(conn_a, "max_threads"), ("1", 1))
+            self.assertEqual(setting_row(conn_b, "max_threads"), ("2", 1))
+            # Re-read A after B ran queries: B's value must not have leaked.
+            self.assertEqual(setting_row(conn_a, "max_threads"), ("1", 1))
+        finally:
+            conn_b.close()
+            conn_a.close()
+
+    def test_second_connection_does_not_inherit_first_connection_settings(self):
+        conn_a = connect(":memory:?output_format_json_quote_denormals=1")
+        conn_b = connect(":memory:")
+        try:
+            self.assertEqual(
+                setting_row(conn_b, "output_format_json_quote_denormals"), ("0", 0)
+            )
+            self.assertEqual(
+                str(conn_b.query("SELECT nan AS x", "JSONEachRow")).strip(),
+                '{"x":null}',
+            )
+            self.assertEqual(
+                str(conn_a.query("SELECT nan AS x", "JSONEachRow")).strip(),
+                '{"x":"nan"}',
+            )
+        finally:
+            conn_b.close()
+            conn_a.close()
+
+    def test_settings_do_not_survive_into_new_connection_after_close(self):
+        conn_a = connect(":memory:?max_threads=1")
+        conn_a.close()
+        conn_b = connect(":memory:")
+        try:
+            _, changed = setting_row(conn_b, "max_threads")
+            self.assertEqual(changed, 0)
+        finally:
+            conn_b.close()
+
+    def test_experimental_setting_via_connection_arg(self):
+        conn = connect(":memory:?allow_experimental_nullable_tuple_type=1")
+        try:
+            self.assertEqual(
+                setting_row(conn, "allow_experimental_nullable_tuple_type"), ("1", 1)
+            )
+        finally:
+            conn.close()
+
+    def test_multiple_settings_in_one_connection_string(self):
+        conn = connect(":memory:?max_threads=2&output_format_json_quote_denormals=1")
+        try:
+            self.assertEqual(setting_row(conn, "max_threads"), ("2", 1))
+            self.assertEqual(
+                str(conn.query("SELECT nan AS x", "JSONEachRow")).strip(),
+                '{"x":"nan"}',
+            )
+        finally:
+            conn.close()
+
+    def test_negative_setting_value_via_connection_arg(self):
+        conn = connect(":memory:?max_partitions_to_read=-1")
+        try:
+            self.assertEqual(setting_row(conn, "max_partitions_to_read"), ("-1", 1))
+        finally:
+            conn.close()
+
+    def test_bare_flag_sets_boolean_setting(self):
+        conn = connect(":memory:?final")
+        try:
+            self.assertEqual(setting_row(conn, "final"), ("1", 1))
+        finally:
+            conn.close()
+
+    def test_per_query_settings_clause_overrides_connection_arg(self):
+        conn = connect(":memory:?output_format_json_quote_denormals=1")
+        try:
+            out = str(
+                conn.query(
+                    "SELECT nan AS x SETTINGS output_format_json_quote_denormals = 0",
+                    "JSONEachRow",
+                )
+            ).strip()
+            self.assertEqual(out, '{"x":null}')
+            # The override is per query; the connection-level value is intact.
+            self.assertEqual(
+                str(conn.query("SELECT nan AS x", "JSONEachRow")).strip(),
+                '{"x":"nan"}',
+            )
+        finally:
+            conn.close()
+
+    def test_set_statement_stays_isolated_between_connections(self):
+        conn_a = connect(":memory:")
+        conn_b = connect(":memory:")
+        try:
+            conn_a.query("SET max_threads = 1")
+            self.assertEqual(setting_row(conn_a, "max_threads"), ("1", 1))
+            _, changed = setting_row(conn_b, "max_threads")
+            self.assertEqual(changed, 0)
+        finally:
+            conn_b.close()
+            conn_a.close()
+
+    def test_invalid_setting_value_fails_connection(self):
+        with self.assertRaisesRegex(Exception, "max_threads"):
+            connect(":memory:?max_threads=not_a_number")
+
+    def test_failed_connection_does_not_pin_engine_instance(self):
+        """A failed connect must release its engine reference; otherwise the
+        process-wide engine stays alive on the old path forever and any later
+        connect with a different path errors with 'already initialized'."""
+        with self.assertRaises(Exception):
+            connect(":memory:?max_threads=not_a_number")
+        test_dir = ".test_connection_argv_settings_leak"
+        shutil.rmtree(test_dir, ignore_errors=True)
+        conn = connect(f"file:{test_dir}")
+        try:
+            self.assertEqual(str(conn.query("SELECT 1", "CSV")).strip(), "1")
+        finally:
+            conn.close()
+            shutil.rmtree(test_dir, ignore_errors=True)
+
+    def test_unknown_option_is_still_ignored(self):
+        conn = connect(":memory:?definitely_not_a_chdb_setting=42")
+        try:
+            self.assertEqual(str(conn.query("SELECT 1", "CSV")).strip(), "1")
+        finally:
+            conn.close()
+
+    def test_mode_ro_enforces_readonly(self):
+        test_dir = ".test_connection_argv_settings_ro"
+        shutil.rmtree(test_dir, ignore_errors=True)
+        rw = connect(f"file:{test_dir}")
+        rw.query("CREATE TABLE argv_ro_t (x Int32) ENGINE = MergeTree() ORDER BY x")
+        rw.query("INSERT INTO argv_ro_t VALUES (7)")
+        rw.close()
+        conn = connect(f"file:{test_dir}?mode=ro")
+        try:
+            self.assertEqual(setting_row(conn, "readonly"), ("2", 1))
+            self.assertEqual(str(conn.query("SELECT x FROM argv_ro_t", "CSV")).strip(), "7")
+            # readonly=2 (not 1): per-query settings stay usable on a ro connection.
+            self.assertEqual(
+                str(
+                    conn.query(
+                        "SELECT x FROM argv_ro_t SETTINGS max_threads = 1", "CSV"
+                    )
+                ).strip(),
+                "7",
+            )
+            with self.assertRaisesRegex(Exception, "[Rr]eadonly"):
+                conn.query("INSERT INTO argv_ro_t VALUES (8)")
+        finally:
+            conn.close()
+            shutil.rmtree(test_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #191.

Settings passed to `chdb_connect()` as `--key=value` (and through the Python DSN, e.g. `:memory:?output_format_json_quote_denormals=1`) were silently ignored: `EmbeddedServer` flattens argv into its Poco config and never forwards setting-named keys into any `Settings` object, unlike clickhouse-local where every setting is registered as a program option and applied to the context. Only per-query `SETTINGS` clauses worked.

## What this does

`ChdbClient` now parses the connection's argv and applies every key that names a built-in query-level setting (`Settings::hasBuiltin`, so aliases like `allow_experimental_nullable_tuple_type` work) to **that connection's session context** — the same place a `SET` statement writes. Consequences:

- Every connection gets its settings honored, not just the one that boots the process-wide engine; concurrent connections to the same path keep fully isolated settings.
- Recognized forms mirror `argsToConfig`: `--key=value`, `--key value` (including negative numbers like `--max_partitions_to_read -1`), and bare `--key` meaning 1.
- Unknown keys stay config-only (server options like `--path` are untouched); an invalid value for a known setting fails the connection, like clickhouse-local.
- Since `ChdbClient` construction can now throw, `connect_chdb_with_exception` releases the `EmbeddedServer` reference taken by `getInstance()` on failure — previously a failed connect pinned the engine alive on its path forever, blocking any later connect with a different path.
- The Python DSN `mode=ro` flag, which used to be entirely inert, now takes effect through the same path. It maps to `readonly=2` (writes and DDL rejected) rather than `readonly=1`, so read-only connections can still tune per-query settings.

## Testing

`tests/test_connection_argv_settings.py` (16 cases): system.settings visibility, output-behavior effect (`SELECT nan` under `output_format_json_quote_denormals`), two simultaneous connections with different values on the same path, no inheritance across connections or after close, per-query `SETTINGS` override, `SET` isolation, negative values, bare flags, invalid value → connection error, failed connect not pinning the engine, unknown keys ignored, `mode=ro` enforcement. Verified the same scenarios against `libchdb.so` through the raw C API (two-token negative form included). Existing connection/session suites (`test_conn_cursor`, `test_session_concurrency`, `test_named_collection`, `test_open_session_after_failure`, `test_exit_open_connection`) pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply connection `argv` settings to the connection's own session
> - `ChdbClient` constructor now accepts `argc`/`argv` and calls `applyCmdSettings`, which parses `--key=value`, `--key value`, and bare `--key` forms, filters to built-in settings (`Settings::hasBuiltin`), and applies them to the session via `global_context->applySettingsChanges`. Non-setting keys are ignored; invalid values for known settings throw and fail the connection.
> - DSN `mode=ro` now maps to `--readonly=2` instead of `--readonly=1`, allowing per-query `SETTINGS` while still rejecting writes and DDL.
> - `connect_chdb_with_exception` wraps `ChdbClient` creation in a try/catch that calls `EmbeddedServer::releaseInstance()` on failure, so failed connects no longer pin the engine.
> - Adds C and Python test suites plus CI workflow steps to validate per-connection settings, isolation, `mode=ro` behavior, and engine-pin fix.
> - Risk: `mode=ro` semantics change — `build_clickhouse_args` in [LocalChdb.cpp](https://github.com/chdb-io/chdb-core/pull/196/files#diff-0082b16a50c64cd3e101506fd08019c9d11d435621e360df07c8f8837a0a5a14) now passes `--readonly=2`, which permits per-query `SETTINGS` on read-only file-backed connections; any caller relying on `readonly=1` (no per-query settings) will see different behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9574d77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->