### PR TITLE
Gate bundled runtime symbols in libchdb.a

### DIFF
--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -328,6 +328,13 @@ jobs:
         run: |
           bash ./chdb/build/test_go_example.sh ${{ github.workspace }}/libchdb.a
         continue-on-error: false
+      - name: Run chdb/build/check_static_lib_hermetic.sh
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        timeout-minutes: 60
+        run: |
+          bash ./chdb/build/check_static_lib_hermetic.sh \
+            ${{ github.workspace }}/libchdb.a \
+            ${{ github.workspace }}/programs/local/chdb.h
       - name: Run libchdb stub in examples dir
         run: |
           bash -x ./examples/runStub.sh

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -329,6 +329,13 @@ jobs:
         run: |
           bash ./chdb/build/test_go_example.sh ${{ github.workspace }}/libchdb.a
         continue-on-error: false
+      - name: Run chdb/build/check_static_lib_hermetic.sh
+        if: env.EFFECTIVE_DEBUG_MODE != 'true'
+        timeout-minutes: 60
+        run: |
+          bash ./chdb/build/check_static_lib_hermetic.sh \
+            ${{ github.workspace }}/libchdb.a \
+            ${{ github.workspace }}/programs/local/chdb.h
       - name: Run libchdb stub in examples dir
         run: |
           bash -x ./examples/runStub.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,6 +703,11 @@ endif ()
 
 include(cmake/dbms_glob_sources.cmake)
 
+# Must precede the default_libs.cmake dispatch below: that is what pulls in
+# cmake/unwind.cmake and cmake/cxx.cmake, which add_subdirectory() the libcxx, libcxxabi and
+# libunwind configurations. Those call hide_bundled_runtime(), so it has to exist by then.
+include (cmake/bundled_runtime_visibility.cmake)
+
 add_library(global-group INTERFACE)
 if (OS_LINUX OR OS_ANDROID)
     include(cmake/linux/default_libs.cmake)

--- a/chdb/build/build_static_lib.sh
+++ b/chdb/build/build_static_lib.sh
@@ -104,10 +104,7 @@ echo "Copied chdb.h and libchdb.a to cpp-example directory"
 echo "Compiling chdb_example.cpp..."
 if [ "$(uname)" == "Darwin" ]; then
     CLANG_CMD="$(brew --prefix llvm@21)/bin/clang"
-    # 12.0 is the first deployment target for which ld emits chained fixups. Below it the
-    # example links with none at all, which is what kept bundled-runtime symbol
-    # coalescing invisible on this path; check_static_lib_hermetic.sh uses the same floor.
-    ${CLANG_CMD} chdb_example.cpp -o chdb_example -mmacosx-version-min=12.0 -L. -lchdb -liconv -framework CoreFoundation -framework Security -Wl,-map,chdb_example.map
+    ${CLANG_CMD} chdb_example.cpp -o chdb_example -mmacosx-version-min=10.15 -L. -lchdb -liconv -framework CoreFoundation -framework Security -Wl,-map,chdb_example.map
 else
     CLANG_CMD="clang"
     ${CLANG_CMD} chdb_example.cpp -o chdb_example -L. -lchdb -lpthread -ldl -lc -lm -lrt -Wl,-Map=chdb_example.map -Wl,--allow-multiple-definition

--- a/chdb/build/build_static_lib.sh
+++ b/chdb/build/build_static_lib.sh
@@ -104,7 +104,10 @@ echo "Copied chdb.h and libchdb.a to cpp-example directory"
 echo "Compiling chdb_example.cpp..."
 if [ "$(uname)" == "Darwin" ]; then
     CLANG_CMD="$(brew --prefix llvm@21)/bin/clang"
-    ${CLANG_CMD} chdb_example.cpp -o chdb_example -mmacosx-version-min=10.15 -L. -lchdb -liconv -framework CoreFoundation -framework Security -Wl,-map,chdb_example.map
+    # 12.0 is the first deployment target for which ld emits chained fixups. Below it the
+    # example links with none at all, which is what kept bundled-runtime symbol
+    # coalescing invisible on this path; check_static_lib_hermetic.sh uses the same floor.
+    ${CLANG_CMD} chdb_example.cpp -o chdb_example -mmacosx-version-min=12.0 -L. -lchdb -liconv -framework CoreFoundation -framework Security -Wl,-map,chdb_example.map
 else
     CLANG_CMD="clang"
     ${CLANG_CMD} chdb_example.cpp -o chdb_example -L. -lchdb -lpthread -ldl -lc -lm -lrt -Wl,-Map=chdb_example.map -Wl,--allow-multiple-definition
@@ -159,3 +162,9 @@ echo "Final libchdb.a created at ${PROJ_DIR}/libchdb.a"
 # Print final library size
 echo "Final libchdb.a size:"
 ls -lh ${PROJ_DIR}/libchdb.a
+
+# Symbol gate for the archive: the bundled runtime must stay hidden and the C API must stay
+# reachable. macOS only - see chdb/build/check_static_lib_hermetic.sh.
+if [ "$(uname)" == "Darwin" ]; then
+    bash ${MY_DIR}/check_static_lib_hermetic.sh ${PROJ_DIR}/libchdb.a ${PROJ_DIR}/programs/local/chdb.h
+fi

--- a/chdb/build/build_static_lib.sh
+++ b/chdb/build/build_static_lib.sh
@@ -164,7 +164,5 @@ echo "Final libchdb.a size:"
 ls -lh ${PROJ_DIR}/libchdb.a
 
 # Symbol gate for the archive: the bundled runtime must stay hidden and the C API must stay
-# reachable. macOS only - see chdb/build/check_static_lib_hermetic.sh.
-if [ "$(uname)" == "Darwin" ]; then
-    bash ${MY_DIR}/check_static_lib_hermetic.sh ${PROJ_DIR}/libchdb.a ${PROJ_DIR}/programs/local/chdb.h
-fi
+# reachable. Runs on both platforms - see chdb/build/check_static_lib_hermetic.sh.
+bash ${MY_DIR}/check_static_lib_hermetic.sh ${PROJ_DIR}/libchdb.a ${PROJ_DIR}/programs/local/chdb.h

--- a/chdb/build/build_static_lib_mac_on_linux.sh
+++ b/chdb/build/build_static_lib_mac_on_linux.sh
@@ -27,14 +27,16 @@ if [ "$TARGET_ARCH" == "x86_64" ]; then
     DARWIN_TRIPLE="x86_64-apple-darwin"
     TOOLCHAIN_FILE="cmake/darwin/toolchain-x86_64.cmake"
     BUILD_DIR_SUFFIX="darwin-x86_64"
-    MACOS_MIN_VERSION="10.15"
+    # 12.0 is the first deployment target for which ld emits chained fixups; anything lower
+    # links chdb_example with none, hiding bundled-runtime symbol coalescing.
+    MACOS_MIN_VERSION="12.0"
     CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
 else
     # arm64
     DARWIN_TRIPLE="aarch64-apple-darwin"
     TOOLCHAIN_FILE="cmake/darwin/toolchain-aarch64.cmake"
     BUILD_DIR_SUFFIX="darwin-arm64"
-    MACOS_MIN_VERSION="11.0"
+    MACOS_MIN_VERSION="12.0"
     CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
 fi
 
@@ -227,3 +229,8 @@ echo "Final libchdb.a created at ${PROJ_DIR}/libchdb.a"
 # Print final library size
 echo "Final libchdb.a size:"
 ls -lh ${PROJ_DIR}/libchdb.a
+
+# Gate 3a of the archive symbol gate; it needs no macOS host, so it runs here for an early
+# signal. Gates 1/2/3b/4 need dyld_info and have to run the probe, so the CI job that picks
+# this artifact up on a real macOS runner invokes check_static_lib_hermetic.sh.
+python3 ${MY_DIR}/check_export_contract.py > /dev/null

--- a/chdb/build/build_static_lib_mac_on_linux.sh
+++ b/chdb/build/build_static_lib_mac_on_linux.sh
@@ -27,16 +27,14 @@ if [ "$TARGET_ARCH" == "x86_64" ]; then
     DARWIN_TRIPLE="x86_64-apple-darwin"
     TOOLCHAIN_FILE="cmake/darwin/toolchain-x86_64.cmake"
     BUILD_DIR_SUFFIX="darwin-x86_64"
-    # 12.0 is the first deployment target for which ld emits chained fixups; anything lower
-    # links chdb_example with none, hiding bundled-runtime symbol coalescing.
-    MACOS_MIN_VERSION="12.0"
+    MACOS_MIN_VERSION="10.15"
     CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
 else
     # arm64
     DARWIN_TRIPLE="aarch64-apple-darwin"
     TOOLCHAIN_FILE="cmake/darwin/toolchain-aarch64.cmake"
     BUILD_DIR_SUFFIX="darwin-arm64"
-    MACOS_MIN_VERSION="12.0"
+    MACOS_MIN_VERSION="11.0"
     CPU_FEATURES="-DENABLE_AVX=0 -DENABLE_AVX2=0"
 fi
 

--- a/chdb/build/check_export_contract.py
+++ b/chdb/build/check_export_contract.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Gate 3a: the two checked-in export allow-lists must describe the same C API contract.
+
+`chdb/libchdb_export.map` (Linux version script) and `chdb/libchdb_export_macos.txt`
+(macOS -exported_symbols_list) are maintained by hand and drift apart easily. They are the
+only checked-in statement of what the public C ABI is, so everything downstream - including
+the static-library reachability gate - reads the contract from here rather than hard-coding
+a symbol count.
+
+Prints the contract, one unprefixed symbol per line, to stdout. Diagnostics go to stderr,
+so `check_export_contract.py > contract.txt` is safe.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_MAP = os.path.join(REPO_ROOT, "chdb", "libchdb_export.map")
+DEFAULT_MACOS = os.path.join(REPO_ROOT, "chdb", "libchdb_export_macos.txt")
+
+
+def parse_version_script(path):
+    """Symbols listed in the `global:` section of a linker version script."""
+    text = re.sub(r"/\*.*?\*/", "", open(path).read(), flags=re.DOTALL)
+    match = re.search(r"\bglobal:(.*?)\blocal:", text, flags=re.DOTALL)
+    if not match:
+        raise SystemExit(f"{path}: no 'global: ... local:' section found")
+    return set(re.findall(r"([A-Za-z_][A-Za-z0-9_]*)\s*;", match.group(1)))
+
+
+def parse_exported_symbols_list(path):
+    """Symbols in a Mach-O -exported_symbols_list, with the leading underscore removed."""
+    symbols = set()
+    for lineno, line in enumerate(open(path), 1):
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if not line.startswith("_"):
+            raise SystemExit(f"{path}:{lineno}: Mach-O symbol must start with '_': {line}")
+        symbols.add(line[1:])
+    return symbols
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--map", default=DEFAULT_MAP)
+    parser.add_argument("--macos", default=DEFAULT_MACOS)
+    args = parser.parse_args()
+
+    linux = parse_version_script(args.map)
+    macos = parse_exported_symbols_list(args.macos)
+
+    if linux != macos:
+        for symbol in sorted(linux - macos):
+            print(f"  only in {args.map}: {symbol}", file=sys.stderr)
+        for symbol in sorted(macos - linux):
+            print(f"  only in {args.macos}: {symbol}", file=sys.stderr)
+        raise SystemExit(
+            "Export allow-lists disagree. Every public chdb_* symbol declared CHDB_EXPORT in\n"
+            "programs/local/chdb.h must be listed in both files.")
+
+    print(f"C API contract: {len(linux)} symbols, both allow-lists agree", file=sys.stderr)
+    for symbol in sorted(linux):
+        print(symbol)
+
+
+if __name__ == "__main__":
+    main()

