### PR TITLE
Package Linux ARM64 debuginfo as tar.xz to stay under GitHub's 2 GiB asset limit

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -586,8 +586,12 @@ jobs:
       - name: Package debug symbols
         run: |
           ls *.debug
-          tar -czvf linux-aarch64-debuginfo.tar.gz *.debug
-          ls -lh linux-aarch64-debuginfo.tar.gz
+          # xz instead of gzip: the aarch64 debuginfo exceeds GitHub's 2 GiB
+          # release-asset limit as .tar.gz (2.2 GiB as of v26.7.1-rc.1), so the
+          # upload 422'd silently (masked by continue-on-error) and the release
+          # shipped without it. Matches build_linux_x86_wheels.yml.
+          XZ_OPT='-T0 -4' tar -cJvf linux-aarch64-debuginfo.tar.xz *.debug
+          ls -lh linux-aarch64-debuginfo.tar.xz
       # -----------------------------------------------------------------------
       # chdb-core-lite: slim variant build & smoke test (~50 MB wheel)
       # chdb/build.sh's CHDB_LITE branch skips the libchdb.so link entirely —
@@ -761,7 +765,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         continue-on-error: true
         run: |
-          gh release upload ${{ github.ref_name }} linux-aarch64-debuginfo.tar.gz --clobber
+          gh release upload ${{ github.ref_name }} linux-aarch64-debuginfo.tar.xz --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/upload-artifact@v7
@@ -771,7 +775,7 @@ jobs:
             ./dist/*.whl
             ./linux-aarch64-libchdb.tar.gz
             ./linux-aarch64-libchdb-static.tar.gz
-            ./linux-aarch64-debuginfo.tar.gz
+            ./linux-aarch64-debuginfo.tar.xz
           overwrite: true
       - name: Upload pypi
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -586,10 +586,6 @@ jobs:
       - name: Package debug symbols
         run: |
           ls *.debug
-          # xz instead of gzip: the aarch64 debuginfo exceeds GitHub's 2 GiB
-          # release-asset limit as .tar.gz (2.2 GiB as of v26.7.1-rc.1), so the
-          # upload 422'd silently (masked by continue-on-error) and the release
-          # shipped without it. Matches build_linux_x86_wheels.yml.
           XZ_OPT='-T0 -4' tar -cJvf linux-aarch64-debuginfo.tar.xz *.debug
           ls -lh linux-aarch64-debuginfo.tar.xz
       # -----------------------------------------------------------------------


### PR DESCRIPTION
The aarch64 debuginfo release asset is packaged with gzip. As of `v26.7.1-rc.1` it reached 2.2 GiB, over GitHub's 2 GiB per-asset limit, so the upload 422'd (`size must be less than 2147483648`). `continue-on-error: true` on the upload step masked the failure, so the release shipped without ARM64 debug symbols.

Switch to `.tar.xz` (multithreaded, `-4`), matching `build_linux_x86_wheels.yml`. Compression drops it well under the limit — the x86_64 `.tar.xz` is ~1.4 GiB.

Fixes #200

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Package Linux ARM64 debuginfo as `tar.xz` instead of `tar.gz`
> Switches the debug symbols archive in `build_linux_arm64_wheels-gh.yml` from gzip to xz compression (`XZ_OPT='-T0 -4' tar -cJvf`) to stay under GitHub's 2 GiB asset limit. Updates the release upload and `actions/upload-artifact` steps to reference the new `linux-aarch64-debuginfo.tar.xz` filename.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc8e920.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->