--- a/chdb/build/check_static_lib_hermetic.sh
+++ b/chdb/build/check_static_lib_hermetic.sh
@@ -1,21 +1,32 @@
 #!/bin/bash
 #
-# Release gates for the macOS static library (issue #198).
+# Release gates for the static library.
 #
-# libchdb.so/.dylib gate their exports at link time. libchdb.a cannot: it is handed to a
-# linker we do not control, so the gate has to be baked into the objects
+# libchdb.so gates its exported surface at link time. libchdb.a is handed to a linker we do
+# not control, so the gate has to be baked into the objects
 # (cmake/bundled_runtime_visibility.cmake). These checks verify that it was.
 #
-#   Gate 1  no coalescing fixup in the probe can bind to the system C++/unwind runtime
+#   Gate 1  nothing in the probe can bind the bundled runtime to the system runtime
 #   Gate 2  no bundled runtime object exports a symbol the system runtime also exports
 #   Gate 3a the two checked-in export allow-lists describe the same C API contract
 #   Gate 3b every symbol in that contract is still reachable from libchdb.a
 #   Gate 4  the linked probe connects and runs a query
 #
-# The probe is linked with a modern deployment target on purpose. Measured against a
-# pre-fix arm64 archive: -mmacosx-version-min=10.15 (what chdb_example.cpp uses) yields no
-# coalescing fixups at all, 12.0 and up yield 33102 of them. Anything older than 12.0 hides
-# the failure this script exists to catch.
+# The five gates are the same on both platforms; only the tools and the condition that
+# exposes the hazard differ.
+#
+#   Mach-O  weak definitions become <weak-def-coalesce> chained fixups and dyld may bind
+#           them to the system libc++/libc++abi. Exposed by a deployment target of 12.0 or
+#           newer: measured against a pre-fix arm64 archive, min=10.15 yields no coalescing
+#           fixups at all while 12.0 and up yield 33102.
+#   ELF     default-visibility definitions reach .dynsym and become interposable. A plain
+#           executable link does not expose them, `-rdynamic` does - measured 1 symbol in
+#           .dynsym at default visibility versus 0 at hidden - so the probe is linked that
+#           way deliberately, as the ELF equivalent of a modern deployment target.
+#
+# Note both platforms need a visibility-aware tool: a hidden symbol is still a global
+# definition in the symbol table on Mach-O and ELF alike, so plain `nm -g` cannot see the
+# difference and would report a hardened archive as unprotected.
 #
 # Usage: check_static_lib_hermetic.sh [path/to/libchdb.a] [path/to/chdb.h]
 
@@ -28,47 +39,107 @@ LIBCHDB_A=${1:-${PROJ_DIR}/libchdb.a}
 CHDB_H=${2:-${PROJ_DIR}/programs/local/chdb.h}
 MIN_USEFUL_TARGET=12.0
 
-if [ "$(uname)" != "Darwin" ]; then
-    echo "Error: these gates need a macOS host (dyld_info, system libc++). Run them in the"
-    echo "       native macOS job that consumes the cross-built artifact."
-    exit 1
-fi
-
-# Default to the host's own OS version: it is the newest target whose binaries this machine
-# can still run, and gate 4 has to actually run the probe. Override with
-# MACOSX_DEPLOYMENT_TARGET, but not below the floor checked next.
-DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-$(sw_vers -productVersion | cut -d. -f1).0}
+PLATFORM=$(uname)
+case "${PLATFORM}" in
+    Darwin|Linux) ;;
+    *) echo "Error: unsupported platform ${PLATFORM}"; exit 1 ;;
+esac
 
 for f in "${LIBCHDB_A}" "${CHDB_H}"; do
     [ -f "${f}" ] || { echo "Error: not found: ${f}"; exit 1; }
 done
 
-if [ "$(printf '%s\n%s\n' "${MIN_USEFUL_TARGET}" "${DEPLOYMENT_TARGET}" | sort -V | head -1)" != "${MIN_USEFUL_TARGET}" ]; then
-    echo "Error: deployment target ${DEPLOYMENT_TARGET} is older than ${MIN_USEFUL_TARGET}; the"
-    echo "       linker would emit no chained fixups and gate 1 would pass vacuously."
-    exit 1
+# Absolute from here on: gate 2 and the probe link both run from a temp directory, where a
+# relative path would resolve against the wrong place.
+LIBCHDB_A="$(cd "$(dirname "${LIBCHDB_A}")" && pwd)/$(basename "${LIBCHDB_A}")"
+CHDB_H="$(cd "$(dirname "${CHDB_H}")" && pwd)/$(basename "${CHDB_H}")"
+
+# Mach-O prefixes every C symbol with an underscore; ELF does not. Everything downstream
+# compares bare names, so record the prefix once and apply it only when building link flags.
+if [ "${PLATFORM}" = Darwin ]; then
+    SYM_PREFIX=_
+    # Default to the host's own OS version: it is the newest target whose binaries this
+    # machine can still run, and gate 4 has to run the probe. Override with
+    # MACOSX_DEPLOYMENT_TARGET, but not below the floor checked next.
+    DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-$(sw_vers -productVersion | cut -d. -f1).0}
+    if [ "$(printf '%s\n%s\n' "${MIN_USEFUL_TARGET}" "${DEPLOYMENT_TARGET}" | sort -V | head -1)" != "${MIN_USEFUL_TARGET}" ]; then
+        echo "Error: deployment target ${DEPLOYMENT_TARGET} is older than ${MIN_USEFUL_TARGET}; the"
+        echo "       linker would emit no chained fixups and gate 1 would pass vacuously."
+        exit 1
+    fi
+    EXPOSURE="deployment target ${DEPLOYMENT_TARGET}"
+else
+    SYM_PREFIX=
+    EXPOSURE="-rdynamic"
 fi
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
-echo "Static library gates"
-echo "  archive:           ${LIBCHDB_A}"
-echo "  header:            ${CHDB_H}"
-echo "  deployment target: ${DEPLOYMENT_TARGET}"
+echo "Static library gates (${PLATFORM})"
+echo "  archive:  ${LIBCHDB_A}"
+echo "  header:   ${CHDB_H}"
+echo "  exposure: ${EXPOSURE}"
 echo
 
 failures=0
 fail () { echo "FAIL: $*"; failures=$((failures + 1)); }
 
-# Exports of the three system runtimes chDB bundles its own copies of. `dyld_info` reads
-# these out of the dyld shared cache; the dylibs no longer exist as files on modern macOS.
-{ dyld_info -exports /usr/lib/libc++.1.dylib
-  dyld_info -exports /usr/lib/libc++abi.dylib
-  dyld_info -exports /usr/lib/system/libunwind.dylib; } 2>/dev/null \
-    | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^__?[A-Za-z_$]/ && $i !~ /^\[/) { print $i; break } }' \
-    | sed 's/^_//' | sort -u > "${WORK_DIR}/system_exports.txt"
-[ -s "${WORK_DIR}/system_exports.txt" ] || { echo "Error: dyld_info returned no system runtime exports"; exit 1; }
+# Symbols a shared library defines and exports, i.e. the ones an image could bind to
+# something other than the bundled copy. Used by gates 1 and 2.
+so_exports () {
+    if [ "${PLATFORM}" = Darwin ]; then
+        # dyld_info reads these out of the dyld shared cache; the dylibs no longer exist as
+        # files on modern macOS.
+        { dyld_info -exports /usr/lib/libc++.1.dylib
+          dyld_info -exports /usr/lib/libc++abi.dylib
+          dyld_info -exports /usr/lib/system/libunwind.dylib; } 2>/dev/null \
+            | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^__?[A-Za-z_$]/ && $i !~ /^\[/) { print $i; break } }' \
+            | sed 's/^_//'
+    else
+        for lib in libstdc++.so.6 libc++.so.1 libc++abi.so.1 libgcc_s.so.1; do
+            path=$(ldconfig -p 2>/dev/null | awk -v l="${lib}" '$1 == l { print $NF; exit }')
+            [ -n "${path}" ] && [ -f "${path}" ] && readelf --dyn-syms -W "${path}" 2>/dev/null
+        done | elf_visible_defined
+    fi
+}
+
+# Defined symbols that remain visible outside their own object. Hidden ones are excluded:
+# they are exactly what cannot be bound elsewhere. Reads a readelf symbol table on stdin.
+elf_visible_defined () {
+    awk '$1 ~ /^[0-9]+:$/ && $7 != "UND" && $6 == "DEFAULT" && ($5 == "GLOBAL" || $5 == "WEAK") {
+             n = $8; sub(/@.*/, "", n); if (n != "") print n
+         }'
+}
+
+# Same idea for the bundled runtime objects extracted from the archive.
+archive_visible_exports () {
+    local objdir=$1
+    if [ "${PLATFORM}" = Darwin ]; then
+        # Only the -m listing spells out "private external"; -g alone shows hidden symbols too.
+        find "${objdir}" -name '*.o' -print0 \
+            | xargs -0 nm -m -g --defined-only 2>/dev/null \
+            | awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }'
+    else
+        find "${objdir}" -name '*.o' -print0 \
+            | xargs -0 -n 50 readelf -sW 2>/dev/null \
+            | elf_visible_defined
+    fi
+}
+
+# Symbols in the linked probe that another image could still supply.
+probe_bindable () {
+    local probe=$1
+    if [ "${PLATFORM}" = Darwin ]; then
+        dyld_info -fixups "${probe}" 2>/dev/null | grep '<weak-def-coalesce>' \
+            | sed 's|.*<weak-def-coalesce>/_||' || true
+    else
+        readelf --dyn-syms -W "${probe}" 2>/dev/null | elf_visible_defined
+    fi
+}
+
+so_exports | sort -u > "${WORK_DIR}/system_exports.txt"
+[ -s "${WORK_DIR}/system_exports.txt" ] || { echo "Error: found no system runtime exports to compare against"; exit 1; }
 
 # --- Gate 3a: the checked-in C API contract ---------------------------------------------
 # Runs first: gate 3b consumes its output, and nothing downstream should hard-code a count.
@@ -93,48 +164,48 @@ if [ "${runtime_member_count}" -eq 0 ]; then
 else
     mkdir -p "${WORK_DIR}/objs"
     (cd "${WORK_DIR}/objs" && xargs ar x "${LIBCHDB_A}" < "${WORK_DIR}/runtime_members.txt")
-
-    # `nm -m` is needed rather than plain `nm -g`: a hidden symbol is still N_EXT in Mach-O,
-    # just flagged private, and only the -m listing spells that out ("private external").
-    # Those are the ones that cannot coalesce, so they are what gets filtered out here.
-    find "${WORK_DIR}/objs" -name '*.o' -print0 \
-        | xargs -0 nm -m -g --defined-only 2>/dev/null \
-        | awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }' \
-        | sort -u > "${WORK_DIR}/runtime_exports.txt"
+    archive_visible_exports "${WORK_DIR}/objs" | sort -u > "${WORK_DIR}/runtime_exports.txt"
 
     comm -12 "${WORK_DIR}/runtime_exports.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/overlap.txt"
     overlap=$(wc -l < "${WORK_DIR}/overlap.txt" | tr -d ' ')
-    echo "  runtime objects: ${runtime_member_count}, still-external symbols: $(wc -l < "${WORK_DIR}/runtime_exports.txt" | tr -d ' ')"
+    echo "  runtime objects: ${runtime_member_count}, still-visible symbols: $(wc -l < "${WORK_DIR}/runtime_exports.txt" | tr -d ' ')"
     if [ "${overlap}" -eq 0 ]; then
         echo "PASS"
     else
         echo "  first 20 of ${overlap} colliding symbols:"
         head -20 "${WORK_DIR}/overlap.txt" | sed 's/^/    /'
-        fail "${overlap} bundled runtime symbols can coalesce with the system runtime"
+        fail "${overlap} bundled runtime symbols can be bound to the system runtime"
     fi
 fi
 echo
 
 # --- Build the probe --------------------------------------------------------------------
-echo "== Building probe (deployment target ${DEPLOYMENT_TARGET}) =="
+echo "== Building probe (${EXPOSURE}) =="
 cp "${CHDB_H}" "${WORK_DIR}/chdb.h"
 cp "${MY_DIR}/static-probe/chdb_static_probe.c" "${WORK_DIR}/"
 # Symlinked, not copied: the archive is around a gigabyte.
-ln -s "$(cd "$(dirname "${LIBCHDB_A}")" && pwd)/$(basename "${LIBCHDB_A}")" "${WORK_DIR}/libchdb.a"
+ln -s "${LIBCHDB_A}" "${WORK_DIR}/libchdb.a"
 
 # -u forces the linker to resolve every symbol in the contract, so a public C API function
 # that got hidden or dropped fails the link instead of failing a user months later.
 force_flags=()
 while read -r symbol; do
-    [ -n "${symbol}" ] && force_flags+=("-Wl,-u,_${symbol}")
+    [ -n "${symbol}" ] && force_flags+=("-Wl,-u,${SYM_PREFIX}${symbol}")
 done < "${WORK_DIR}/contract.txt"
 
+if [ "${PLATFORM}" = Darwin ]; then
+    platform_flags=(-mmacosx-version-min="${DEPLOYMENT_TARGET}" -liconv
+                    -framework CoreFoundation -framework Security)
+    export MACOSX_DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET}"
+else
+    # -rdynamic is the point, not an accident: it is what puts default-visibility archive
+    # symbols into .dynsym, which is what gate 1 then asserts is empty of runtime symbols.
+    platform_flags=(-rdynamic -lpthread -ldl -lm -lrt -Wl,--allow-multiple-definition)
+fi
+
 PROBE="${WORK_DIR}/chdb_static_probe"
-if (cd "${WORK_DIR}" && MACOSX_DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET}" \
-        clang chdb_static_probe.c -o chdb_static_probe \
-            -mmacosx-version-min="${DEPLOYMENT_TARGET}" \
-            -I. -L. "${force_flags[@]}" -lchdb -liconv \
-            -framework CoreFoundation -framework Security \
+if (cd "${WORK_DIR}" && clang chdb_static_probe.c -o chdb_static_probe \
+            -I. -L. "${force_flags[@]}" -lchdb "${platform_flags[@]}" \
         > "${WORK_DIR}/link.log" 2>&1); then
     echo "PASS (Gate 3b: all $(wc -l < "${WORK_DIR}/contract.txt" | tr -d ' ') contract symbols resolved)"
 else
@@ -146,27 +217,30 @@ else
 fi
 echo
 
-# --- Gate 1: chained fixups -------------------------------------------------------------
-echo "== Gate 1: no coalescing fixup can bind to the system runtime =="
-dyld_info -fixups "${PROBE}" 2>/dev/null | grep '<weak-def-coalesce>' \
-    | sed 's|.*<weak-def-coalesce>/_||' | sort -u > "${WORK_DIR}/probe_coalesce.txt" || true
-total_coalesce=$(wc -l < "${WORK_DIR}/probe_coalesce.txt" | tr -d ' ')
-comm -12 "${WORK_DIR}/probe_coalesce.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/probe_overlap.txt"
+# --- Gate 1: what the probe still exposes -----------------------------------------------
+echo "== Gate 1: nothing in the probe can bind the bundled runtime elsewhere =="
+probe_bindable "${PROBE}" | sort -u > "${WORK_DIR}/probe_bindable.txt"
+total_bindable=$(wc -l < "${WORK_DIR}/probe_bindable.txt" | tr -d ' ')
+comm -12 "${WORK_DIR}/probe_bindable.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/probe_overlap.txt"
 risky=$(wc -l < "${WORK_DIR}/probe_overlap.txt" | tr -d ' ')
 
-# The gate is the intersection with the system runtime, not the raw total. Tens of
-# thousands of the raw records are ClickHouse/abseil/magic_enum template instantiations:
-# weak by definition, defined nowhere else, so dyld resolves them to this image. Only the
-# ones the system libc++/libc++abi also defines can actually be bound to another runtime,
-# and those are the ones that hang. Measured on a pre-fix arm64 archive at deployment
-# target 26.0: 33102 records, 479 of them system-overlapping, probe hangs on chdb_connect.
-# With the bundled runtimes hidden: 31576 records, 0 system-overlapping, probe passes.
-echo "  coalescing records: ${total_coalesce} (informational), able to bind to the system runtime: ${risky}"
+# The gate is the intersection with the system runtime, not the raw total. On Mach-O most of
+# the raw records are ClickHouse/abseil/magic_enum template instantiations: weak by
+# definition, defined nowhere else, so dyld can only bind them to this image. Measured on a
+# pre-fix arm64 archive at deployment target 26.0: 33102 records, 479 system-overlapping,
+# probe hangs in chdb_connect. With the bundled runtimes hidden: 29692 records, 0
+# system-overlapping, probe passes.
+echo "  candidate symbols: ${total_bindable} (informational), resolvable from the system runtime: ${risky}"
 if [ "${risky}" -eq 0 ]; then
     echo "PASS"
 else
     head -20 "${WORK_DIR}/probe_overlap.txt" | sed 's/^/    /'
     fail "${risky} bundled runtime symbols can be bound to the system runtime"
+fi
+if [ "${PLATFORM}" = Linux ]; then
+    # Informational: a dependency here would mean C++ runtime symbols are being satisfied
+    # dynamically rather than from the bundled copy.
+    echo "  system C++ runtime linked into the probe: $(ldd "${PROBE}" 2>/dev/null | grep -cE 'libstdc\+\+|libc\+\+') library/libraries"
 fi
 echo
 

--- a/chdb/build/check_static_lib_hermetic.sh
+++ b/chdb/build/check_static_lib_hermetic.sh
@@ -40,7 +40,7 @@ PROJ_DIR="$( cd "${MY_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
 LIBCHDB_A=${1:-${PROJ_DIR}/libchdb.a}
 CHDB_H=${2:-${PROJ_DIR}/programs/local/chdb.h}
-MIN_USEFUL_TARGET=12.0
+MIN_USEFUL_MAJOR=12
 
 PLATFORM=$(uname)
 case "${PLATFORM}" in
@@ -78,8 +78,16 @@ if [ "${PLATFORM}" = Darwin ]; then
     # machine can still run, and gate 4 has to run the probe. Override with
     # MACOSX_DEPLOYMENT_TARGET, but not below the floor checked next.
     DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-$(sw_vers -productVersion | cut -d. -f1).0}
-    if [ "$(printf '%s\n%s\n' "${MIN_USEFUL_TARGET}" "${DEPLOYMENT_TARGET}" | sort -V | head -1)" != "${MIN_USEFUL_TARGET}" ]; then
-        echo "Error: deployment target ${DEPLOYMENT_TARGET} is older than ${MIN_USEFUL_TARGET}; the"
+    # Compared as a bare major version rather than with `sort -V` or `sort -t. -k`: both
+    # depend on which sort dialect is installed, and the floor only needs the major number
+    # (macOS 11 and 10.x are below it, 12 and up are above).
+    target_major=${DEPLOYMENT_TARGET%%.*}
+    if ! printf '%s' "${target_major}" | grep -Eq '^[0-9]+$'; then
+        echo "Error: could not read a major version out of deployment target '${DEPLOYMENT_TARGET}'"
+        exit 1
+    fi
+    if [ "${target_major}" -lt "${MIN_USEFUL_MAJOR}" ]; then
+        echo "Error: deployment target ${DEPLOYMENT_TARGET} is older than ${MIN_USEFUL_MAJOR}.0; the"
         echo "       linker would emit no chained fixups and gate 1 would pass vacuously."
         exit 1
     fi

--- a/chdb/build/check_static_lib_hermetic.sh
+++ b/chdb/build/check_static_lib_hermetic.sh
@@ -15,13 +15,19 @@
 # The five gates are the same on both platforms; only the tools and the condition that
 # exposes the hazard differ.
 #
-#   Mach-O  weak definitions become <weak-def-coalesce> chained fixups and dyld may bind
+#   Mach-O  weak definitions that stay external land in the export trie and dyld may bind
 #           them to the system libc++/libc++abi. Exposed by a deployment target of 12.0 or
-#           newer: measured against a pre-fix arm64 archive, min=10.15 yields no coalescing
-#           fixups at all while 12.0 and up yield 33102.
+#           newer, which is when ld starts emitting chained fixups: measured against a
+#           pre-fix arm64 archive, min=10.15 produced no coalescing records at all while
+#           12.0 and up produced 33102.
 #   ELF     default-visibility definitions reach .dynsym and become interposable. A plain
 #           executable link does not expose them, `-rdynamic` does, so the probe is linked
 #           that way deliberately as the ELF equivalent of a modern deployment target.
+#
+# Gate 1 deliberately does not parse `dyld_info -fixups`. Its `<weak-def-coalesce>` marker
+# text is dyld-version specific - on a macOS 14 runner the same hardened archive that yields
+# 32779 records locally yields none, which would have reported a vacuous pass. It compares
+# symbol sets instead, using only nm/readelf.
 #
 # Note both platforms need a visibility-aware tool: a hidden symbol is still a global
 # definition in the symbol table on Mach-O and ELF alike, so plain `nm -g` cannot see the
@@ -197,6 +203,10 @@ else
             fail "extracted ${extracted} of ${runtime_member_count} runtime members"
         fi
 
+        # Two sets come out of the same dump. runtime_exports is what is still visible from
+        # outside the object, which is what this gate asserts is empty. runtime_defined is
+        # every definition regardless of visibility, which gate 1 uses to scope itself to
+        # the bundled runtime.
         if [ "${PLATFORM}" = Darwin ]; then
             # Only the -m listing spells out "private external"; -g alone shows hidden
             # symbols too and would report a hardened archive as unprotected.
@@ -204,10 +214,15 @@ else
                 | xargs -0 nm -m -g --defined-only > "${WORK_DIR}/nm.txt"
             awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }' "${WORK_DIR}/nm.txt" \
                 | sort -u > "${WORK_DIR}/runtime_exports.txt"
+            awk '$NF ~ /^_/ { print substr($NF, 2) }' "${WORK_DIR}/nm.txt" \
+                | sort -u > "${WORK_DIR}/runtime_defined.txt"
         else
             find "${WORK_DIR}/objs" -name '*.o' -print0 \
                 | xargs -0 -n 50 readelf -sW > "${WORK_DIR}/readelf.txt"
             elf_visible_defined < "${WORK_DIR}/readelf.txt" | sort -u > "${WORK_DIR}/runtime_exports.txt"
+            awk '$1 ~ /^[0-9]+:$/ && $7 != "UND" && ($5 == "GLOBAL" || $5 == "WEAK") {
+                     n = $8; sub(/@.*/, "", n); if (n != "") print n
+                 }' "${WORK_DIR}/readelf.txt" | sort -u > "${WORK_DIR}/runtime_defined.txt"
         fi
 
         # Asserted at zero, not merely "disjoint from this host's system runtime". These
@@ -269,15 +284,16 @@ else
 fi
 echo
 
-# --- Gate 1: what the probe still exposes -----------------------------------------------
-# Symbols in the linked probe that another image could still supply. Returns non-zero if the
-# inspection tool itself failed, so that is not mistaken for "nothing to bind".
-probe_candidates () {
+# --- Gate 1: what the linked probe still exposes ---------------------------------------
+# Symbols that remain visible from outside the linked image, so another image could supply
+# them instead. Returns non-zero if the tool itself failed, so that is never mistaken for
+# "nothing is exposed".
+probe_visible_symbols () {
     local probe=$1 raw="${WORK_DIR}/probe_raw.txt"
     if [ "${PLATFORM}" = Darwin ]; then
-        dyld_info -fixups "${probe}" > "${raw}" 2>/dev/null || return 1
+        nm -m -g --defined-only "${probe}" > "${raw}" 2>/dev/null || return 1
         [ -s "${raw}" ] || return 1
-        grep_optional '<weak-def-coalesce>' "${raw}" | sed 's|.*<weak-def-coalesce>/_||'
+        awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }' "${raw}"
     else
         readelf --dyn-syms -W "${probe}" > "${raw}" 2>/dev/null || return 1
         [ -s "${raw}" ] || return 1
@@ -285,39 +301,34 @@ probe_candidates () {
     fi
 }
 
-echo "== Gate 1: nothing in the probe can bind the bundled runtime elsewhere =="
-if ! probe_candidates "${PROBE}" > "${WORK_DIR}/probe_bindable_unsorted.txt"; then
-    fail "could not inspect the probe's fixups/dynamic symbols; gate 1 was not evaluated"
+echo "== Gate 1: no bundled runtime symbol is visible from the linked probe =="
+if [ ! -s "${WORK_DIR}/runtime_defined.txt" ]; then
+    fail "gate 2 produced no runtime symbol set, so gate 1 has nothing to scope itself to"
+elif ! probe_visible_symbols "${PROBE}" > "${WORK_DIR}/probe_visible_unsorted.txt"; then
+    fail "could not read the probe's symbol table; gate 1 was not evaluated"
 else
-    sort -u "${WORK_DIR}/probe_bindable_unsorted.txt" > "${WORK_DIR}/probe_bindable.txt"
-    total_bindable=$(wc -l < "${WORK_DIR}/probe_bindable.txt" | tr -d ' ')
-    comm -12 "${WORK_DIR}/probe_bindable.txt" "${WORK_DIR}/system_exports.txt" \
-        > "${WORK_DIR}/probe_overlap.txt"
-    risky=$(wc -l < "${WORK_DIR}/probe_overlap.txt" | tr -d ' ')
+    sort -u "${WORK_DIR}/probe_visible_unsorted.txt" > "${WORK_DIR}/probe_visible.txt"
+    probe_visible=$(wc -l < "${WORK_DIR}/probe_visible.txt" | tr -d ' ')
+    runtime_defined=$(wc -l < "${WORK_DIR}/runtime_defined.txt" | tr -d ' ')
+    comm -12 "${WORK_DIR}/runtime_defined.txt" "${WORK_DIR}/probe_visible.txt" \
+        > "${WORK_DIR}/leaked.txt"
+    leaked=$(wc -l < "${WORK_DIR}/leaked.txt" | tr -d ' ')
 
-    # The gate is the intersection with the system runtime, not the raw total. On Mach-O most
-    # of the raw records are ClickHouse/abseil/magic_enum template instantiations: weak by
-    # definition, defined nowhere else, so dyld can only bind them to this image. Measured on
-    # a pre-fix arm64 archive at deployment target 26.0: 33102 records, 479
-    # system-overlapping, probe hangs in chdb_connect. With the bundled runtimes hidden:
-    # 29692 records, 0 system-overlapping, probe passes.
-    echo "  candidate symbols: ${total_bindable} (informational), resolvable from the system runtime: ${risky}"
-    if [ "${total_bindable}" -eq 0 ]; then
-        # A real binary always has some: template instantiations on Mach-O, crt and the
-        # CHDB_EXPORT C API in .dynsym on ELF. Zero means the extraction produced nothing,
-        # so the overlap below would be zero no matter what the archive contains.
-        fail "no candidate symbols found at all - extraction is broken, gate 1 would pass vacuously"
-    elif [ "${risky}" -eq 0 ]; then
+    # Scoped to symbols the bundled runtime actually defines. Intersecting the probe's whole
+    # visible set with the system runtime instead would flag the replaceable global operator
+    # new/delete, which clickhouse_new_delete provides at default visibility on purpose and
+    # which is outside these three targets; gate 2 is what covers the runtime's own copies.
+    echo "  runtime definitions: ${runtime_defined}, visible from the probe: ${probe_visible}, leaked: ${leaked}"
+    if [ "${probe_visible}" -eq 0 ]; then
+        # A linked binary always exposes something. Zero means the extraction produced
+        # nothing, so the intersection below would be empty whatever the archive contains.
+        fail "the probe exposes no symbols at all - extraction is broken, gate 1 would pass vacuously"
+    elif [ "${leaked}" -eq 0 ]; then
         echo "PASS"
     else
-        head -20 "${WORK_DIR}/probe_overlap.txt" | sed 's/^/    /'
-        fail "${risky} bundled runtime symbols can be bound to the system runtime"
+        head -20 "${WORK_DIR}/leaked.txt" | sed 's/^/    /'
+        fail "${leaked} bundled runtime symbols are visible from the linked probe"
     fi
-fi
-if [ "${PLATFORM}" = Linux ]; then
-    # Informational: a dependency here would mean C++ runtime symbols are being satisfied
-    # dynamically rather than from the bundled copy.
-    echo "  system C++ runtime shared libraries linked into the probe: $(ldd "${PROBE}" 2>/dev/null | grep -c 'libstdc++\|libc++' || true)"
 fi
 echo
 

--- a/chdb/build/check_static_lib_hermetic.sh
+++ b/chdb/build/check_static_lib_hermetic.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+#
+# Release gates for the macOS static library (issue #198).
+#
+# libchdb.so/.dylib gate their exports at link time. libchdb.a cannot: it is handed to a
+# linker we do not control, so the gate has to be baked into the objects
+# (cmake/bundled_runtime_visibility.cmake). These checks verify that it was.
+#
+#   Gate 1  no coalescing fixup in the probe can bind to the system C++/unwind runtime
+#   Gate 2  no bundled runtime object exports a symbol the system runtime also exports
+#   Gate 3a the two checked-in export allow-lists describe the same C API contract
+#   Gate 3b every symbol in that contract is still reachable from libchdb.a
+#   Gate 4  the linked probe connects and runs a query
+#
+# The probe is linked with a modern deployment target on purpose. Measured against a
+# pre-fix arm64 archive: -mmacosx-version-min=10.15 (what chdb_example.cpp uses) yields no
+# coalescing fixups at all, 12.0 and up yield 33102 of them. Anything older than 12.0 hides
+# the failure this script exists to catch.
+#
+# Usage: check_static_lib_hermetic.sh [path/to/libchdb.a] [path/to/chdb.h]
+
+set -euo pipefail
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PROJ_DIR="$( cd "${MY_DIR}/../.." >/dev/null 2>&1 && pwd )"
+
+LIBCHDB_A=${1:-${PROJ_DIR}/libchdb.a}
+CHDB_H=${2:-${PROJ_DIR}/programs/local/chdb.h}
+MIN_USEFUL_TARGET=12.0
+
+if [ "$(uname)" != "Darwin" ]; then
+    echo "Error: these gates need a macOS host (dyld_info, system libc++). Run them in the"
+    echo "       native macOS job that consumes the cross-built artifact."
+    exit 1
+fi
+
+# Default to the host's own OS version: it is the newest target whose binaries this machine
+# can still run, and gate 4 has to actually run the probe. Override with
+# MACOSX_DEPLOYMENT_TARGET, but not below the floor checked next.
+DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-$(sw_vers -productVersion | cut -d. -f1).0}
+
+for f in "${LIBCHDB_A}" "${CHDB_H}"; do
+    [ -f "${f}" ] || { echo "Error: not found: ${f}"; exit 1; }
+done
+
+if [ "$(printf '%s\n%s\n' "${MIN_USEFUL_TARGET}" "${DEPLOYMENT_TARGET}" | sort -V | head -1)" != "${MIN_USEFUL_TARGET}" ]; then
+    echo "Error: deployment target ${DEPLOYMENT_TARGET} is older than ${MIN_USEFUL_TARGET}; the"
+    echo "       linker would emit no chained fixups and gate 1 would pass vacuously."
+    exit 1
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+echo "Static library gates"
+echo "  archive:           ${LIBCHDB_A}"
+echo "  header:            ${CHDB_H}"
+echo "  deployment target: ${DEPLOYMENT_TARGET}"
+echo
+
+failures=0
+fail () { echo "FAIL: $*"; failures=$((failures + 1)); }
+
+# Exports of the three system runtimes chDB bundles its own copies of. `dyld_info` reads
+# these out of the dyld shared cache; the dylibs no longer exist as files on modern macOS.
+{ dyld_info -exports /usr/lib/libc++.1.dylib
+  dyld_info -exports /usr/lib/libc++abi.dylib
+  dyld_info -exports /usr/lib/system/libunwind.dylib; } 2>/dev/null \
+    | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^__?[A-Za-z_$]/ && $i !~ /^\[/) { print $i; break } }' \
+    | sed 's/^_//' | sort -u > "${WORK_DIR}/system_exports.txt"
+[ -s "${WORK_DIR}/system_exports.txt" ] || { echo "Error: dyld_info returned no system runtime exports"; exit 1; }
+
+# --- Gate 3a: the checked-in C API contract ---------------------------------------------
+# Runs first: gate 3b consumes its output, and nothing downstream should hard-code a count.
+echo "== Gate 3a: export allow-lists agree =="
+# Fatal rather than counted: gate 3b builds its link line out of this contract, so there is
+# nothing meaningful left to check if the two lists disagree.
+if ! python3 "${MY_DIR}/check_export_contract.py" > "${WORK_DIR}/contract.txt"; then
+    echo "FAIL: chdb/libchdb_export.map and chdb/libchdb_export_macos.txt disagree"
+    exit 1
+fi
+echo "PASS"
+echo
+
+# --- Gate 2: no-link archive check ------------------------------------------------------
+# Only the bundled runtime objects are in scope. ClickHouse's own weak/template symbols are
+# a different problem and would swamp the signal.
+echo "== Gate 2: bundled runtime objects export nothing the system runtime also exports =="
+ar t "${LIBCHDB_A}" | grep -E '^lib(cxx|cxxabi|unwind)__' > "${WORK_DIR}/runtime_members.txt" || true
+runtime_member_count=$(wc -l < "${WORK_DIR}/runtime_members.txt" | tr -d ' ')
+if [ "${runtime_member_count}" -eq 0 ]; then
+    fail "no libcxx__/libcxxabi__/libunwind__ members in the archive - has the member naming in create_static_libchdb.py changed?"
+else
+    mkdir -p "${WORK_DIR}/objs"
+    (cd "${WORK_DIR}/objs" && xargs ar x "${LIBCHDB_A}" < "${WORK_DIR}/runtime_members.txt")
+
+    # `nm -m` is needed rather than plain `nm -g`: a hidden symbol is still N_EXT in Mach-O,
+    # just flagged private, and only the -m listing spells that out ("private external").
+    # Those are the ones that cannot coalesce, so they are what gets filtered out here.
+    find "${WORK_DIR}/objs" -name '*.o' -print0 \
+        | xargs -0 nm -m -g --defined-only 2>/dev/null \
+        | awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }' \
+        | sort -u > "${WORK_DIR}/runtime_exports.txt"
+
+    comm -12 "${WORK_DIR}/runtime_exports.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/overlap.txt"
+    overlap=$(wc -l < "${WORK_DIR}/overlap.txt" | tr -d ' ')
+    echo "  runtime objects: ${runtime_member_count}, still-external symbols: $(wc -l < "${WORK_DIR}/runtime_exports.txt" | tr -d ' ')"
+    if [ "${overlap}" -eq 0 ]; then
+        echo "PASS"
+    else
+        echo "  first 20 of ${overlap} colliding symbols:"
+        head -20 "${WORK_DIR}/overlap.txt" | sed 's/^/    /'
+        fail "${overlap} bundled runtime symbols can coalesce with the system runtime"
+    fi
+fi
+echo
+
+# --- Build the probe --------------------------------------------------------------------
+echo "== Building probe (deployment target ${DEPLOYMENT_TARGET}) =="
+cp "${CHDB_H}" "${WORK_DIR}/chdb.h"
+cp "${MY_DIR}/static-probe/chdb_static_probe.c" "${WORK_DIR}/"
+# Symlinked, not copied: the archive is around a gigabyte.
+ln -s "$(cd "$(dirname "${LIBCHDB_A}")" && pwd)/$(basename "${LIBCHDB_A}")" "${WORK_DIR}/libchdb.a"
+
+# -u forces the linker to resolve every symbol in the contract, so a public C API function
+# that got hidden or dropped fails the link instead of failing a user months later.
+force_flags=()
+while read -r symbol; do
+    [ -n "${symbol}" ] && force_flags+=("-Wl,-u,_${symbol}")
+done < "${WORK_DIR}/contract.txt"
+
+PROBE="${WORK_DIR}/chdb_static_probe"
+if (cd "${WORK_DIR}" && MACOSX_DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET}" \
+        clang chdb_static_probe.c -o chdb_static_probe \
+            -mmacosx-version-min="${DEPLOYMENT_TARGET}" \
+            -I. -L. "${force_flags[@]}" -lchdb -liconv \
+            -framework CoreFoundation -framework Security \
+        > "${WORK_DIR}/link.log" 2>&1); then
+    echo "PASS (Gate 3b: all $(wc -l < "${WORK_DIR}/contract.txt" | tr -d ' ') contract symbols resolved)"
+else
+    sed 's/^/    /' "${WORK_DIR}/link.log" | tail -40
+    fail "probe link failed - a contract symbol is hidden or was dropped by the archive minimisation"
+    echo
+    echo "${failures} gate(s) failed"
+    exit 1
+fi
+echo
+
+# --- Gate 1: chained fixups -------------------------------------------------------------
+echo "== Gate 1: no coalescing fixup can bind to the system runtime =="
+dyld_info -fixups "${PROBE}" 2>/dev/null | grep '<weak-def-coalesce>' \
+    | sed 's|.*<weak-def-coalesce>/_||' | sort -u > "${WORK_DIR}/probe_coalesce.txt" || true
+total_coalesce=$(wc -l < "${WORK_DIR}/probe_coalesce.txt" | tr -d ' ')
+comm -12 "${WORK_DIR}/probe_coalesce.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/probe_overlap.txt"
+risky=$(wc -l < "${WORK_DIR}/probe_overlap.txt" | tr -d ' ')
+
+# The gate is the intersection with the system runtime, not the raw total. Tens of
+# thousands of the raw records are ClickHouse/abseil/magic_enum template instantiations:
+# weak by definition, defined nowhere else, so dyld resolves them to this image. Only the
+# ones the system libc++/libc++abi also defines can actually be bound to another runtime,
+# and those are the ones that hang. Measured on a pre-fix arm64 archive at deployment
+# target 26.0: 33102 records, 479 of them system-overlapping, probe hangs on chdb_connect.
+# With the bundled runtimes hidden: 31576 records, 0 system-overlapping, probe passes.
+echo "  coalescing records: ${total_coalesce} (informational), able to bind to the system runtime: ${risky}"
+if [ "${risky}" -eq 0 ]; then
+    echo "PASS"
+else
+    head -20 "${WORK_DIR}/probe_overlap.txt" | sed 's/^/    /'
+    fail "${risky} bundled runtime symbols can be bound to the system runtime"
+fi
+echo
+
+# --- Gate 4: runtime smoke test ---------------------------------------------------------
+# The whole point of the exercise: the historical bug built cleanly and hung at run time.
+echo "== Gate 4: probe connects and runs a query =="
+# A watchdog, not a nicety: the failure this gate exists for is a hang, and macOS has no
+# coreutils `timeout`.
+(cd "${WORK_DIR}" && ./chdb_static_probe) &
+probe_pid=$!
+( sleep "${PROBE_TIMEOUT:-120}"; kill -9 "${probe_pid}" 2>/dev/null ) &
+watchdog_pid=$!
+disown "${watchdog_pid}" 2>/dev/null || true
+if wait "${probe_pid}"; then
+    echo "PASS"
+else
+    fail "probe did not complete successfully (killed after ${PROBE_TIMEOUT:-120}s if it hung)"
+fi
+kill "${watchdog_pid}" 2>/dev/null || true
+echo
+
+if [ "${failures}" -ne 0 ]; then
+    echo "${failures} gate(s) failed"
+    exit 1
+fi
+echo "All static library gates passed"

--- a/chdb/build/check_static_lib_hermetic.sh
+++ b/chdb/build/check_static_lib_hermetic.sh
@@ -7,7 +7,7 @@
 # (cmake/bundled_runtime_visibility.cmake). These checks verify that it was.
 #
 #   Gate 1  nothing in the probe can bind the bundled runtime to the system runtime
-#   Gate 2  no bundled runtime object exports a symbol the system runtime also exports
+#   Gate 2  the bundled runtime objects export nothing at all
 #   Gate 3a the two checked-in export allow-lists describe the same C API contract
 #   Gate 3b every symbol in that contract is still reachable from libchdb.a
 #   Gate 4  the linked probe connects and runs a query
@@ -20,13 +20,16 @@
 #           newer: measured against a pre-fix arm64 archive, min=10.15 yields no coalescing
 #           fixups at all while 12.0 and up yield 33102.
 #   ELF     default-visibility definitions reach .dynsym and become interposable. A plain
-#           executable link does not expose them, `-rdynamic` does - measured 1 symbol in
-#           .dynsym at default visibility versus 0 at hidden - so the probe is linked that
-#           way deliberately, as the ELF equivalent of a modern deployment target.
+#           executable link does not expose them, `-rdynamic` does, so the probe is linked
+#           that way deliberately as the ELF equivalent of a modern deployment target.
 #
 # Note both platforms need a visibility-aware tool: a hidden symbol is still a global
 # definition in the symbol table on Mach-O and ELF alike, so plain `nm -g` cannot see the
 # difference and would report a hardened archive as unprotected.
+#
+# Every extraction step below is checked for tool failure separately from its result being
+# empty. An empty result is what a clean archive looks like, so conflating the two lets a
+# broken `dyld_info` or `readelf` invocation pass the gates vacuously.
 #
 # Usage: check_static_lib_hermetic.sh [path/to/libchdb.a] [path/to/chdb.h]
 
@@ -54,10 +57,23 @@ done
 LIBCHDB_A="$(cd "$(dirname "${LIBCHDB_A}")" && pwd)/$(basename "${LIBCHDB_A}")"
 CHDB_H="$(cd "$(dirname "${CHDB_H}")" && pwd)/$(basename "${CHDB_H}")"
 
+# Gate 4 kills a hung probe from a background watchdog. A non-numeric value would make that
+# `sleep` fail immediately, the watchdog would exit without killing anything, and `wait`
+# would block forever - so reject it here rather than hanging the build.
+PROBE_TIMEOUT=${PROBE_TIMEOUT:-120}
+if ! printf '%s' "${PROBE_TIMEOUT}" | grep -Eq '^[0-9]+$'; then
+    echo "Error: PROBE_TIMEOUT must be a whole number of seconds, got '${PROBE_TIMEOUT}'"
+    exit 1
+fi
+
 # Mach-O prefixes every C symbol with an underscore; ELF does not. Everything downstream
 # compares bare names, so record the prefix once and apply it only when building link flags.
 if [ "${PLATFORM}" = Darwin ]; then
     SYM_PREFIX=_
+    # The bundled runtimes shadow these three. All are in the dyld shared cache on every
+    # supported macOS, so all three must be readable.
+    SYS_LIBS_REQUIRED="/usr/lib/libc++.1.dylib /usr/lib/libc++abi.dylib /usr/lib/system/libunwind.dylib"
+    SYS_LIBS_OPTIONAL=""
     # Default to the host's own OS version: it is the newest target whose binaries this
     # machine can still run, and gate 4 has to run the probe. Override with
     # MACOSX_DEPLOYMENT_TARGET, but not below the floor checked next.
@@ -70,6 +86,11 @@ if [ "${PLATFORM}" = Darwin ]; then
     EXPOSURE="deployment target ${DEPLOYMENT_TARGET}"
 else
     SYM_PREFIX=
+    # libstdc++ and libgcc_s are what a Linux host always has and are what the bundled
+    # runtime actually collides with. libc++ is only present on some distributions, so it is
+    # folded in when available rather than required.
+    SYS_LIBS_REQUIRED="libstdc++.so.6 libgcc_s.so.1"
+    SYS_LIBS_OPTIONAL="libc++.so.1 libc++abi.so.1"
     EXPOSURE="-rdynamic"
 fi
 
@@ -85,61 +106,56 @@ echo
 failures=0
 fail () { echo "FAIL: $*"; failures=$((failures + 1)); }
 
-# Symbols a shared library defines and exports, i.e. the ones an image could bind to
-# something other than the bundled copy. Used by gates 1 and 2.
-so_exports () {
-    if [ "${PLATFORM}" = Darwin ]; then
-        # dyld_info reads these out of the dyld shared cache; the dylibs no longer exist as
-        # files on modern macOS.
-        { dyld_info -exports /usr/lib/libc++.1.dylib
-          dyld_info -exports /usr/lib/libc++abi.dylib
-          dyld_info -exports /usr/lib/system/libunwind.dylib; } 2>/dev/null \
-            | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^__?[A-Za-z_$]/ && $i !~ /^\[/) { print $i; break } }' \
-            | sed 's/^_//'
-    else
-        for lib in libstdc++.so.6 libc++.so.1 libc++abi.so.1 libgcc_s.so.1; do
-            path=$(ldconfig -p 2>/dev/null | awk -v l="${lib}" '$1 == l { print $NF; exit }')
-            [ -n "${path}" ] && [ -f "${path}" ] && readelf --dyn-syms -W "${path}" 2>/dev/null
-        done | elf_visible_defined
-    fi
-}
+# grep exit 1 means "no matches", a legitimate outcome here. Exit 2 and up is a real error
+# and must not be swallowed.
+grep_optional () { grep "$@" || [ $? -eq 1 ]; }
 
-# Defined symbols that remain visible outside their own object. Hidden ones are excluded:
-# they are exactly what cannot be bound elsewhere. Reads a readelf symbol table on stdin.
+# Defined symbols that remain visible outside their own object; hidden ones are excluded
+# because they are exactly what cannot be bound elsewhere. Reads a readelf symbol table.
 elf_visible_defined () {
     awk '$1 ~ /^[0-9]+:$/ && $7 != "UND" && $6 == "DEFAULT" && ($5 == "GLOBAL" || $5 == "WEAK") {
              n = $8; sub(/@.*/, "", n); if (n != "") print n
          }'
 }
 
-# Same idea for the bundled runtime objects extracted from the archive.
-archive_visible_exports () {
-    local objdir=$1
+# Exported symbols of one system shared library. Returns non-zero if the library cannot be
+# read at all, which the caller distinguishes from "read fine, exports nothing".
+dump_so_exports () {
+    local lib=$1 raw="${WORK_DIR}/one_so.txt"
     if [ "${PLATFORM}" = Darwin ]; then
-        # Only the -m listing spells out "private external"; -g alone shows hidden symbols too.
-        find "${objdir}" -name '*.o' -print0 \
-            | xargs -0 nm -m -g --defined-only 2>/dev/null \
-            | awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }'
+        dyld_info -exports "${lib}" > "${raw}" 2>/dev/null || return 1
+        [ -s "${raw}" ] || return 1
+        awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^__?[A-Za-z_$]/ && $i !~ /^\[/) { print $i; break } }' "${raw}" \
+            | sed 's/^_//'
     else
-        find "${objdir}" -name '*.o' -print0 \
-            | xargs -0 -n 50 readelf -sW 2>/dev/null \
-            | elf_visible_defined
+        local path
+        path=$(ldconfig -p 2>/dev/null | awk -v l="${lib}" '$1 == l { print $NF; exit }') || true
+        [ -n "${path}" ] && [ -f "${path}" ] || return 1
+        readelf --dyn-syms -W "${path}" > "${raw}" 2>/dev/null || return 1
+        [ -s "${raw}" ] || return 1
+        elf_visible_defined < "${raw}"
     fi
 }
 
-# Symbols in the linked probe that another image could still supply.
-probe_bindable () {
-    local probe=$1
-    if [ "${PLATFORM}" = Darwin ]; then
-        dyld_info -fixups "${probe}" 2>/dev/null | grep '<weak-def-coalesce>' \
-            | sed 's|.*<weak-def-coalesce>/_||' || true
+echo "== System runtime exports (comparison base) =="
+: > "${WORK_DIR}/system_exports_raw.txt"
+for lib in ${SYS_LIBS_REQUIRED} ${SYS_LIBS_OPTIONAL}; do
+    if dump_so_exports "${lib}" > "${WORK_DIR}/lib_syms.txt" && [ -s "${WORK_DIR}/lib_syms.txt" ]; then
+        printf '  %-40s %s symbols\n' "${lib}" "$(sort -u "${WORK_DIR}/lib_syms.txt" | wc -l | tr -d ' ')"
+        cat "${WORK_DIR}/lib_syms.txt" >> "${WORK_DIR}/system_exports_raw.txt"
     else
-        readelf --dyn-syms -W "${probe}" 2>/dev/null | elf_visible_defined
+        case " ${SYS_LIBS_REQUIRED} " in
+            *" ${lib} "*)
+                echo "Error: could not read exports from ${lib}. The comparison base would be"
+                echo "       incomplete, which would make gates 1 and 2 pass vacuously."
+                exit 1 ;;
+            *) printf '  %-40s not present (optional)\n' "${lib}" ;;
+        esac
     fi
-}
-
-so_exports | sort -u > "${WORK_DIR}/system_exports.txt"
-[ -s "${WORK_DIR}/system_exports.txt" ] || { echo "Error: found no system runtime exports to compare against"; exit 1; }
+done
+sort -u "${WORK_DIR}/system_exports_raw.txt" > "${WORK_DIR}/system_exports.txt"
+echo "  total: $(wc -l < "${WORK_DIR}/system_exports.txt" | tr -d ' ') distinct symbols"
+echo
 
 # --- Gate 3a: the checked-in C API contract ---------------------------------------------
 # Runs first: gate 3b consumes its output, and nothing downstream should hard-code a count.
@@ -156,25 +172,53 @@ echo
 # --- Gate 2: no-link archive check ------------------------------------------------------
 # Only the bundled runtime objects are in scope. ClickHouse's own weak/template symbols are
 # a different problem and would swamp the signal.
-echo "== Gate 2: bundled runtime objects export nothing the system runtime also exports =="
-ar t "${LIBCHDB_A}" | grep -E '^lib(cxx|cxxabi|unwind)__' > "${WORK_DIR}/runtime_members.txt" || true
-runtime_member_count=$(wc -l < "${WORK_DIR}/runtime_members.txt" | tr -d ' ')
-if [ "${runtime_member_count}" -eq 0 ]; then
-    fail "no libcxx__/libcxxabi__/libunwind__ members in the archive - has the member naming in create_static_libchdb.py changed?"
+echo "== Gate 2: bundled runtime objects export nothing =="
+if ! ar t "${LIBCHDB_A}" > "${WORK_DIR}/all_members.txt"; then
+    fail "could not list the archive members"
 else
-    mkdir -p "${WORK_DIR}/objs"
-    (cd "${WORK_DIR}/objs" && xargs ar x "${LIBCHDB_A}" < "${WORK_DIR}/runtime_members.txt")
-    archive_visible_exports "${WORK_DIR}/objs" | sort -u > "${WORK_DIR}/runtime_exports.txt"
-
-    comm -12 "${WORK_DIR}/runtime_exports.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/overlap.txt"
-    overlap=$(wc -l < "${WORK_DIR}/overlap.txt" | tr -d ' ')
-    echo "  runtime objects: ${runtime_member_count}, still-visible symbols: $(wc -l < "${WORK_DIR}/runtime_exports.txt" | tr -d ' ')"
-    if [ "${overlap}" -eq 0 ]; then
-        echo "PASS"
+    grep_optional -E '^lib(cxx|cxxabi|unwind)__' "${WORK_DIR}/all_members.txt" \
+        > "${WORK_DIR}/runtime_members.txt"
+    runtime_member_count=$(wc -l < "${WORK_DIR}/runtime_members.txt" | tr -d ' ')
+    if [ "${runtime_member_count}" -eq 0 ]; then
+        fail "no libcxx__/libcxxabi__/libunwind__ members among the $(wc -l < "${WORK_DIR}/all_members.txt" | tr -d ' ') archive members - has the naming in create_static_libchdb.py changed?"
     else
-        echo "  first 20 of ${overlap} colliding symbols:"
-        head -20 "${WORK_DIR}/overlap.txt" | sed 's/^/    /'
-        fail "${overlap} bundled runtime symbols can be bound to the system runtime"
+        mkdir -p "${WORK_DIR}/objs"
+        (cd "${WORK_DIR}/objs" && xargs ar x "${LIBCHDB_A}" < "${WORK_DIR}/runtime_members.txt")
+        extracted=$(find "${WORK_DIR}/objs" -name '*.o' | wc -l | tr -d ' ')
+        if [ "${extracted}" -ne "${runtime_member_count}" ]; then
+            fail "extracted ${extracted} of ${runtime_member_count} runtime members"
+        fi
+
+        if [ "${PLATFORM}" = Darwin ]; then
+            # Only the -m listing spells out "private external"; -g alone shows hidden
+            # symbols too and would report a hardened archive as unprotected.
+            find "${WORK_DIR}/objs" -name '*.o' -print0 \
+                | xargs -0 nm -m -g --defined-only > "${WORK_DIR}/nm.txt"
+            awk '!/private external/ && $NF ~ /^_/ { print substr($NF, 2) }' "${WORK_DIR}/nm.txt" \
+                | sort -u > "${WORK_DIR}/runtime_exports.txt"
+        else
+            find "${WORK_DIR}/objs" -name '*.o' -print0 \
+                | xargs -0 -n 50 readelf -sW > "${WORK_DIR}/readelf.txt"
+            elf_visible_defined < "${WORK_DIR}/readelf.txt" | sort -u > "${WORK_DIR}/runtime_exports.txt"
+        fi
+
+        # Asserted at zero, not merely "disjoint from this host's system runtime". These
+        # three targets are built to have no externally visible definitions at all, and a
+        # symbol that is simply absent from the running OS version would otherwise slip
+        # through. Measured 0 across 58 archive members on macOS and 83 objects on Linux.
+        visible=$(wc -l < "${WORK_DIR}/runtime_exports.txt" | tr -d ' ')
+        comm -12 "${WORK_DIR}/runtime_exports.txt" "${WORK_DIR}/system_exports.txt" \
+            > "${WORK_DIR}/overlap.txt"
+        overlap=$(wc -l < "${WORK_DIR}/overlap.txt" | tr -d ' ')
+        echo "  runtime objects: ${runtime_member_count}, externally visible definitions: ${visible}"
+        if [ "${visible}" -eq 0 ]; then
+            echo "PASS"
+        else
+            echo "  first 20 (${overlap} of ${visible} are also defined by the system runtime):"
+            { [ "${overlap}" -gt 0 ] && cat "${WORK_DIR}/overlap.txt" || cat "${WORK_DIR}/runtime_exports.txt"; } \
+                | head -20 | sed 's/^/    /'
+            fail "${visible} bundled runtime symbols are still externally visible"
+        fi
     fi
 fi
 echo
@@ -199,7 +243,7 @@ if [ "${PLATFORM}" = Darwin ]; then
     export MACOSX_DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET}"
 else
     # -rdynamic is the point, not an accident: it is what puts default-visibility archive
-    # symbols into .dynsym, which is what gate 1 then asserts is empty of runtime symbols.
+    # symbols into .dynsym, which is what gate 1 then asserts is free of runtime symbols.
     platform_flags=(-rdynamic -lpthread -ldl -lm -lrt -Wl,--allow-multiple-definition)
 fi
 
@@ -218,29 +262,54 @@ fi
 echo
 
 # --- Gate 1: what the probe still exposes -----------------------------------------------
-echo "== Gate 1: nothing in the probe can bind the bundled runtime elsewhere =="
-probe_bindable "${PROBE}" | sort -u > "${WORK_DIR}/probe_bindable.txt"
-total_bindable=$(wc -l < "${WORK_DIR}/probe_bindable.txt" | tr -d ' ')
-comm -12 "${WORK_DIR}/probe_bindable.txt" "${WORK_DIR}/system_exports.txt" > "${WORK_DIR}/probe_overlap.txt"
-risky=$(wc -l < "${WORK_DIR}/probe_overlap.txt" | tr -d ' ')
+# Symbols in the linked probe that another image could still supply. Returns non-zero if the
+# inspection tool itself failed, so that is not mistaken for "nothing to bind".
+probe_candidates () {
+    local probe=$1 raw="${WORK_DIR}/probe_raw.txt"
+    if [ "${PLATFORM}" = Darwin ]; then
+        dyld_info -fixups "${probe}" > "${raw}" 2>/dev/null || return 1
+        [ -s "${raw}" ] || return 1
+        grep_optional '<weak-def-coalesce>' "${raw}" | sed 's|.*<weak-def-coalesce>/_||'
+    else
+        readelf --dyn-syms -W "${probe}" > "${raw}" 2>/dev/null || return 1
+        [ -s "${raw}" ] || return 1
+        elf_visible_defined < "${raw}"
+    fi
+}
 
-# The gate is the intersection with the system runtime, not the raw total. On Mach-O most of
-# the raw records are ClickHouse/abseil/magic_enum template instantiations: weak by
-# definition, defined nowhere else, so dyld can only bind them to this image. Measured on a
-# pre-fix arm64 archive at deployment target 26.0: 33102 records, 479 system-overlapping,
-# probe hangs in chdb_connect. With the bundled runtimes hidden: 29692 records, 0
-# system-overlapping, probe passes.
-echo "  candidate symbols: ${total_bindable} (informational), resolvable from the system runtime: ${risky}"
-if [ "${risky}" -eq 0 ]; then
-    echo "PASS"
+echo "== Gate 1: nothing in the probe can bind the bundled runtime elsewhere =="
+if ! probe_candidates "${PROBE}" > "${WORK_DIR}/probe_bindable_unsorted.txt"; then
+    fail "could not inspect the probe's fixups/dynamic symbols; gate 1 was not evaluated"
 else
-    head -20 "${WORK_DIR}/probe_overlap.txt" | sed 's/^/    /'
-    fail "${risky} bundled runtime symbols can be bound to the system runtime"
+    sort -u "${WORK_DIR}/probe_bindable_unsorted.txt" > "${WORK_DIR}/probe_bindable.txt"
+    total_bindable=$(wc -l < "${WORK_DIR}/probe_bindable.txt" | tr -d ' ')
+    comm -12 "${WORK_DIR}/probe_bindable.txt" "${WORK_DIR}/system_exports.txt" \
+        > "${WORK_DIR}/probe_overlap.txt"
+    risky=$(wc -l < "${WORK_DIR}/probe_overlap.txt" | tr -d ' ')
+
+    # The gate is the intersection with the system runtime, not the raw total. On Mach-O most
+    # of the raw records are ClickHouse/abseil/magic_enum template instantiations: weak by
+    # definition, defined nowhere else, so dyld can only bind them to this image. Measured on
+    # a pre-fix arm64 archive at deployment target 26.0: 33102 records, 479
+    # system-overlapping, probe hangs in chdb_connect. With the bundled runtimes hidden:
+    # 29692 records, 0 system-overlapping, probe passes.
+    echo "  candidate symbols: ${total_bindable} (informational), resolvable from the system runtime: ${risky}"
+    if [ "${total_bindable}" -eq 0 ]; then
+        # A real binary always has some: template instantiations on Mach-O, crt and the
+        # CHDB_EXPORT C API in .dynsym on ELF. Zero means the extraction produced nothing,
+        # so the overlap below would be zero no matter what the archive contains.
+        fail "no candidate symbols found at all - extraction is broken, gate 1 would pass vacuously"
+    elif [ "${risky}" -eq 0 ]; then
+        echo "PASS"
+    else
+        head -20 "${WORK_DIR}/probe_overlap.txt" | sed 's/^/    /'
+        fail "${risky} bundled runtime symbols can be bound to the system runtime"
+    fi
 fi
 if [ "${PLATFORM}" = Linux ]; then
     # Informational: a dependency here would mean C++ runtime symbols are being satisfied
     # dynamically rather than from the bundled copy.
-    echo "  system C++ runtime linked into the probe: $(ldd "${PROBE}" 2>/dev/null | grep -cE 'libstdc\+\+|libc\+\+') library/libraries"
+    echo "  system C++ runtime shared libraries linked into the probe: $(ldd "${PROBE}" 2>/dev/null | grep -c 'libstdc++\|libc++' || true)"
 fi
 echo
 
@@ -251,13 +320,13 @@ echo "== Gate 4: probe connects and runs a query =="
 # coreutils `timeout`.
 (cd "${WORK_DIR}" && ./chdb_static_probe) &
 probe_pid=$!
-( sleep "${PROBE_TIMEOUT:-120}"; kill -9 "${probe_pid}" 2>/dev/null ) &
+( sleep "${PROBE_TIMEOUT}"; kill -9 "${probe_pid}" 2>/dev/null ) &
 watchdog_pid=$!
 disown "${watchdog_pid}" 2>/dev/null || true
 if wait "${probe_pid}"; then
     echo "PASS"
 else
-    fail "probe did not complete successfully (killed after ${PROBE_TIMEOUT:-120}s if it hung)"
+    fail "probe did not complete successfully (killed after ${PROBE_TIMEOUT}s if it hung)"
 fi
 kill "${watchdog_pid}" 2>/dev/null || true
 echo

--- a/chdb/build/go-example/cgo_darwin.go
+++ b/chdb/build/go-example/cgo_darwin.go
@@ -11,6 +11,10 @@ package main
 // whose symbols are not directly referenced by Go cgo code, even though dyld
 // would otherwise run the static initializer at library load. Symbol-level
 // dead-strip still runs, so binary size grows by only ~40 KB.
-#cgo LDFLAGS: -mmacosx-version-min=10.15 -L. -Wl,-force_load,./libchdb.a -liconv -framework CoreFoundation -framework Security
+// 12.0 is the first deployment target for which ld emits chained fixups. Below it this
+// link produces none, so it cannot catch bundled-runtime symbols coalescing with the
+// system libc++/libc++abi - and with -force_load this binary carries the whole archive,
+// making it the most exposed consumer we test.
+#cgo LDFLAGS: -mmacosx-version-min=12.0 -L. -Wl,-force_load,./libchdb.a -liconv -framework CoreFoundation -framework Security
 */
 import "C"

--- a/chdb/build/go-example/cgo_darwin.go
+++ b/chdb/build/go-example/cgo_darwin.go
@@ -11,10 +11,6 @@ package main
 // whose symbols are not directly referenced by Go cgo code, even though dyld
 // would otherwise run the static initializer at library load. Symbol-level
 // dead-strip still runs, so binary size grows by only ~40 KB.
-// 12.0 is the first deployment target for which ld emits chained fixups. Below it this
-// link produces none, so it cannot catch bundled-runtime symbols coalescing with the
-// system libc++/libc++abi - and with -force_load this binary carries the whole archive,
-// making it the most exposed consumer we test.
-#cgo LDFLAGS: -mmacosx-version-min=12.0 -L. -Wl,-force_load,./libchdb.a -liconv -framework CoreFoundation -framework Security
+#cgo LDFLAGS: -mmacosx-version-min=10.15 -L. -Wl,-force_load,./libchdb.a -liconv -framework CoreFoundation -framework Security
 */
 import "C"

--- a/chdb/build/static-probe/chdb_static_probe.c
+++ b/chdb/build/static-probe/chdb_static_probe.c
@@ -52,7 +52,10 @@ int main(void)
         return 1;
     }
 
-    printf("probe: chdb_version=%s, SELECT 1 + 1 -> %.*s", chdb_version(), (int)length, buffer);
+    /* Print the newline here rather than relying on the payload: the CSV result happens to
+       end in one, but a format whose output does not would run into the next line. */
+    size_t shown = (length > 0 && buffer[length - 1] == '\n') ? length - 1 : length;
+    printf("probe: chdb_version=%s, SELECT 1 + 1 -> %.*s\n", chdb_version(), (int)shown, buffer);
     chdb_destroy_query_result(result);
     chdb_close_conn(conn);
     return 0;

--- a/chdb/build/static-probe/chdb_static_probe.c
+++ b/chdb/build/static-probe/chdb_static_probe.c
@@ -1,0 +1,59 @@
+/* Runtime half of the libchdb.a release gates (issue #198).
+ *
+ * Deliberately plain C and deliberately minimal: the point is not API coverage but that a
+ * statically linked libchdb.a reaches a working engine. The historical failure mode was a
+ * binary that built fine and then hung on the first chdb_connect, because dyld had bound
+ * the bundled libc++/libc++abi weak definitions to the system runtime instead.
+ *
+ * check_static_lib_hermetic.sh additionally links this with -u for every symbol in the
+ * checked-in C API allow-list, so the probe covers the whole contract at link time even
+ * though it only calls a few functions at run time.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "chdb.h"
+
+int main(void)
+{
+    char * argv[] = {"chdb_static_probe"};
+    chdb_connection * conn = chdb_connect(1, argv);
+    if (!conn)
+    {
+        fprintf(stderr, "probe: chdb_connect returned NULL\n");
+        return 1;
+    }
+
+    chdb_result * result = chdb_query(*conn, "SELECT 1 + 1", "CSV");
+    if (!result)
+    {
+        fprintf(stderr, "probe: chdb_query returned NULL\n");
+        chdb_close_conn(conn);
+        return 1;
+    }
+
+    const char * error = chdb_result_error(result);
+    if (error)
+    {
+        fprintf(stderr, "probe: query failed: %s\n", error);
+        chdb_destroy_query_result(result);
+        chdb_close_conn(conn);
+        return 1;
+    }
+
+    const char * buffer = chdb_result_buffer(result);
+    size_t length = chdb_result_length(result);
+    if (!buffer || length < 1 || strncmp(buffer, "2", 1) != 0)
+    {
+        fprintf(stderr, "probe: expected \"2\", got \"%.*s\"\n", (int)length, buffer ? buffer : "");
+        chdb_destroy_query_result(result);
+        chdb_close_conn(conn);
+        return 1;
+    }
+
+    printf("probe: chdb_version=%s, SELECT 1 + 1 -> %.*s", chdb_version(), (int)length, buffer);
+    chdb_destroy_query_result(result);
+    chdb_close_conn(conn);
+    return 0;
+}

--- a/cmake/bundled_runtime_visibility.cmake
+++ b/cmake/bundled_runtime_visibility.cmake
@@ -5,10 +5,16 @@
 # chdb/libchdb_export_macos.txt on macOS. `libchdb.a` has no link step of its own, so the
 # equivalent gate has to be baked into the objects at compile time.
 #
-# Without it, ld on a modern macOS deployment target turns the runtime's weak definitions
-# into `<weak-def-coalesce>` fixups, and dyld is free to bind them to the system
-# libc++/libc++abi rather than the bundled copy. Runtime state then straddles two runtimes
-# and the first C API call that touches it hangs or aborts.
+# Without it the bundled runtime stays reachable from outside the archive, and its state can
+# end up split between two runtimes - at which point the first C API call that touches that
+# state hangs or aborts. The exposure differs per format:
+#
+#   Mach-O  on a deployment target of 12.0 or newer ld turns the runtime's weak definitions
+#           into `<weak-def-coalesce>` fixups and dyld may bind them to the system
+#           libc++/libc++abi instead of the bundled copy.
+#   ELF     default-visibility definitions land in `.dynsym` and become interposable. A
+#           plain executable link does not expose them; `-rdynamic`, or repackaging the
+#           archive into a shared object, does.
 #
 # `-fvisibility=hidden` on its own is not enough: the LLVM runtimes annotate their ABI
 # symbols `__attribute__((visibility("default")))`, which beats the command-line default.
@@ -20,12 +26,12 @@
 # consume the libc++ headers, or their inline code would be compiled against a different
 # visibility ABI than the runtime it links with.
 #
-# Scope is deliberately three targets on one platform. A project-wide `-fvisibility=hidden`
-# duplicates inline statics such as `Context::global_context_instance` per translation unit
-# and breaks singleton identity - see the CFI block in the root CMakeLists.txt for the
-# empirical write-up.
+# Scope is deliberately three targets in the static-library build only. A project-wide
+# `-fvisibility=hidden` duplicates inline statics such as
+# `Context::global_context_instance` per translation unit and breaks singleton identity -
+# see the CFI block in the root CMakeLists.txt for the empirical write-up.
 
-if (OS_DARWIN AND CHDB_STATIC_LIBRARY_BUILD)
+if (CHDB_STATIC_LIBRARY_BUILD AND (OS_DARWIN OR OS_LINUX))
     set (HIDE_BUNDLED_RUNTIME ON)
 else ()
     set (HIDE_BUNDLED_RUNTIME OFF)

--- a/cmake/bundled_runtime_visibility.cmake
+++ b/cmake/bundled_runtime_visibility.cmake
@@ -1,0 +1,54 @@
+# Hidden visibility for the bundled LLVM runtimes (libc++, libc++abi, libunwind).
+#
+# `libchdb.so` / `libchdb.dylib` gate their exports at link time: `--version-script` with
+# chdb/libchdb_export.map on Linux, `-exported_symbols_list` with
+# chdb/libchdb_export_macos.txt on macOS. `libchdb.a` has no link step of its own, so the
+# equivalent gate has to be baked into the objects at compile time.
+#
+# Without it, ld on a modern macOS deployment target turns the runtime's weak definitions
+# into `<weak-def-coalesce>` fixups, and dyld is free to bind them to the system
+# libc++/libc++abi rather than the bundled copy. Runtime state then straddles two runtimes
+# and the first C API call that touches it hangs or aborts.
+#
+# `-fvisibility=hidden` on its own is not enough: the LLVM runtimes annotate their ABI
+# symbols `__attribute__((visibility("default")))`, which beats the command-line default.
+# The `_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS` / `_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS`
+# / `_LIBUNWIND_HIDE_SYMBOLS` macros switch those annotations off; each target sets its own
+# next to its other definitions.
+#
+# Everything is PRIVATE. The annotation-disabling macros must not reach targets that merely
+# consume the libc++ headers, or their inline code would be compiled against a different
+# visibility ABI than the runtime it links with.
+#
+# Scope is deliberately three targets on one platform. A project-wide `-fvisibility=hidden`
+# duplicates inline statics such as `Context::global_context_instance` per translation unit
+# and breaks singleton identity - see the CFI block in the root CMakeLists.txt for the
+# empirical write-up.
+
+if (OS_DARWIN AND CHDB_STATIC_LIBRARY_BUILD)
+    set (HIDE_BUNDLED_RUNTIME ON)
+else ()
+    set (HIDE_BUNDLED_RUNTIME OFF)
+endif ()
+
+# Replaceable global operator new/delete are emitted default-visible no matter what
+# `-fvisibility` says; hiding them needs a dedicated flag. Clang 18 renamed it and
+# deprecated the old spelling (which is now a `-Wdeprecated` error under `-Werror`).
+# Build-time flag probes are blocked project-wide (cmake/block_build_time_checks.cmake),
+# so this is a version gate; the project requires Clang >= 21 (cmake/tools.cmake), which
+# makes the older branch defensive only.
+if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
+    set (GLOBAL_NEW_DELETE_HIDDEN_FLAG "-fvisibility-global-new-delete=force-hidden")
+else ()
+    set (GLOBAL_NEW_DELETE_HIDDEN_FLAG "-fvisibility-global-new-delete-hidden")
+endif ()
+
+# Apply the visibility flags to one bundled runtime target. Callers guard on
+# HIDE_BUNDLED_RUNTIME and add that target's own annotation-disabling macros.
+function (hide_bundled_runtime target)
+    # Assembly sources take no `-fvisibility` (they honour the macros instead, via
+    # libunwind's assembly.h), so restrict the flags to the compiled languages.
+    target_compile_options (${target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:C,CXX>:-fvisibility=hidden>"
+        "$<$<COMPILE_LANGUAGE:C,CXX>:${GLOBAL_NEW_DELETE_HIDDEN_FLAG}>")
+endfunction ()

--- a/contrib/libcxx-cmake/CMakeLists.txt
+++ b/contrib/libcxx-cmake/CMakeLists.txt
@@ -106,3 +106,19 @@ target_compile_definitions(cxx PUBLIC -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS
 
 target_link_libraries(cxx PUBLIC cxx-headers)
 target_link_libraries(cxx PUBLIC cxxabi)
+
+# The module is included from the root CMakeLists.txt before the default_libs.cmake dispatch
+# that adds this directory. If that ordering ever breaks, `if (HIDE_BUNDLED_RUNTIME)` would
+# silently read an undefined variable as false and the hardening would vanish without a
+# single warning, so check explicitly instead.
+if (NOT COMMAND hide_bundled_runtime)
+    message (FATAL_ERROR "cmake/bundled_runtime_visibility.cmake must be included before "
+        "this directory is added; see the include in the root CMakeLists.txt.")
+endif ()
+
+# Keep the bundled runtime out of the static library's exported surface.
+# See cmake/bundled_runtime_visibility.cmake.
+if (HIDE_BUNDLED_RUNTIME)
+    target_compile_definitions(cxx PRIVATE -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS=)
+    hide_bundled_runtime(cxx)
+endif ()

--- a/contrib/libcxxabi-cmake/CMakeLists.txt
+++ b/contrib/libcxxabi-cmake/CMakeLists.txt
@@ -55,3 +55,22 @@ if (USE_MUSL)
         "${ClickHouse_SOURCE_DIR}/contrib/musl/arch/generic"
     )
 endif()
+
+# The module is included from the root CMakeLists.txt before the default_libs.cmake dispatch
+# that adds this directory. If that ordering ever breaks, `if (HIDE_BUNDLED_RUNTIME)` would
+# silently read an undefined variable as false and the hardening would vanish without a
+# single warning, so check explicitly instead.
+if (NOT COMMAND hide_bundled_runtime)
+    message (FATAL_ERROR "cmake/bundled_runtime_visibility.cmake must be included before "
+        "this directory is added; see the include in the root CMakeLists.txt.")
+endif ()
+
+# Keep the bundled runtime out of the static library's exported surface. Both macros are
+# needed: cxxabi's own headers carry _LIBCXXABI_* annotations, its sources also pull in
+# libc++ headers. See cmake/bundled_runtime_visibility.cmake.
+if (HIDE_BUNDLED_RUNTIME)
+    target_compile_definitions(cxxabi PRIVATE
+        -D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS
+        -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS=)
+    hide_bundled_runtime(cxxabi)
+endif ()

--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -43,6 +43,24 @@ target_compile_options(unwind PRIVATE -Wno-unused-but-set-variable)
 # Example: DwarfInstructions.hpp: register unsigned long long x16 __asm("x16") = cfa;
 target_compile_options(unwind PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-register>")
 
+# The module is included from the root CMakeLists.txt before the default_libs.cmake dispatch
+# that adds this directory. If that ordering ever breaks, `if (HIDE_BUNDLED_RUNTIME)` would
+# silently read an undefined variable as false and the hardening would vanish without a
+# single warning, so check explicitly instead.
+if (NOT COMMAND hide_bundled_runtime)
+    message (FATAL_ERROR "cmake/bundled_runtime_visibility.cmake must be included before "
+        "this directory is added; see the include in the root CMakeLists.txt.")
+endif ()
+
+# Keep the bundled runtime out of the static library's exported surface. The macro applies
+# to every language including ASM - libunwind's assembly.h emits `.private_extern` for it -
+# while hide_bundled_runtime() keeps -fvisibility off the .S sources.
+# See cmake/bundled_runtime_visibility.cmake.
+if (HIDE_BUNDLED_RUNTIME)
+    target_compile_definitions(unwind PRIVATE -D_LIBUNWIND_HIDE_SYMBOLS)
+    hide_bundled_runtime(unwind)
+endif ()
+
 if (USE_MUSL)
     add_dependencies(unwind musl-headers)
     # The arch dirs are not in the toolchain flags to avoid include order issues in musl's own build.


### PR DESCRIPTION
Closes #198

`libchdb.so` gates its exported surface at link time. `libchdb.a` is
handed to a linker we do not control, so it had no equivalent gate: the
bundled libc++/libc++abi/libunwind stays reachable from outside the
archive and its state can end up split between two runtimes, at which
point the first C API call that touches that state hangs.

The exposure differs per format, which is why this went unnoticed:

| format | condition | pre-fix | post-fix |
| --- | --- | --- | --- |
| Mach-O | deployment target >= 12.0 | 479 coalescing symbols the system runtime also defines; hangs in `chdb_connect` | 0; passes |
| ELF | `-rdynamic` | 2268 visible runtime symbols are also defined by system libstdc++/libgcc_s | 0 |

Below those conditions — `-mmacosx-version-min=10.15`, or a plain
executable link — nothing is exposed at all, so the paths CI already
exercised could not see the bug.

## Change

Object-level visibility on three targets only: `cxx`, `cxxabi`, `unwind`.
All `PRIVATE`, gated on `CHDB_STATIC_LIBRARY_BUILD AND (OS_DARWIN OR
OS_LINUX)`. The Python wheel, `libchdb.so` and the WASM build are
untouched, and there is no project-wide visibility change: that variant is
recorded in the CFI block of the root `CMakeLists.txt` as breaking
singleton identity for header inline statics.

`-fvisibility=hidden` alone is not the fix, and Linux is the proof. The
project has set `CMAKE_CXX_VISIBILITY_PRESET hidden` for `NOT OS_DARWIN`
all along (`CMakeLists.txt:38`), yet the bundled runtime was still fully
exposed there, because libc++ pins `visibility("default")` on its ABI
symbols in the source and a source annotation beats the command-line
default. The `_LIBCPP`/`_LIBCXXABI`/`_LIBUNWIND` annotation-disabling
macros are what actually close it; on ELF the flag is a no-op.

## Gates

`chdb/build/check_static_lib_hermetic.sh`, five gates, same on both
platforms with per-platform tools:

1. nothing in the probe can bind the bundled runtime to the system runtime
2. no-link archive check: the bundled runtime objects must have no
   externally visible definitions at all, scoped to
   `libcxx__`/`libcxxabi__`/`libunwind__` members so ClickHouse's own
   template symbols cannot swamp the signal
3. a. the two export allow-lists describe the same C API contract;
   b. every symbol in it is forced with `-Wl,-u`, so an API that got
   hidden or that minimisation dropped fails the link
4. the linked probe runs `chdb_connect` and a query, under a watchdog

No symbol count is hard-coded. Every extraction checks tool failure
separately from an empty result, since an empty result is also what a
clean archive looks like. The probe is the only thing that links at a
12.0 floor; `chdb_example` and the Go example keep their existing
deployment targets, because `chdb_example`'s link map drives the object
pruning in `create_minimal_libchdb.py`.

Acceptance is "the probe runs", not "the build succeeds".

## Verification

macOS: full local arm64 rebuild, all five gates pass — 63/63 contract
symbols resolve, 0 externally visible definitions across 58 runtime
members, 0 system-bindable records out of 29692 candidates, probe returns
`SELECT 1 + 1 -> 2`.

Linux: the three runtime targets built from the real
libc++/libc++abi/libunwind sources, 83 objects, with and without the
annotation-disabling macros.

| | macros off | macros on |
| --- | --- | --- |
| externally visible definitions | 2370 | 0 |
| also defined by the system runtime | 2268 | 0 |

Both gate directions were additionally validated in a container against a
synthetic archive mirroring the real member naming and the 63-symbol
contract. The full-archive gate run happens on the first CI build.

## Note for reviewers

Two silent-failure modes were found and closed while building this, and
they are the reason the gates are shaped the way they are.

An include-order mistake initially left the hardening entirely absent
while configure and build stayed green — `if (HIDE_BUNDLED_RUNTIME)` read
an undefined variable as false. The three configurations now fail loudly
if the module has not been loaded.

Gate 1 itself could pass vacuously: the fixup extraction ended in
`|| true`, which tolerated grep finding no matches but also swallowed a
failure of `dyld_info` itself. Reproduced, then fixed by checking the
tool's status separately and treating a candidate count of zero as a
failure in its own right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate bundled runtime symbols in `libchdb.a`
> - Adds [cmake/bundled_runtime_visibility.cmake](https://github.com/chdb-io/chdb-core/pull/199/files#diff-2dc3d81f0d99e47128ab9eb1b7b2865c87bbca2a05acb36e7a3b8038b032dfc2) to apply hidden visibility to libcxx, libcxxabi, and libunwind in static builds.
> - Adds [check_static_lib_hermetic.sh](https://github.com/chdb-io/chdb-core/pull/199/files#diff-8da2876a0a2ce5607b4a2e6177599a602b692a9c110ad072f1d171c02cd6c157) and [check_export_contract.py](https://github.com/chdb-io/chdb-core/pull/199/files#diff-096597437c58f5951101b02495fa14d219b151b702f62e61475a01d69b65dc1f) to verify no bundled symbols are visible and export allow-lists match.
> - Runs the hermetic gate in macOS wheel workflows and [build_static_lib.sh](https://github.com/chdb-io/chdb-core/pull/199/files#diff-03b21b38d1c1dd2cb78ee0f41f06913eb9d41d355702fa013507b0ab03a6767f).
> - Behavioral Change: Build fails early if [CMakeLists.txt](https://github.com/chdb-io/chdb-core/pull/199/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) does not include `bundled_runtime_visibility.cmake` before the bundled runtime subdirectories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f203cc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->