### PR TITLE
Give a durable control plane the three engine primitives it cannot write itself

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -321,6 +321,7 @@ jobs:
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
           bash -x ./examples/runShutdownTest.sh
+          bash -x ./examples/runDurableAbiTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -306,6 +306,7 @@ jobs:
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
           bash -x ./examples/runShutdownTest.sh
+          bash -x ./examples/runDurableAbiTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -351,6 +351,7 @@ jobs:
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
           bash -x ./examples/runShutdownTest.sh
+          bash -x ./examples/runDurableAbiTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -352,6 +352,7 @@ jobs:
           bash -x ./examples/runQueryParamsTest.sh
           bash -x ./examples/runStreamQueryEofTest.sh
           bash -x ./examples/runShutdownTest.sh
+          bash -x ./examples/runDurableAbiTest.sh
       # Both ADBC validation suites, against the libchdb just built. Placed
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.

--- a/.gitignore
+++ b/.gitignore
@@ -284,6 +284,9 @@ test_main
 /examples/chdbStreamInsertTest
 /examples/chdbStreamQueryEofTest
 /examples/chdbShutdownTest
+/examples/chdbDurableAbiTest
+/examples/chdb_durable_abi_test_db
+/examples/chdb_durable_abi_test_backups
 libchdb.so
 *.gz
 *.bz2

--- a/chdb/build/check_statement_coverage.py
+++ b/chdb/build/check_statement_coverage.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Every top-level statement the engine can parse must have a classification test.
+
+`examples/chdbDurableAbiTest.c` asserts a class for each statement shape, and a
+durable control plane trusts that table: a statement the classifier has no
+opinion about comes back UNKNOWN, which the caller refuses. That is the safe
+direction, but only if someone notices. A hand-written table does not notice --
+`ParserCopyQuery` sat in the engine unlisted while the test claimed to cover
+every shape.
+
+So the table is checked against the engine instead of trusted. The alternatives
+tried by `ParserQuery::parseImpl` and `ParserQueryWithOutput::parseImpl` are the
+definition of "top-level statement"; every one of them must appear in the test
+table's `parser` column, or be listed below with a reason.
+
+Run from anywhere; exits non-zero and names the gap when one appears.
+"""
+
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PARSER_SOURCES = [
+    os.path.join(REPO, "src", "Parsers", "ParserQuery.cpp"),
+    os.path.join(REPO, "src", "Parsers", "ParserQueryWithOutput.cpp"),
+]
+TEST_TABLE = os.path.join(REPO, "examples", "chdbDurableAbiTest.c")
+
+# Parsers that are not a top-level statement alternative of their own.
+NOT_A_STATEMENT = {
+    # Recurses into itself for the EXECUTE AS / PARALLEL WITH sub-query.
+    "ParserQuery",
+    # An aggregate: its own alternatives are enumerated in the other file.
+    "ParserQueryWithOutput",
+    # Clause helpers for INTO OUTFILE / FORMAT, not statements.
+    "ParserIdentifier",
+    "ParserStringLiteral",
+}
+
+# Statement alternatives the test table cannot exercise, with the reason.
+# Removing an entry is how you promote one back into the table.
+UNREACHABLE = {
+    "ParserCreateMaskingPolicy": (
+        "no accepted spelling in this build -- every CREATE/ALTER MASKING POLICY "
+        "form tried against libchdb parses as UNKNOWN"
+    ),
+}
+
+
+def parsers_declared_in(path):
+    """The Parser types instantiated as alternatives in a parseImpl."""
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+    return set(re.findall(r"^\s+(Parser[A-Za-z0-9_]+)\s+[a-z_]+_p\b", text, re.MULTILINE))
+
+
+def parsers_covered_by_table(path):
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+    match = re.search(r"k_all_statements\[\]\s*=\s*\{(.*?)\n\};", text, re.DOTALL)
+    if not match:
+        raise SystemExit(f"{path}: could not find the k_all_statements table")
+    return set(re.findall(r'\{\s*"(Parser[A-Za-z0-9_]+)"', match.group(1)))
+
+
+def main():
+    engine = set()
+    for source in PARSER_SOURCES:
+        if not os.path.exists(source):
+            raise SystemExit(f"missing parser source: {source}")
+        engine |= parsers_declared_in(source)
+    engine -= NOT_A_STATEMENT
+
+    covered = parsers_covered_by_table(TEST_TABLE)
+
+    uncovered = engine - covered - set(UNREACHABLE)
+    stale_exemptions = set(UNREACHABLE) - engine
+    stale_rows = covered - engine
+
+    failed = False
+
+    if uncovered:
+        failed = True
+        print(
+            "These statement parsers have no row in the chdbDurableAbiTest table.\n"
+            "Add one asserting the class the statement must get, or add it to\n"
+            "UNREACHABLE in this script with the reason it cannot be tested:",
+            file=sys.stderr,
+        )
+        for name in sorted(uncovered):
+            print(f"  {name}", file=sys.stderr)
+
+    if stale_exemptions:
+        failed = True
+        print(
+            "\nThese are exempted here but no longer exist in the engine; drop them:",
+            file=sys.stderr,
+        )
+        for name in sorted(stale_exemptions):
+            print(f"  {name}", file=sys.stderr)
+
+    if stale_rows:
+        failed = True
+        print(
+            "\nThe test table names parsers the engine no longer has; drop those rows:",
+            file=sys.stderr,
+        )
+        for name in sorted(stale_rows):
+            print(f"  {name}", file=sys.stderr)
+
+    if failed:
+        return 1
+
+    print(
+        f"statement coverage: {len(covered)} of {len(engine)} top-level parsers tested, "
+        f"{len(UNREACHABLE)} exempted"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -71,6 +71,11 @@
         chdb_adbc_init;
         AdbcDriverInit;
 
+        /* Backup, Restore and Statement Classification */
+        chdb_backup_database_n;
+        chdb_restore_database_n;
+        chdb_classify_query_n;
+
         /* Signal Handler Control */
         chdb_set_signal_handlers_enabled;
         chdb_reset_signal_handlers;

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -63,6 +63,10 @@ _chdb_stream_fetch_arrow
 _chdb_adbc_init
 _AdbcDriverInit
 
+_chdb_backup_database_n
+_chdb_restore_database_n
+_chdb_classify_query_n
+
 _chdb_set_signal_handlers_enabled
 _chdb_reset_signal_handlers
 

--- a/examples/chdbDurableAbiTest.c
+++ b/examples/chdbDurableAbiTest.c
@@ -179,123 +179,140 @@ static void expect_backup_error(chdb_connection conn, const char * label, const 
  * this table is what says so. */
 struct statement_case
 {
+    /// The ParserQuery / ParserQueryWithOutput alternative that produces this
+    /// statement. check_statement_coverage.py reads these and fails when a
+    /// parser in the engine has no row here -- which is what makes a
+    /// newly-added statement type show up as a failure rather than as an
+    /// UNKNOWN in someone's log.
+    const char * parser;
     const char * sql;
     chdb_query_class want;
 };
 
 static const struct statement_case k_all_statements[] = {
     /* Reads */
-    {"EXPLAIN SELECT 1", CHDB_QUERY_READ_ONLY},
-    {"SELECT 1", CHDB_QUERY_READ_ONLY},
-    {"SHOW TABLES", CHDB_QUERY_READ_ONLY},
-    {"SHOW COLUMNS FROM t", CHDB_QUERY_READ_ONLY},
-    {"SHOW ENGINES", CHDB_QUERY_READ_ONLY},
-    {"SHOW FUNCTIONS", CHDB_QUERY_READ_ONLY},
-    {"SHOW INDEXES FROM t", CHDB_QUERY_READ_ONLY},
-    {"SHOW SETTING max_threads", CHDB_QUERY_READ_ONLY},
-    {"SHOW PROCESSLIST", CHDB_QUERY_READ_ONLY},
-    {"SHOW ACCESS", CHDB_QUERY_READ_ONLY},
-    {"SHOW USERS", CHDB_QUERY_READ_ONLY},
-    {"SHOW GRANTS", CHDB_QUERY_READ_ONLY},
-    {"SHOW PRIVILEGES", CHDB_QUERY_READ_ONLY},
-    {"SHOW CREATE USER u", CHDB_QUERY_READ_ONLY},
-    {"SHOW CREATE ROLE r", CHDB_QUERY_READ_ONLY},
-    {"SHOW CREATE TABLE t", CHDB_QUERY_READ_ONLY},
-    {"SHOW CREATE DATABASE d", CHDB_QUERY_READ_ONLY},
-    {"EXISTS TABLE t", CHDB_QUERY_READ_ONLY},
-    {"DESCRIBE TABLE t", CHDB_QUERY_READ_ONLY},
-    {"DESCRIBE FILESYSTEM CACHE 'x'", CHDB_QUERY_READ_ONLY},
-    {"CHECK TABLE t", CHDB_QUERY_READ_ONLY},
-    {"CHECK ALL TABLES", CHDB_QUERY_READ_ONLY},
+    {"ParserExplainQuery", "EXPLAIN SELECT 1", CHDB_QUERY_READ_ONLY},
+    {"ParserSelectWithUnionQuery", "SELECT 1", CHDB_QUERY_READ_ONLY},
+    {"ParserShowTablesQuery", "SHOW TABLES", CHDB_QUERY_READ_ONLY},
+    {"ParserShowColumnsQuery", "SHOW COLUMNS FROM t", CHDB_QUERY_READ_ONLY},
+    {"ParserShowEnginesQuery", "SHOW ENGINES", CHDB_QUERY_READ_ONLY},
+    {"ParserShowFunctionsQuery", "SHOW FUNCTIONS", CHDB_QUERY_READ_ONLY},
+    {"ParserShowIndexesQuery", "SHOW INDEXES FROM t", CHDB_QUERY_READ_ONLY},
+    {"ParserShowSettingQuery", "SHOW SETTING max_threads", CHDB_QUERY_READ_ONLY},
+    {"ParserShowProcesslistQuery", "SHOW PROCESSLIST", CHDB_QUERY_READ_ONLY},
+    {"ParserShowAccessQuery", "SHOW ACCESS", CHDB_QUERY_READ_ONLY},
+    {"ParserShowAccessEntitiesQuery", "SHOW USERS", CHDB_QUERY_READ_ONLY},
+    {"ParserShowGrantsQuery", "SHOW GRANTS", CHDB_QUERY_READ_ONLY},
+    {"ParserShowPrivilegesQuery", "SHOW PRIVILEGES", CHDB_QUERY_READ_ONLY},
+    {"ParserShowCreateAccessEntityQuery", "SHOW CREATE USER u", CHDB_QUERY_READ_ONLY},
+    {"ParserShowCreateAccessEntityQuery", "SHOW CREATE ROLE r", CHDB_QUERY_READ_ONLY},
+    {"ParserTablePropertiesQuery", "SHOW CREATE TABLE t", CHDB_QUERY_READ_ONLY},
+    {"ParserTablePropertiesQuery", "SHOW CREATE DATABASE d", CHDB_QUERY_READ_ONLY},
+    {"ParserTablePropertiesQuery", "EXISTS TABLE t", CHDB_QUERY_READ_ONLY},
+    {"ParserDescribeTableQuery", "DESCRIBE TABLE t", CHDB_QUERY_READ_ONLY},
+    {"ParserDescribeCacheQuery", "DESCRIBE FILESYSTEM CACHE 'x'", CHDB_QUERY_READ_ONLY},
+    {"ParserCheckQuery", "CHECK TABLE t", CHDB_QUERY_READ_ONLY},
+    {"ParserCheckQuery", "CHECK ALL TABLES", CHDB_QUERY_READ_ONLY},
 
     /* Writes a checkpoint of the database carries */
-    {"INSERT INTO t VALUES (1)", CHDB_QUERY_MUTATING},
-    {"CREATE TABLE t (a Int) ENGINE=Memory", CHDB_QUERY_MUTATING},
-    {"ALTER TABLE t ADD COLUMN b Int", CHDB_QUERY_MUTATING},
-    {"ALTER DATABASE d MODIFY SETTING x = 1", CHDB_QUERY_MUTATING},
-    {"RENAME TABLE a TO b", CHDB_QUERY_MUTATING},
-    {"DROP TABLE t", CHDB_QUERY_MUTATING},
-    {"TRUNCATE TABLE t", CHDB_QUERY_MUTATING},
-    {"UNDROP TABLE t", CHDB_QUERY_MUTATING},
-    {"OPTIMIZE TABLE t", CHDB_QUERY_MUTATING},
-    {"DELETE FROM t WHERE 1", CHDB_QUERY_MUTATING},
-    {"UPDATE t SET a = 1 WHERE 1", CHDB_QUERY_MUTATING},
-    {"CREATE INDEX i ON t (a) TYPE minmax", CHDB_QUERY_MUTATING},
-    {"DROP INDEX i ON t", CHDB_QUERY_MUTATING},
+    {"ParserInsertQuery", "INSERT INTO t VALUES (1)", CHDB_QUERY_MUTATING},
+    {"ParserCreateQuery", "CREATE TABLE t (a Int) ENGINE=Memory", CHDB_QUERY_MUTATING},
+    {"ParserAlterQuery", "ALTER TABLE t ADD COLUMN b Int", CHDB_QUERY_MUTATING},
+    {"ParserAlterQuery", "ALTER DATABASE d MODIFY SETTING x = 1", CHDB_QUERY_MUTATING},
+    {"ParserRenameQuery", "RENAME TABLE a TO b", CHDB_QUERY_MUTATING},
+    {"ParserDropQuery", "DROP TABLE t", CHDB_QUERY_MUTATING},
+    {"ParserDropQuery", "TRUNCATE TABLE t", CHDB_QUERY_MUTATING},
+    {"ParserUndropQuery", "UNDROP TABLE t", CHDB_QUERY_MUTATING},
+    {"ParserOptimizeQuery", "OPTIMIZE TABLE t", CHDB_QUERY_MUTATING},
+    {"ParserDeleteQuery", "DELETE FROM t WHERE 1", CHDB_QUERY_MUTATING},
+    {"ParserUpdateQuery", "UPDATE t SET a = 1 WHERE 1", CHDB_QUERY_MUTATING},
+    {"ParserCreateIndexQuery", "CREATE INDEX i ON t (a) TYPE minmax", CHDB_QUERY_MUTATING},
+    {"ParserDropIndexQuery", "DROP INDEX i ON t", CHDB_QUERY_MUTATING},
     /* An ingest path feeding rows through a table function in the SELECT
      * still writes into the database, so a checkpoint carries it. Only
      * INSERT INTO FUNCTION writes somewhere else. */
-    {"INSERT INTO t SELECT * FROM format(JSONEachRow, '{\"a\":1}')", CHDB_QUERY_MUTATING},
-    {"INSERT INTO t SELECT * FROM url('http://x', JSONEachRow)", CHDB_QUERY_MUTATING},
+    {"ParserInsertQuery", "INSERT INTO t SELECT * FROM format(JSONEachRow, '{\"a\":1}')", CHDB_QUERY_MUTATING},
+    {"ParserInsertQuery", "INSERT INTO t SELECT * FROM url('http://x', JSONEachRow)", CHDB_QUERY_MUTATING},
 
     /* Reaching the `system` database is global whatever the verb, because no
      * `BACKUP DATABASE` covers it. */
-    {"INSERT INTO system.wasm_modules VALUES ('m', 'b')", CHDB_QUERY_MUTATING_GLOBAL},
-    {"ALTER TABLE system.t MODIFY COLUMN c String", CHDB_QUERY_MUTATING_GLOBAL},
-    {"DROP TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
-    {"TRUNCATE TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserInsertQuery", "INSERT INTO system.wasm_modules VALUES ('m', 'b')", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserAlterQuery", "ALTER TABLE system.t MODIFY COLUMN c String", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropQuery", "DROP TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropQuery", "TRUNCATE TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
 
     /* A temporary table lives outside every database, so no backup of one
      * holds it; CHECK GRANT only evaluates and changes nothing. */
-    {"CREATE TEMPORARY TABLE tmp (a Int32)", CHDB_QUERY_CONTROL},
-    {"DROP TEMPORARY TABLE tmp", CHDB_QUERY_CONTROL},
-    {"CHECK GRANT SELECT ON *.*", CHDB_QUERY_READ_ONLY},
+    {"ParserCreateQuery", "CREATE TEMPORARY TABLE tmp (a Int32)", CHDB_QUERY_CONTROL},
+    {"ParserDropQuery", "DROP TEMPORARY TABLE tmp", CHDB_QUERY_CONTROL},
+    {"ParserCheckGrantQuery", "CHECK GRANT SELECT ON *.*", CHDB_QUERY_READ_ONLY},
 
     /* A partition move names its destination on the command, not on the
      * statement; `SETTINGS x = DEFAULT` resets the connection's choice by
      * another spelling. */
-    {"ALTER TABLE t MOVE PARTITION 1 TO TABLE other.t", CHDB_QUERY_MUTATING},
-    {"INSERT INTO t SETTINGS async_insert = DEFAULT VALUES (1)", CHDB_QUERY_CONTROL},
-    {"INSERT INTO t SETTINGS mutations_sync = DEFAULT VALUES (1)", CHDB_QUERY_CONTROL},
+    {"ParserAlterQuery", "ALTER TABLE t MOVE PARTITION 1 TO TABLE other.t", CHDB_QUERY_MUTATING},
+    {"ParserInsertQuery", "INSERT INTO t SETTINGS async_insert = DEFAULT VALUES (1)", CHDB_QUERY_CONTROL},
+    {"ParserInsertQuery", "INSERT INTO t SETTINGS mutations_sync = DEFAULT VALUES (1)", CHDB_QUERY_CONTROL},
 
     /* Session and server state */
-    {"USE d", CHDB_QUERY_CONTROL},
-    {"SET max_threads=1", CHDB_QUERY_CONTROL},
-    {"SET ROLE r", CHDB_QUERY_CONTROL},
-    {"SYSTEM FLUSH LOGS", CHDB_QUERY_CONTROL},
-    {"SYSTEM FLUSH ASYNC INSERT QUEUE", CHDB_QUERY_CONTROL},
-    {"KILL QUERY WHERE 1", CHDB_QUERY_CONTROL},
-    {"ATTACH TABLE t", CHDB_QUERY_CONTROL},
-    {"ATTACH DATABASE d", CHDB_QUERY_CONTROL},
-    {"DETACH TABLE t", CHDB_QUERY_CONTROL},
-    {"BACKUP DATABASE d TO File('x')", CHDB_QUERY_CONTROL},
-    {"RESTORE DATABASE d FROM File('x')", CHDB_QUERY_CONTROL},
-    {"BEGIN TRANSACTION", CHDB_QUERY_CONTROL},
-    {"COMMIT", CHDB_QUERY_CONTROL},
-    {"ROLLBACK", CHDB_QUERY_CONTROL},
-    {"SET TRANSACTION SNAPSHOT 1", CHDB_QUERY_CONTROL},
-    {"WATCH lv", CHDB_QUERY_CONTROL},
-    {"EXECUTE AS u SELECT 1", CHDB_QUERY_CONTROL},
+    {"ParserUseQuery", "USE d", CHDB_QUERY_CONTROL},
+    {"ParserSetQuery", "SET max_threads=1", CHDB_QUERY_CONTROL},
+    {"ParserSetRoleQuery", "SET ROLE r", CHDB_QUERY_CONTROL},
+    {"ParserSystemQuery", "SYSTEM FLUSH LOGS", CHDB_QUERY_CONTROL},
+    {"ParserSystemQuery", "SYSTEM FLUSH ASYNC INSERT QUEUE", CHDB_QUERY_CONTROL},
+    {"ParserKillQueryQuery", "KILL QUERY WHERE 1", CHDB_QUERY_CONTROL},
+    {"ParserCreateQuery", "ATTACH TABLE t", CHDB_QUERY_CONTROL},
+    {"ParserCreateQuery", "ATTACH DATABASE d", CHDB_QUERY_CONTROL},
+    {"ParserDropQuery", "DETACH TABLE t", CHDB_QUERY_CONTROL},
+    {"ParserBackupQuery", "BACKUP DATABASE d TO File('x')", CHDB_QUERY_CONTROL},
+    {"ParserBackupQuery", "RESTORE DATABASE d FROM File('x')", CHDB_QUERY_CONTROL},
+    {"ParserTransactionControl", "BEGIN TRANSACTION", CHDB_QUERY_CONTROL},
+    {"ParserTransactionControl", "COMMIT", CHDB_QUERY_CONTROL},
+    {"ParserTransactionControl", "ROLLBACK", CHDB_QUERY_CONTROL},
+    {"ParserTransactionControl", "SET TRANSACTION SNAPSHOT 1", CHDB_QUERY_CONTROL},
+    {"ParserWatchQuery", "WATCH lv", CHDB_QUERY_CONTROL},
+    {"ParserExecuteAsQuery", "EXECUTE AS u SELECT 1", CHDB_QUERY_CONTROL},
     /* Partition moves touch the filesystem, not the table's content */
-    {"ALTER TABLE t FREEZE", CHDB_QUERY_CONTROL},
-    {"ALTER TABLE t MOVE PARTITION 1 TO DISK 'd'", CHDB_QUERY_CONTROL},
+    {"ParserAlterQuery", "ALTER TABLE t FREEZE", CHDB_QUERY_CONTROL},
+    {"ParserAlterQuery", "ALTER TABLE t MOVE PARTITION 1 TO DISK 'd'", CHDB_QUERY_CONTROL},
     /* Objects that live beside the databases, so no checkpoint holds them */
-    {"CREATE FUNCTION f AS (x) -> x", CHDB_QUERY_MUTATING_GLOBAL},
-    {"DROP FUNCTION f", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE WORKLOAD w", CHDB_QUERY_MUTATING_GLOBAL},
-    {"DROP WORKLOAD w", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE RESOURCE r (WRITE DISK d)", CHDB_QUERY_MUTATING_GLOBAL},
-    {"DROP RESOURCE r", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE NAMED COLLECTION nc AS a = 1", CHDB_QUERY_MUTATING_GLOBAL},
-    {"DROP NAMED COLLECTION nc", CHDB_QUERY_MUTATING_GLOBAL},
-    {"ALTER NAMED COLLECTION nc SET a = 2", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE HYPOTHETICAL INDEX hi ON t (a) TYPE minmax", CHDB_QUERY_CONTROL},
-    {"DROP ALL HYPOTHETICAL INDEXES", CHDB_QUERY_CONTROL},
+    {"ParserCreateFunctionQuery", "CREATE FUNCTION f AS (x) -> x", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropFunctionQuery", "DROP FUNCTION f", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateWorkloadQuery", "CREATE WORKLOAD w", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropWorkloadQuery", "DROP WORKLOAD w", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateResourceQuery", "CREATE RESOURCE r (WRITE DISK d)", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropResourceQuery", "DROP RESOURCE r", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateNamedCollectionQuery", "CREATE NAMED COLLECTION nc AS a = 1", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropNamedCollectionQuery", "DROP NAMED COLLECTION nc", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserAlterNamedCollectionQuery", "ALTER NAMED COLLECTION nc SET a = 2", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserHypotheticalIndexQuery", "CREATE HYPOTHETICAL INDEX hi ON t (a) TYPE minmax", CHDB_QUERY_CONTROL},
+    {"ParserHypotheticalIndexQuery", "DROP ALL HYPOTHETICAL INDEXES", CHDB_QUERY_CONTROL},
     /* Access management */
-    {"CREATE USER u IDENTIFIED WITH no_password", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE ROLE r", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE QUOTA q", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE ROW POLICY p ON t", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CREATE SETTINGS PROFILE sp", CHDB_QUERY_MUTATING_GLOBAL},
-    {"DROP USER u", CHDB_QUERY_MUTATING_GLOBAL},
-    {"MOVE USER u TO local_directory", CHDB_QUERY_MUTATING_GLOBAL},
-    {"GRANT SELECT ON *.* TO u", CHDB_QUERY_MUTATING_GLOBAL},
-    {"REVOKE SELECT ON *.* FROM u", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateUserQuery", "CREATE USER u IDENTIFIED WITH no_password", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateRoleQuery", "CREATE ROLE r", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateQuotaQuery", "CREATE QUOTA q", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateRowPolicyQuery", "CREATE ROW POLICY p ON t", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserCreateSettingsProfileQuery", "CREATE SETTINGS PROFILE sp", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserDropAccessEntityQuery", "DROP USER u", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserMoveAccessEntityQuery", "MOVE USER u TO local_directory", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserGrantQuery", "GRANT SELECT ON *.* TO u", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ParserGrantQuery", "REVOKE SELECT ON *.* FROM u", CHDB_QUERY_MUTATING_GLOBAL},
 
     /* PARALLEL WITH takes the class of its most restricted arm */
-    {"SELECT 1 PARALLEL WITH SELECT 2", CHDB_QUERY_READ_ONLY},
-    {"INSERT INTO t VALUES (1) PARALLEL WITH SELECT 2", CHDB_QUERY_MUTATING},
-    {"SELECT 1 PARALLEL WITH USE d", CHDB_QUERY_CONTROL},
+    {"ParserParallelWithQuery", "SELECT 1 PARALLEL WITH SELECT 2", CHDB_QUERY_READ_ONLY},
+    {"ParserParallelWithQuery", "INSERT INTO t VALUES (1) PARALLEL WITH SELECT 2", CHDB_QUERY_MUTATING},
+    {"ParserParallelWithQuery", "SELECT 1 PARALLEL WITH USE d", CHDB_QUERY_CONTROL},
+
+    /* Statements the table did not reach before. COPY serves the PostgreSQL
+     * wire protocol and names its endpoint as an identifier, not a string. */
+    {"ParserCopyQuery", "COPY t TO STDOUT", CHDB_QUERY_CONTROL},
+    {"ParserCopyQuery", "COPY t FROM STDIN", CHDB_QUERY_CONTROL},
+    {"ParserSnapshotQuery", "SNAPSHOT TABLE t TO Disk('d','p')", CHDB_QUERY_CONTROL},
+    {"ParserUndropQuery", "UNDROP TABLE t", CHDB_QUERY_MUTATING},
+    {"ParserDeleteQuery", "DELETE FROM t WHERE 1", CHDB_QUERY_MUTATING},
+    {"ParserUpdateQuery", "UPDATE t SET a = 1 WHERE 1", CHDB_QUERY_MUTATING},
+    /* An implicit SELECT: chdb lets a bare expression stand as a query. */
+    {"ParserSelectQuery", "1 + 2", CHDB_QUERY_READ_ONLY},
 };
 
 int main(void)
@@ -647,8 +664,9 @@ int main(void)
             chdb_query_analysis_v1 a;
             if (!analyze(*conn, k_all_statements[i].sql, NULL, &a) || a.query_class != (uint32_t)k_all_statements[i].want)
             {
-                printf("    %-52s want %d, got %u\n",
-                       k_all_statements[i].sql, (int)k_all_statements[i].want, a.query_class);
+                printf("    %-28s %-44s want %d, got %u\n",
+                       k_all_statements[i].parser, k_all_statements[i].sql,
+                       (int)k_all_statements[i].want, a.query_class);
                 wrong++;
             }
         }

--- a/examples/chdbDurableAbiTest.c
+++ b/examples/chdbDurableAbiTest.c
@@ -1,0 +1,597 @@
+/**
+ * chdbDurableAbiTest.c — chdb_backup_database_n, chdb_restore_database_n and
+ * chdb_classify_query_n, the three primitives a durable-object control plane
+ * needs from the engine.
+ *
+ * The control plane lives in the binding: leases, manifests, WAL segments and
+ * object storage are all above this line. What it cannot do for itself is
+ * quote a database name into a BACKUP statement without risking injection, or
+ * decide whether a statement its caller handed it is a read, a write it should
+ * log, or something it should refuse. Both are the parser's job, so both live
+ * here.
+ *
+ * Build: clang examples/chdbDurableAbiTest.c -I./programs/local -L. -lchdb \
+ *          -o examples/chdbDurableAbiTest
+ * Run:   LD_LIBRARY_PATH=. ./examples/chdbDurableAbiTest
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "chdb.h"
+
+static int g_failed = 0;
+
+static void fail(const char * label, const char * detail)
+{
+    printf("%-46s FAIL: %s\n", label, detail);
+    g_failed++;
+}
+
+static void pass(const char * label)
+{
+    printf("%-46s ok\n", label);
+}
+
+/* A statement's class, or a note about why we could not get one. */
+static void expect_class(chdb_connection conn, const char * label, const char * sql, chdb_query_class want)
+{
+    chdb_query_class got = CHDB_QUERY_UNKNOWN;
+    if (chdb_classify_query_n(conn, sql, strlen(sql), &got, NULL) != CHDBSuccess)
+    {
+        fail(label, "chdb_classify_query_n returned CHDBError");
+        return;
+    }
+    if (got != want)
+    {
+        char detail[128];
+        snprintf(detail, sizeof(detail), "want class %d, got %d", (int)want, (int)got);
+        fail(label, detail);
+        return;
+    }
+    pass(label);
+}
+
+/* Run a statement and require it to succeed. */
+static int run(chdb_connection conn, const char * sql)
+{
+    chdb_result * r = chdb_query(conn, sql, "CSV");
+    const char * err = r ? chdb_result_error(r) : "null result";
+    if (err)
+    {
+        printf("setup failed for `%s`: %s\n", sql, err);
+        chdb_destroy_query_result(r);
+        return 0;
+    }
+    chdb_destroy_query_result(r);
+    return 1;
+}
+
+/* Read one scalar as CSV text and compare it. */
+static void expect_scalar(chdb_connection conn, const char * label, const char * sql, const char * want)
+{
+    chdb_result * r = chdb_query(conn, sql, "CSV");
+    const char * err = r ? chdb_result_error(r) : "null result";
+    if (err)
+    {
+        fail(label, err);
+        chdb_destroy_query_result(r);
+        return;
+    }
+    if (chdb_result_length(r) != strlen(want) || memcmp(chdb_result_buffer(r), want, strlen(want)) != 0)
+    {
+        char detail[256];
+        snprintf(detail, sizeof(detail), "want `%s`, got `%.*s`", want, (int)chdb_result_length(r), chdb_result_buffer(r));
+        fail(label, detail);
+        chdb_destroy_query_result(r);
+        return;
+    }
+    chdb_destroy_query_result(r);
+    pass(label);
+}
+
+static void expect_backup_error(chdb_connection conn, const char * label, const char * db, const char * path)
+{
+    chdb_result * r = chdb_backup_database_n(conn, db, strlen(db), path, strlen(path), NULL, 0);
+    const char * err = r ? chdb_result_error(r) : NULL;
+    if (!err)
+        fail(label, "expected an error, got success");
+    else
+        pass(label);
+    chdb_destroy_query_result(r);
+}
+
+
+/* Every shape ParserQuery and ParserQueryWithOutput can produce, and the class
+ * it must get. When upstream adds a statement type, its AST arrives here with
+ * no QueryKind and no entry in the classifier, so it classifies UNKNOWN and
+ * this table is what says so. */
+struct statement_case
+{
+    const char * sql;
+    chdb_query_class want;
+};
+
+static const struct statement_case k_all_statements[] = {
+    /* Reads */
+    {"EXPLAIN SELECT 1", CHDB_QUERY_READ_ONLY},
+    {"SELECT 1", CHDB_QUERY_READ_ONLY},
+    {"SHOW TABLES", CHDB_QUERY_READ_ONLY},
+    {"SHOW COLUMNS FROM t", CHDB_QUERY_READ_ONLY},
+    {"SHOW ENGINES", CHDB_QUERY_READ_ONLY},
+    {"SHOW FUNCTIONS", CHDB_QUERY_READ_ONLY},
+    {"SHOW INDEXES FROM t", CHDB_QUERY_READ_ONLY},
+    {"SHOW SETTING max_threads", CHDB_QUERY_READ_ONLY},
+    {"SHOW PROCESSLIST", CHDB_QUERY_READ_ONLY},
+    {"SHOW ACCESS", CHDB_QUERY_READ_ONLY},
+    {"SHOW USERS", CHDB_QUERY_READ_ONLY},
+    {"SHOW GRANTS", CHDB_QUERY_READ_ONLY},
+    {"SHOW PRIVILEGES", CHDB_QUERY_READ_ONLY},
+    {"SHOW CREATE USER u", CHDB_QUERY_READ_ONLY},
+    {"SHOW CREATE ROLE r", CHDB_QUERY_READ_ONLY},
+    {"SHOW CREATE TABLE t", CHDB_QUERY_READ_ONLY},
+    {"SHOW CREATE DATABASE d", CHDB_QUERY_READ_ONLY},
+    {"EXISTS TABLE t", CHDB_QUERY_READ_ONLY},
+    {"DESCRIBE TABLE t", CHDB_QUERY_READ_ONLY},
+    {"DESCRIBE FILESYSTEM CACHE 'x'", CHDB_QUERY_READ_ONLY},
+    {"CHECK TABLE t", CHDB_QUERY_READ_ONLY},
+    {"CHECK ALL TABLES", CHDB_QUERY_READ_ONLY},
+
+    /* Writes a checkpoint of the database carries */
+    {"INSERT INTO t VALUES (1)", CHDB_QUERY_MUTATING},
+    {"CREATE TABLE t (a Int) ENGINE=Memory", CHDB_QUERY_MUTATING},
+    {"ALTER TABLE t ADD COLUMN b Int", CHDB_QUERY_MUTATING},
+    {"ALTER DATABASE d MODIFY SETTING x = 1", CHDB_QUERY_MUTATING},
+    {"RENAME TABLE a TO b", CHDB_QUERY_MUTATING},
+    {"DROP TABLE t", CHDB_QUERY_MUTATING},
+    {"TRUNCATE TABLE t", CHDB_QUERY_MUTATING},
+    {"UNDROP TABLE t", CHDB_QUERY_MUTATING},
+    {"OPTIMIZE TABLE t", CHDB_QUERY_MUTATING},
+    {"DELETE FROM t WHERE 1", CHDB_QUERY_MUTATING},
+    {"UPDATE t SET a = 1 WHERE 1", CHDB_QUERY_MUTATING},
+    {"CREATE INDEX i ON t (a) TYPE minmax", CHDB_QUERY_MUTATING},
+    {"DROP INDEX i ON t", CHDB_QUERY_MUTATING},
+    /* An ingest path feeding rows through a table function in the SELECT
+     * still writes into the database, so a checkpoint carries it. Only
+     * INSERT INTO FUNCTION writes somewhere else. */
+    {"INSERT INTO t SELECT * FROM format(JSONEachRow, '{\"a\":1}')", CHDB_QUERY_MUTATING},
+    {"INSERT INTO t SELECT * FROM url('http://x', JSONEachRow)", CHDB_QUERY_MUTATING},
+
+    /* Reaching the `system` database is global whatever the verb, because no
+     * `BACKUP DATABASE` covers it. */
+    {"INSERT INTO system.wasm_modules VALUES ('m', 'b')", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ALTER TABLE system.t MODIFY COLUMN c String", CHDB_QUERY_MUTATING_GLOBAL},
+    {"DROP TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
+    {"TRUNCATE TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
+
+    /* Session and server state */
+    {"USE d", CHDB_QUERY_CONTROL},
+    {"SET max_threads=1", CHDB_QUERY_CONTROL},
+    {"SET ROLE r", CHDB_QUERY_CONTROL},
+    {"SYSTEM FLUSH LOGS", CHDB_QUERY_CONTROL},
+    {"SYSTEM FLUSH ASYNC INSERT QUEUE", CHDB_QUERY_CONTROL},
+    {"KILL QUERY WHERE 1", CHDB_QUERY_CONTROL},
+    {"ATTACH TABLE t", CHDB_QUERY_CONTROL},
+    {"ATTACH DATABASE d", CHDB_QUERY_CONTROL},
+    {"DETACH TABLE t", CHDB_QUERY_CONTROL},
+    {"BACKUP DATABASE d TO File('x')", CHDB_QUERY_CONTROL},
+    {"RESTORE DATABASE d FROM File('x')", CHDB_QUERY_CONTROL},
+    {"BEGIN TRANSACTION", CHDB_QUERY_CONTROL},
+    {"COMMIT", CHDB_QUERY_CONTROL},
+    {"ROLLBACK", CHDB_QUERY_CONTROL},
+    {"SET TRANSACTION SNAPSHOT 1", CHDB_QUERY_CONTROL},
+    {"WATCH lv", CHDB_QUERY_CONTROL},
+    {"EXECUTE AS u SELECT 1", CHDB_QUERY_CONTROL},
+    /* Partition moves touch the filesystem, not the table's content */
+    {"ALTER TABLE t FREEZE", CHDB_QUERY_CONTROL},
+    {"ALTER TABLE t MOVE PARTITION 1 TO DISK 'd'", CHDB_QUERY_CONTROL},
+    /* Objects that live beside the databases, so no checkpoint holds them */
+    {"CREATE FUNCTION f AS (x) -> x", CHDB_QUERY_MUTATING_GLOBAL},
+    {"DROP FUNCTION f", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE WORKLOAD w", CHDB_QUERY_MUTATING_GLOBAL},
+    {"DROP WORKLOAD w", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE RESOURCE r (WRITE DISK d)", CHDB_QUERY_MUTATING_GLOBAL},
+    {"DROP RESOURCE r", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE NAMED COLLECTION nc AS a = 1", CHDB_QUERY_MUTATING_GLOBAL},
+    {"DROP NAMED COLLECTION nc", CHDB_QUERY_MUTATING_GLOBAL},
+    {"ALTER NAMED COLLECTION nc SET a = 2", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE HYPOTHETICAL INDEX hi ON t (a) TYPE minmax", CHDB_QUERY_CONTROL},
+    {"DROP ALL HYPOTHETICAL INDEXES", CHDB_QUERY_CONTROL},
+    /* Access management */
+    {"CREATE USER u IDENTIFIED WITH no_password", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE ROLE r", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE QUOTA q", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE ROW POLICY p ON t", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CREATE SETTINGS PROFILE sp", CHDB_QUERY_MUTATING_GLOBAL},
+    {"DROP USER u", CHDB_QUERY_MUTATING_GLOBAL},
+    {"MOVE USER u TO local_directory", CHDB_QUERY_MUTATING_GLOBAL},
+    {"GRANT SELECT ON *.* TO u", CHDB_QUERY_MUTATING_GLOBAL},
+    {"REVOKE SELECT ON *.* FROM u", CHDB_QUERY_MUTATING_GLOBAL},
+    {"CHECK GRANT SELECT ON *.*", CHDB_QUERY_MUTATING_GLOBAL},
+
+    /* PARALLEL WITH takes the class of its most restricted arm */
+    {"SELECT 1 PARALLEL WITH SELECT 2", CHDB_QUERY_READ_ONLY},
+    {"INSERT INTO t VALUES (1) PARALLEL WITH SELECT 2", CHDB_QUERY_MUTATING},
+    {"SELECT 1 PARALLEL WITH USE d", CHDB_QUERY_CONTROL},
+};
+
+int main(void)
+{
+    /* BACKUP TO File() only writes under backups.allowed_path, so a durable
+     * binding sets it to the scratch directory it owns. That constraint is
+     * unchanged by this API -- the engine refuses a path outside it.
+     *
+     * Absolute, because a relative allowed_path resolves against the data
+     * directory and a relative backup path then resolves against that, which
+     * is not where anyone means. A binding managing its own scratch directory
+     * knows the absolute path already. */
+    char cwd[512];
+    if (!getcwd(cwd, sizeof(cwd)))
+    {
+        printf("getcwd failed\n");
+        return 1;
+    }
+
+    char arg0[] = "chdb";
+    char arg1[600];
+    char arg2[600];
+    char backups_dir[600];
+    snprintf(arg1, sizeof(arg1), "--path=%s/chdb_durable_abi_test_db", cwd);
+    snprintf(backups_dir, sizeof(backups_dir), "%s/chdb_durable_abi_test_backups", cwd);
+    snprintf(arg2, sizeof(arg2), "--backups.allowed_path=%s", backups_dir);
+    char * args[] = {arg0, arg1, arg2};
+    chdb_connection * conn = chdb_connect(3, args);
+    if (!conn)
+    {
+        printf("chdb_connect failed\n");
+        return 1;
+    }
+
+    /* A database name that would break naive string concatenation: a dash
+     * needs backticks, and the embedded backtick has to be doubled. */
+    const char * db = "durable-obj`1";
+    if (!run(*conn, "CREATE DATABASE `durable-obj``1`")
+        || !run(*conn, "CREATE TABLE `durable-obj``1`.t (id UInt32, name String) ENGINE = MergeTree ORDER BY id")
+        || !run(*conn, "INSERT INTO `durable-obj``1`.t VALUES (1,'a'),(2,'b'),(3,'c')"))
+    {
+        chdb_close_conn(conn);
+        return 1;
+    }
+
+    /* 1. Classification: the four classes, decided by the parser. */
+    expect_class(*conn, "1a. SELECT is READ_ONLY", "SELECT count() FROM `durable-obj``1`.t", CHDB_QUERY_READ_ONLY);
+    expect_class(*conn, "1b. INSERT is MUTATING", "INSERT INTO t VALUES (4,'d')", CHDB_QUERY_MUTATING);
+    expect_class(*conn, "1c. CREATE TABLE is MUTATING", "CREATE TABLE u (id UInt32) ENGINE = Memory", CHDB_QUERY_MUTATING);
+    expect_class(*conn, "1d. ALTER UPDATE is MUTATING", "ALTER TABLE t UPDATE name = 'z' WHERE id = 1", CHDB_QUERY_MUTATING);
+    expect_class(*conn, "1e. USE is CONTROL", "USE other", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "1f. SET is CONTROL", "SET max_threads = 4", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "1g. ATTACH is CONTROL", "ATTACH TABLE t", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "1h. DETACH is CONTROL", "DETACH TABLE t", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "1i. SYSTEM is CONTROL", "SYSTEM DROP MARK CACHE", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "1j. BACKUP is CONTROL", "BACKUP DATABASE d TO File('x')", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "1k. RESTORE is CONTROL", "RESTORE DATABASE d FROM File('x')", CHDB_QUERY_CONTROL);
+    /* chdb runs with implicit_select on, so a bare expression is a SELECT.
+     * Unparseable means unparseable. */
+    expect_class(*conn, "1l. gibberish is UNKNOWN", "SELECT FROM WHERE ((", CHDB_QUERY_UNKNOWN);
+    expect_class(*conn, "1m. empty input is UNKNOWN", "   ", CHDB_QUERY_UNKNOWN);
+
+    /* A read that writes a file is not a read. */
+    expect_class(*conn, "1n. SELECT INTO OUTFILE is CONTROL", "SELECT 1 INTO OUTFILE 'out.csv'", CHDB_QUERY_CONTROL);
+    expect_class(
+        *conn, "1o. INSERT INTO FUNCTION is CONTROL", "INSERT INTO FUNCTION file('o.csv') SELECT 1", CHDB_QUERY_CONTROL);
+
+    /* Statements outside the database a checkpoint captures. */
+    expect_class(
+        *conn, "1p. CREATE FUNCTION is MUTATING_GLOBAL", "CREATE FUNCTION f AS (x) -> x + 1", CHDB_QUERY_MUTATING_GLOBAL);
+    expect_class(
+        *conn,
+        "1q. CREATE USER is MUTATING_GLOBAL",
+        "CREATE USER u IDENTIFIED WITH no_password",
+        CHDB_QUERY_MUTATING_GLOBAL);
+    expect_class(*conn, "1r. GRANT is MUTATING_GLOBAL", "GRANT SELECT ON *.* TO u", CHDB_QUERY_MUTATING_GLOBAL);
+    expect_class(
+        *conn,
+        "1s. write into system is MUTATING_GLOBAL",
+        "INSERT INTO system.wasm_modules VALUES ('m', 'bytes')",
+        CHDB_QUERY_MUTATING_GLOBAL);
+
+    /* 2. A batch is as restricted as its most restricted statement. */
+    expect_class(*conn, "2a. SELECT; SELECT stays READ_ONLY", "SELECT 1; SELECT 2", CHDB_QUERY_READ_ONLY);
+    expect_class(*conn, "2b. SELECT; INSERT is MUTATING", "SELECT 1; INSERT INTO t VALUES (9,'i')", CHDB_QUERY_MUTATING);
+    expect_class(*conn, "2c. INSERT; USE is CONTROL", "INSERT INTO t VALUES (9,'i'); USE other", CHDB_QUERY_CONTROL);
+    expect_class(*conn, "2d. SELECT; gibberish is UNKNOWN", "SELECT 1; SELECT FROM WHERE ((", CHDB_QUERY_UNKNOWN);
+    expect_class(*conn, "2e. trailing `;` is not a statement", "SELECT 1;", CHDB_QUERY_READ_ONLY);
+    expect_class(*conn, "2f. trailing comment is not a statement", "SELECT 1; -- done", CHDB_QUERY_READ_ONLY);
+    /* Inlined data must be stepped over as data, and what follows it must
+     * still be classified -- otherwise a CONTROL statement hides behind rows. */
+    expect_class(
+        *conn, "2g. INSERT VALUES then SELECT", "INSERT INTO t VALUES (7,'g'); SELECT 1", CHDB_QUERY_MUTATING);
+    expect_class(
+        *conn, "2h. USE hidden behind VALUES rows", "INSERT INTO t VALUES (7,'g'); USE other", CHDB_QUERY_CONTROL);
+    expect_class(
+        *conn,
+        "2i. USE hidden behind FORMAT CSV rows",
+        "INSERT INTO t FORMAT CSV\n7,g\n\nUSE other",
+        CHDB_QUERY_CONTROL);
+    expect_class(
+        *conn,
+        "2j. USE hidden behind EXPLAIN INSERT rows",
+        "EXPLAIN INSERT INTO t VALUES (7,'g'); USE other",
+        CHDB_QUERY_CONTROL);
+
+    /* 3. Classification runs the parser, not the statement. */
+    expect_scalar(*conn, "3a. classify did not run the INSERT", "SELECT count() FROM `durable-obj``1`.t", "3\n");
+
+    /* 4. Backup and restore round-trip, with a name and a path that both need
+     *    quoting and a path holding a space and an apostrophe. */
+    char backup_path[700];
+    snprintf(backup_path, sizeof(backup_path), "%s/it's a backup.tar.gz", backups_dir);
+    {
+        chdb_result * r = chdb_backup_database_n(*conn, db, strlen(db), backup_path, strlen(backup_path), NULL, 0);
+        const char * err = r ? chdb_result_error(r) : "null result";
+        if (err)
+            fail("4a. backup an awkward name to an awkward path", err);
+        else
+            pass("4a. backup an awkward name to an awkward path");
+        chdb_destroy_query_result(r);
+    }
+
+    /* A name and a path that are both non-ASCII. */
+    const char * utf8_db = "数据库-α";
+    char utf8_path[700];
+    snprintf(utf8_path, sizeof(utf8_path), "%s/备份-β.tar.gz", backups_dir);
+    if (!run(*conn, "CREATE DATABASE `数据库-α`")
+        || !run(*conn, "CREATE TABLE `数据库-α`.`данные` (id UInt32) ENGINE = MergeTree ORDER BY id")
+        || !run(*conn, "INSERT INTO `数据库-α`.`данные` VALUES (10),(20)"))
+    {
+        chdb_close_conn(conn);
+        return 1;
+    }
+    {
+        chdb_result * r = chdb_backup_database_n(*conn, utf8_db, strlen(utf8_db), utf8_path, strlen(utf8_path), NULL, 0);
+        const char * err = r ? chdb_result_error(r) : "null result";
+        if (err)
+            fail("4b. backup a non-ASCII name to a non-ASCII path", err);
+        else
+            pass("4b. backup a non-ASCII name to a non-ASCII path");
+        chdb_destroy_query_result(r);
+    }
+
+    /* 5. An existing destination is refused rather than overwritten. */
+    expect_backup_error(*conn, "5a. backup refuses an existing file", db, backup_path);
+
+    /* 6. Drop the database and restore it from the archive. RESTORE names the
+     *    database as it appears in the backup, which is how a durable object
+     *    recovers into a scratch directory under its own name. */
+    if (!run(*conn, "DROP DATABASE `durable-obj``1`"))
+    {
+        chdb_close_conn(conn);
+        return 1;
+    }
+    {
+        chdb_result * r = chdb_restore_database_n(*conn, db, strlen(db), backup_path, strlen(backup_path));
+        const char * err = r ? chdb_result_error(r) : "null result";
+        if (err)
+            fail("6a. restore the dropped database", err);
+        else
+            pass("6a. restore the dropped database");
+        chdb_destroy_query_result(r);
+    }
+    expect_scalar(*conn, "6b. restored rows", "SELECT count() FROM `durable-obj``1`.t", "3\n");
+    expect_scalar(
+        *conn, "6c. restored values", "SELECT name FROM `durable-obj``1`.t ORDER BY id", "\"a\"\n\"b\"\n\"c\"\n");
+    expect_scalar(
+        *conn,
+        "6d. restored schema",
+        "SELECT name, type FROM system.columns WHERE database = 'durable-obj`1' AND table = 't' ORDER BY position",
+        "\"id\",\"UInt32\"\n\"name\",\"String\"\n");
+    /* RESTORE must not move the session onto the restored database. */
+    expect_scalar(*conn, "6e. current database unchanged", "SELECT currentDatabase()", "\"default\"\n");
+
+    /* 7. Paths the engine could not read the way the caller meant. */
+    expect_backup_error(*conn, "7a. path outside allowed_path refused", db, "/tmp/chdb-durable-escape.tar.gz");
+    {
+        char relative[700];
+        snprintf(relative, sizeof(relative), "chdb_durable_abi_test_backups/relative.tar.gz");
+        expect_backup_error(*conn, "7b. relative path refused", db, relative);
+    }
+    {
+        char missing_dir[700];
+        snprintf(missing_dir, sizeof(missing_dir), "%s/no-such-dir/x.tar.gz", backups_dir);
+        expect_backup_error(*conn, "7c. missing directory refused", db, missing_dir);
+    }
+
+    /* 8. An incremental backup writes only what changed since its base. */
+    {
+        char incr_path[700];
+        snprintf(incr_path, sizeof(incr_path), "%s/incremental.tar.gz", backups_dir);
+        chdb_result * r = chdb_backup_database_n(
+            *conn, db, strlen(db), incr_path, strlen(incr_path), backup_path, strlen(backup_path));
+        const char * err = r ? chdb_result_error(r) : "null result";
+        if (err)
+            fail("8a. incremental backup against a base", err);
+        else
+            pass("8a. incremental backup against a base");
+        chdb_destroy_query_result(r);
+    }
+    {
+        /* A base that is not there is an error, not a silent full backup. */
+        char incr2[700], nobase[700];
+        snprintf(incr2, sizeof(incr2), "%s/incremental2.tar.gz", backups_dir);
+        snprintf(nobase, sizeof(nobase), "%s/not-a-base.tar.gz", backups_dir);
+        chdb_result * r = chdb_backup_database_n(
+            *conn, db, strlen(db), incr2, strlen(incr2), nobase, strlen(nobase));
+        if (!chdb_result_error(r))
+            fail("8b. missing base refused", "expected an error, got success");
+        else
+            pass("8b. missing base refused");
+        chdb_destroy_query_result(r);
+    }
+
+    /* 9. Argument validation, before anything reaches the parser. */
+    expect_backup_error(*conn, "9a. empty database name refused", "", backup_path);
+    expect_backup_error(*conn, "9b. empty file path refused", db, "");
+    {
+        chdb_query_class ignored = CHDB_QUERY_UNKNOWN;
+        if (chdb_classify_query_n(NULL, "SELECT 1", 8, &ignored, NULL) != CHDBError)
+            fail("9c. classify on a null connection errors", "expected CHDBError");
+        else
+            pass("9c. classify on a null connection errors");
+        if (chdb_classify_query_n(*conn, "SELECT 1", 8, NULL, NULL) != CHDBError)
+            fail("9d. classify without an out param errors", "expected CHDBError");
+        else
+            pass("9d. classify without an out param errors");
+    }
+
+    /* Secrets: what a caller must not write into a durable log. */
+    {
+        struct { const char * sql; int want; } cases[] = {
+            {"CREATE NAMED COLLECTION nc AS access_key_id = 'AKIA', secret_access_key = 's3cr3t'", 1},
+            {"CREATE USER u IDENTIFIED WITH sha256_password BY 'hunter2'", 1},
+            {"SELECT * FROM s3('https://b/k', 'AKIA', 's3cr3t')", 1},
+            {"CREATE USER u IDENTIFIED WITH no_password", 0},
+            {"CREATE FUNCTION f AS (x) -> x + 1", 0},
+            {"SELECT 1", 0},
+            {"INSERT INTO t VALUES (1)", 0},
+            /* Text that did not parse proves nothing, so it must not claim to. */
+            {"SELECT FROM WHERE ((", 0},
+        };
+        for (size_t i = 0; i < sizeof(cases) / sizeof(*cases); i++)
+        {
+            chdb_query_class cls = CHDB_QUERY_UNKNOWN;
+            int has_secrets = -1;
+            char label[96];
+            snprintf(label, sizeof(label), "9e.%zu has_secrets", i + 1);
+            if (chdb_classify_query_n(*conn, cases[i].sql, strlen(cases[i].sql), &cls, &has_secrets) != CHDBSuccess)
+                fail(label, "chdb_classify_query_n returned CHDBError");
+            else if (has_secrets != cases[i].want)
+            {
+                char detail[256];
+                snprintf(detail, sizeof(detail), "want %d, got %d for `%.90s`", cases[i].want, has_secrets, cases[i].sql);
+                fail(label, detail);
+            }
+            else
+                pass(label);
+        }
+        /* One secret anywhere in a batch taints the batch. */
+        chdb_query_class cls = CHDB_QUERY_UNKNOWN;
+        int has_secrets = 0;
+        const char * batch = "SELECT 1; CREATE USER u IDENTIFIED WITH sha256_password BY 'p'";
+        chdb_classify_query_n(*conn, batch, strlen(batch), &cls, &has_secrets);
+        if (!has_secrets)
+            fail("9f. a secret anywhere taints the batch", "expected has_secrets");
+        else
+            pass("9f. a secret anywhere taints the batch");
+    }
+
+    /* 10. Every top-level statement shape gets a class, and the right one. */
+    {
+        const size_t count = sizeof(k_all_statements) / sizeof(*k_all_statements);
+        size_t wrong = 0;
+        for (size_t i = 0; i < count; i++)
+        {
+            chdb_query_class got = CHDB_QUERY_UNKNOWN;
+            if (chdb_classify_query_n(*conn, k_all_statements[i].sql, strlen(k_all_statements[i].sql), &got, NULL)
+                    != CHDBSuccess
+                || got != k_all_statements[i].want)
+            {
+                printf("    %-52s want %d, got %d\n", k_all_statements[i].sql, (int)k_all_statements[i].want, (int)got);
+                wrong++;
+            }
+        }
+        if (wrong)
+        {
+            char detail[128];
+            snprintf(detail, sizeof(detail), "%zu of %zu statement shapes misclassified", wrong, count);
+            fail("10a. every top-level statement shape", detail);
+        }
+        else
+        {
+            char label[128];
+            snprintf(label, sizeof(label), "10a. all %zu top-level statement shapes", count);
+            pass(label);
+        }
+    }
+
+    /* 11. The archive outlives the connection that wrote it: close the engine,
+     *     open it again on the same path, and restore there. This is the shape
+     *     a durable object actually recovers in. */
+    chdb_close_conn(conn);
+    conn = chdb_connect(3, args);
+    if (!conn)
+    {
+        printf("reconnect failed\n");
+        return 1;
+    }
+    if (!run(*conn, "DROP DATABASE `数据库-α`"))
+    {
+        chdb_close_conn(conn);
+        return 1;
+    }
+    {
+        chdb_result * r = chdb_restore_database_n(*conn, utf8_db, strlen(utf8_db), utf8_path, strlen(utf8_path));
+        const char * err = r ? chdb_result_error(r) : "null result";
+        if (err)
+            fail("11a. restore on a reopened connection", err);
+        else
+            pass("11a. restore on a reopened connection");
+        chdb_destroy_query_result(r);
+    }
+    expect_scalar(*conn, "11b. restored rows", "SELECT sum(id) FROM `数据库-α`.`данные`", "30\n");
+
+    /* 12. The new entry points do not disturb the engine's path model: one
+     *     path per process, several connections to it, a different path only
+     *     once they are all closed. */
+    chdb_close_conn(conn);
+    {
+        char other[600];
+        snprintf(other, sizeof(other), "--path=%s/chdb_durable_abi_test_db2", cwd);
+        char * other_args[] = {arg0, other};
+
+        chdb_connection * first = chdb_connect(3, args);
+        chdb_connection * second = chdb_connect(3, args);
+        if (!first || !second)
+            fail("12a. two connections to one path", "expected both to open");
+        else
+            pass("12a. two connections to one path");
+
+        /* Exercising the new ABI on both must not change what follows. */
+        chdb_query_class cls = CHDB_QUERY_UNKNOWN;
+        if (first)
+            chdb_classify_query_n(*first, "SELECT 1", 8, &cls, NULL);
+        if (second)
+            chdb_classify_query_n(*second, "SELECT 1", 8, &cls, NULL);
+
+        chdb_connection * intruder = chdb_connect(2, other_args);
+        if (intruder)
+        {
+            fail("12b. a second path is refused while one is open", "expected NULL");
+            chdb_close_conn(intruder);
+        }
+        else
+            pass("12b. a second path is refused while one is open");
+
+        if (second)
+            chdb_close_conn(second);
+        if (first)
+            chdb_close_conn(first);
+
+        chdb_connection * after = chdb_connect(2, other_args);
+        if (!after)
+            fail("12c. a second path opens once the first is closed", "expected a connection");
+        else
+        {
+            pass("12c. a second path opens once the first is closed");
+            chdb_close_conn(after);
+        }
+    }
+
+    if (g_failed)
+    {
+        printf("\n%d check(s) failed\n", g_failed);
+        return 1;
+    }
+    printf("\nall checks passed\n");
+    return 0;
+}

--- a/examples/chdbDurableAbiTest.c
+++ b/examples/chdbDurableAbiTest.c
@@ -15,9 +15,11 @@
  * Run:   LD_LIBRARY_PATH=. ./examples/chdbDurableAbiTest
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "chdb.h"
 
@@ -339,6 +341,16 @@ int main(void)
     snprintf(arg1, sizeof(arg1), "--path=%s/chdb_durable_abi_test_db", cwd);
     snprintf(backups_dir, sizeof(backups_dir), "%s/chdb_durable_abi_test_backups", cwd);
     snprintf(arg2, sizeof(arg2), "--backups.allowed_path=%s", backups_dir);
+
+    /* The engine writes backups here but does not create the directory, and
+     * the data directory it does create is a sibling -- so on a fresh checkout
+     * nothing exists yet. Make it here rather than in the runner, so the
+     * command at the top of this file works on its own. */
+    if (mkdir(backups_dir, 0755) != 0 && errno != EEXIST)
+    {
+        printf("could not create %s: %s\n", backups_dir, strerror(errno));
+        return 1;
+    }
     char * args[] = {arg0, arg1, arg2};
     chdb_connection * conn = chdb_connect(3, args);
     if (!conn)

--- a/examples/chdbDurableAbiTest.c
+++ b/examples/chdbDurableAbiTest.c
@@ -241,6 +241,13 @@ static const struct statement_case k_all_statements[] = {
     {"DROP TEMPORARY TABLE tmp", CHDB_QUERY_CONTROL},
     {"CHECK GRANT SELECT ON *.*", CHDB_QUERY_READ_ONLY},
 
+    /* A partition move names its destination on the command, not on the
+     * statement; `SETTINGS x = DEFAULT` resets the connection's choice by
+     * another spelling. */
+    {"ALTER TABLE t MOVE PARTITION 1 TO TABLE other.t", CHDB_QUERY_MUTATING},
+    {"INSERT INTO t SETTINGS async_insert = DEFAULT VALUES (1)", CHDB_QUERY_CONTROL},
+    {"INSERT INTO t SETTINGS mutations_sync = DEFAULT VALUES (1)", CHDB_QUERY_CONTROL},
+
     /* Session and server state */
     {"USE d", CHDB_QUERY_CONTROL},
     {"SET max_threads=1", CHDB_QUERY_CONTROL},
@@ -593,6 +600,12 @@ int main(void)
     expect_contained(*conn, "9i.9 multi-target DROP in target", "DROP TABLE mem.a, mem.b", "mem", 1);
     expect_contained(*conn, "9i.10 multi-target DROP straying", "DROP TABLE mem.a, other.b", "mem", 0);
     expect_contained(*conn, "9i.11 ALTER in target", "ALTER TABLE mem.t ADD COLUMN c String", "mem", 1);
+    expect_contained(
+        *conn, "9i.14 MOVE PARTITION within target", "ALTER TABLE mem.a MOVE PARTITION 1 TO TABLE mem.b", "mem", 1);
+    expect_contained(
+        *conn, "9i.15 MOVE PARTITION straying", "ALTER TABLE mem.a MOVE PARTITION 1 TO TABLE other.b", "mem", 0);
+    expect_contained(
+        *conn, "9i.16 MOVE PARTITION into system", "ALTER TABLE mem.a MOVE PARTITION 1 TO TABLE system.b", "mem", 0);
     expect_contained(*conn, "9i.12 a read writes nothing", "SELECT 1", "mem", 1);
     expect_contained(*conn, "9i.13 no target named", "INSERT INTO mem.t VALUES (1)", NULL, 0);
 
@@ -621,6 +634,9 @@ int main(void)
     expect_class(
         *conn, "9k.4 an unrelated setting is fine", "INSERT INTO t SETTINGS max_threads = 4 VALUES (1)",
         CHDB_QUERY_MUTATING);
+    expect_class(
+        *conn, "9k.5 = DEFAULT is the same override", "INSERT INTO t SETTINGS async_insert = DEFAULT VALUES (1)",
+        CHDB_QUERY_CONTROL);
 
     /* 10. Every top-level statement shape gets a class, and the right one. */
     {

--- a/examples/chdbDurableAbiTest.c
+++ b/examples/chdbDurableAbiTest.c
@@ -34,19 +34,89 @@ static void pass(const char * label)
     printf("%-46s ok\n", label);
 }
 
+/* Run the analysis, or report why it could not run. */
+static int analyze(chdb_connection conn, const char * sql, const char * target_db, chdb_query_analysis_v1 * out)
+{
+    memset(out, 0, sizeof(*out));
+    out->struct_size = sizeof(*out);
+    return chdb_classify_query_n(
+               conn, sql, strlen(sql), target_db, target_db ? strlen(target_db) : 0, out)
+        == CHDBSuccess;
+}
+
 /* A statement's class, or a note about why we could not get one. */
 static void expect_class(chdb_connection conn, const char * label, const char * sql, chdb_query_class want)
 {
-    chdb_query_class got = CHDB_QUERY_UNKNOWN;
-    if (chdb_classify_query_n(conn, sql, strlen(sql), &got, NULL) != CHDBSuccess)
+    chdb_query_analysis_v1 a;
+    if (!analyze(conn, sql, NULL, &a))
     {
         fail(label, "chdb_classify_query_n returned CHDBError");
         return;
     }
-    if (got != want)
+    if (a.query_class != (uint32_t)want)
     {
         char detail[128];
-        snprintf(detail, sizeof(detail), "want class %d, got %d", (int)want, (int)got);
+        snprintf(detail, sizeof(detail), "want class %d, got %u", (int)want, a.query_class);
+        fail(label, detail);
+        return;
+    }
+    pass(label);
+}
+
+/* How many executable statements the text holds. */
+static void expect_count(chdb_connection conn, const char * label, const char * sql, uint32_t want)
+{
+    chdb_query_analysis_v1 a;
+    if (!analyze(conn, sql, NULL, &a))
+    {
+        fail(label, "chdb_classify_query_n returned CHDBError");
+        return;
+    }
+    if (a.statement_count != want)
+    {
+        char detail[128];
+        snprintf(detail, sizeof(detail), "want %u statements, got %u", want, a.statement_count);
+        fail(label, detail);
+        return;
+    }
+    pass(label);
+}
+
+/* Whether every persistent write lands in target_db. */
+static void expect_contained(
+    chdb_connection conn, const char * label, const char * sql, const char * target_db, int want)
+{
+    chdb_query_analysis_v1 a;
+    if (!analyze(conn, sql, target_db, &a))
+    {
+        fail(label, "chdb_classify_query_n returned CHDBError");
+        return;
+    }
+    const int got = (a.flags & CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE) != 0;
+    if (got != want)
+    {
+        char detail[160];
+        snprintf(detail, sizeof(detail), "want contained=%d, got %d for `%.80s`", want, got, sql);
+        fail(label, detail);
+        return;
+    }
+    pass(label);
+}
+
+/* Whether the statement acts on a database as a whole. */
+static void expect_lifecycle(chdb_connection conn, const char * label, const char * sql, int want)
+{
+    chdb_query_analysis_v1 a;
+    if (!analyze(conn, sql, "mem", &a))
+    {
+        fail(label, "chdb_classify_query_n returned CHDBError");
+        return;
+    }
+    const int got = (a.flags & CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE) != 0;
+    if (got != want)
+    {
+        char detail[160];
+        snprintf(detail, sizeof(detail), "want lifecycle=%d, got %d for `%.80s`", want, got, sql);
         fail(label, detail);
         return;
     }
@@ -165,6 +235,12 @@ static const struct statement_case k_all_statements[] = {
     {"DROP TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
     {"TRUNCATE TABLE system.t", CHDB_QUERY_MUTATING_GLOBAL},
 
+    /* A temporary table lives outside every database, so no backup of one
+     * holds it; CHECK GRANT only evaluates and changes nothing. */
+    {"CREATE TEMPORARY TABLE tmp (a Int32)", CHDB_QUERY_CONTROL},
+    {"DROP TEMPORARY TABLE tmp", CHDB_QUERY_CONTROL},
+    {"CHECK GRANT SELECT ON *.*", CHDB_QUERY_READ_ONLY},
+
     /* Session and server state */
     {"USE d", CHDB_QUERY_CONTROL},
     {"SET max_threads=1", CHDB_QUERY_CONTROL},
@@ -208,7 +284,6 @@ static const struct statement_case k_all_statements[] = {
     {"MOVE USER u TO local_directory", CHDB_QUERY_MUTATING_GLOBAL},
     {"GRANT SELECT ON *.* TO u", CHDB_QUERY_MUTATING_GLOBAL},
     {"REVOKE SELECT ON *.* FROM u", CHDB_QUERY_MUTATING_GLOBAL},
-    {"CHECK GRANT SELECT ON *.*", CHDB_QUERY_MUTATING_GLOBAL},
 
     /* PARALLEL WITH takes the class of its most restricted arm */
     {"SELECT 1 PARALLEL WITH SELECT 2", CHDB_QUERY_READ_ONLY},
@@ -433,15 +508,24 @@ int main(void)
     expect_backup_error(*conn, "9a. empty database name refused", "", backup_path);
     expect_backup_error(*conn, "9b. empty file path refused", db, "");
     {
-        chdb_query_class ignored = CHDB_QUERY_UNKNOWN;
-        if (chdb_classify_query_n(NULL, "SELECT 1", 8, &ignored, NULL) != CHDBError)
-            fail("9c. classify on a null connection errors", "expected CHDBError");
+        chdb_query_analysis_v1 a;
+        memset(&a, 0, sizeof(a));
+        a.struct_size = sizeof(a);
+        if (chdb_classify_query_n(NULL, "SELECT 1", 8, NULL, 0, &a) != CHDBError)
+            fail("9c. analysis on a null connection errors", "expected CHDBError");
         else
-            pass("9c. classify on a null connection errors");
-        if (chdb_classify_query_n(*conn, "SELECT 1", 8, NULL, NULL) != CHDBError)
-            fail("9d. classify without an out param errors", "expected CHDBError");
+            pass("9c. analysis on a null connection errors");
+        if (chdb_classify_query_n(*conn, "SELECT 1", 8, NULL, 0, NULL) != CHDBError)
+            fail("9d. analysis without an out param errors", "expected CHDBError");
         else
-            pass("9d. classify without an out param errors");
+            pass("9d. analysis without an out param errors");
+        /* A struct_size the engine would write past is a mismatched build. */
+        memset(&a, 0, sizeof(a));
+        a.struct_size = sizeof(a) - 1;
+        if (chdb_classify_query_n(*conn, "SELECT 1", 8, NULL, 0, &a) != CHDBError)
+            fail("9g. undersized struct_size refused", "expected CHDBError");
+        else
+            pass("9g. undersized struct_size refused");
     }
 
     /* Secrets: what a caller must not write into a durable log. */
@@ -459,13 +543,13 @@ int main(void)
         };
         for (size_t i = 0; i < sizeof(cases) / sizeof(*cases); i++)
         {
-            chdb_query_class cls = CHDB_QUERY_UNKNOWN;
-            int has_secrets = -1;
+            chdb_query_analysis_v1 a;
             char label[96];
             snprintf(label, sizeof(label), "9e.%zu has_secrets", i + 1);
-            if (chdb_classify_query_n(*conn, cases[i].sql, strlen(cases[i].sql), &cls, &has_secrets) != CHDBSuccess)
+            int has_secrets = -1;
+            if (!analyze(*conn, cases[i].sql, NULL, &a))
                 fail(label, "chdb_classify_query_n returned CHDBError");
-            else if (has_secrets != cases[i].want)
+            else if ((has_secrets = (a.flags & CHDB_QUERY_HAS_SECRETS) != 0) != cases[i].want)
             {
                 char detail[256];
                 snprintf(detail, sizeof(detail), "want %d, got %d for `%.90s`", cases[i].want, has_secrets, cases[i].sql);
@@ -475,15 +559,68 @@ int main(void)
                 pass(label);
         }
         /* One secret anywhere in a batch taints the batch. */
-        chdb_query_class cls = CHDB_QUERY_UNKNOWN;
-        int has_secrets = 0;
+        chdb_query_analysis_v1 batch_a;
         const char * batch = "SELECT 1; CREATE USER u IDENTIFIED WITH sha256_password BY 'p'";
-        chdb_classify_query_n(*conn, batch, strlen(batch), &cls, &has_secrets);
-        if (!has_secrets)
+        analyze(*conn, batch, NULL, &batch_a);
+        if (!(batch_a.flags & CHDB_QUERY_HAS_SECRETS))
             fail("9f. a secret anywhere taints the batch", "expected has_secrets");
         else
             pass("9f. a secret anywhere taints the batch");
     }
+
+    /* 9h. Statement count: only a count of one is a statement a caller can
+     *     replay on its own. PARALLEL WITH runs both arms. */
+    expect_count(*conn, "9h.1 one statement", "SELECT 1", 1);
+    expect_count(*conn, "9h.2 two statements", "SELECT 1; SELECT 2", 2);
+    expect_count(*conn, "9h.3 trailing semicolon", "SELECT 1;", 1);
+    expect_count(*conn, "9h.4 trailing comment", "SELECT 1; -- done", 1);
+    expect_count(*conn, "9h.5 PARALLEL WITH counts arms", "SELECT 1 PARALLEL WITH SELECT 2", 2);
+    expect_count(*conn, "9h.6 inlined rows are data", "INSERT INTO t VALUES (1),(2),(3)", 1);
+    expect_count(*conn, "9h.7 statement behind rows", "INSERT INTO t VALUES (1); SELECT 1", 2);
+    expect_count(*conn, "9h.8 unparseable is zero", "SELECT FROM WHERE ((", 0);
+    expect_count(*conn, "9h.9 empty is zero", "   ", 0);
+
+    /* 9i. Write containment. The engine resolves an unqualified name through
+     *     the connection's current database before judging. */
+    expect_contained(*conn, "9i.1 qualified write to target", "INSERT INTO mem.t VALUES (1)", "mem", 1);
+    expect_contained(*conn, "9i.2 write to another database", "INSERT INTO other.t VALUES (1)", "mem", 0);
+    expect_contained(*conn, "9i.3 write into system", "INSERT INTO system.wasm_modules VALUES ('m','b')", "mem", 0);
+    expect_contained(*conn, "9i.4 INSERT INTO FUNCTION", "INSERT INTO FUNCTION file('o.csv') SELECT 1", "mem", 0);
+    expect_contained(*conn, "9i.5 INTO OUTFILE", "SELECT 1 INTO OUTFILE 'o.csv'", "mem", 0);
+    expect_contained(*conn, "9i.6 cross-database RENAME", "RENAME TABLE mem.a TO other.b", "mem", 0);
+    expect_contained(*conn, "9i.7 in-database RENAME", "RENAME TABLE mem.a TO mem.b", "mem", 1);
+    expect_contained(*conn, "9i.8 EXCHANGE across databases", "EXCHANGE TABLES mem.a AND other.b", "mem", 0);
+    expect_contained(*conn, "9i.9 multi-target DROP in target", "DROP TABLE mem.a, mem.b", "mem", 1);
+    expect_contained(*conn, "9i.10 multi-target DROP straying", "DROP TABLE mem.a, other.b", "mem", 0);
+    expect_contained(*conn, "9i.11 ALTER in target", "ALTER TABLE mem.t ADD COLUMN c String", "mem", 1);
+    expect_contained(*conn, "9i.12 a read writes nothing", "SELECT 1", "mem", 1);
+    expect_contained(*conn, "9i.13 no target named", "INSERT INTO mem.t VALUES (1)", NULL, 0);
+
+    /* 9j. Database lifecycle: acting on the container, not inside it. */
+    expect_lifecycle(*conn, "9j.1 CREATE DATABASE", "CREATE DATABASE d", 1);
+    expect_lifecycle(*conn, "9j.2 DROP DATABASE", "DROP DATABASE d", 1);
+    expect_lifecycle(*conn, "9j.3 RENAME DATABASE", "RENAME DATABASE a TO b", 1);
+    expect_lifecycle(*conn, "9j.4 CREATE TABLE is not", "CREATE TABLE mem.t (a Int32) ENGINE = Memory", 0);
+    expect_lifecycle(*conn, "9j.5 DROP TABLE is not", "DROP TABLE mem.t", 0);
+    expect_lifecycle(*conn, "9j.6 INSERT is not", "INSERT INTO mem.t VALUES (1)", 0);
+
+    /* 9k. A statement setting that moves a write off the connection's
+     *     synchronous-completion policy belongs to the connection. */
+    expect_class(
+        *conn, "9k.1 async_insert override", "INSERT INTO t SETTINGS async_insert = 1 VALUES (1)", CHDB_QUERY_CONTROL);
+    expect_class(
+        *conn,
+        "9k.2 wait_for_async_insert override",
+        "INSERT INTO t SETTINGS wait_for_async_insert = 0 VALUES (1)",
+        CHDB_QUERY_CONTROL);
+    expect_class(
+        *conn,
+        "9k.3 mutations_sync override",
+        "ALTER TABLE t UPDATE a = 1 WHERE 1 SETTINGS mutations_sync = 0",
+        CHDB_QUERY_CONTROL);
+    expect_class(
+        *conn, "9k.4 an unrelated setting is fine", "INSERT INTO t SETTINGS max_threads = 4 VALUES (1)",
+        CHDB_QUERY_MUTATING);
 
     /* 10. Every top-level statement shape gets a class, and the right one. */
     {
@@ -491,12 +628,11 @@ int main(void)
         size_t wrong = 0;
         for (size_t i = 0; i < count; i++)
         {
-            chdb_query_class got = CHDB_QUERY_UNKNOWN;
-            if (chdb_classify_query_n(*conn, k_all_statements[i].sql, strlen(k_all_statements[i].sql), &got, NULL)
-                    != CHDBSuccess
-                || got != k_all_statements[i].want)
+            chdb_query_analysis_v1 a;
+            if (!analyze(*conn, k_all_statements[i].sql, NULL, &a) || a.query_class != (uint32_t)k_all_statements[i].want)
             {
-                printf("    %-52s want %d, got %d\n", k_all_statements[i].sql, (int)k_all_statements[i].want, (int)got);
+                printf("    %-52s want %d, got %u\n",
+                       k_all_statements[i].sql, (int)k_all_statements[i].want, a.query_class);
                 wrong++;
             }
         }
@@ -557,11 +693,11 @@ int main(void)
             pass("12a. two connections to one path");
 
         /* Exercising the new ABI on both must not change what follows. */
-        chdb_query_class cls = CHDB_QUERY_UNKNOWN;
+        chdb_query_analysis_v1 a;
         if (first)
-            chdb_classify_query_n(*first, "SELECT 1", 8, &cls, NULL);
+            analyze(*first, "SELECT 1", NULL, &a);
         if (second)
-            chdb_classify_query_n(*second, "SELECT 1", 8, &cls, NULL);
+            analyze(*second, "SELECT 1", NULL, &a);
 
         chdb_connection * intruder = chdb_connect(2, other_args);
         if (intruder)

--- a/examples/chdbDurableAbiTest.c
+++ b/examples/chdbDurableAbiTest.c
@@ -501,10 +501,20 @@ int main(void)
         expect_backup_error(*conn, "7c. missing directory refused", db, missing_dir);
     }
 
-    /* 8. An incremental backup writes only what changed since its base. */
+    /* 8. An incremental backup carries what changed since its base, and the
+     *    pair restores to the current state. Backing up an unchanged database
+     *    and never reading the archive back would pass whatever the archive
+     *    held, so the change has to be made first and read back after. */
     {
         char incr_path[700];
         snprintf(incr_path, sizeof(incr_path), "%s/incremental.tar.gz", backups_dir);
+
+        if (!run(*conn, "INSERT INTO `durable-obj``1`.t VALUES (4,'d')"))
+        {
+            chdb_close_conn(conn);
+            return 1;
+        }
+
         chdb_result * r = chdb_backup_database_n(
             *conn, db, strlen(db), incr_path, strlen(incr_path), backup_path, strlen(backup_path));
         const char * err = r ? chdb_result_error(r) : "null result";
@@ -513,6 +523,26 @@ int main(void)
         else
             pass("8a. incremental backup against a base");
         chdb_destroy_query_result(r);
+
+        /* The incremental archive references its base by the path given above,
+         * which is still where it was written. */
+        if (!run(*conn, "DROP DATABASE `durable-obj``1`"))
+        {
+            chdb_close_conn(conn);
+            return 1;
+        }
+        r = chdb_restore_database_n(*conn, db, strlen(db), incr_path, strlen(incr_path));
+        err = r ? chdb_result_error(r) : "null result";
+        if (err)
+            fail("8b. restore from the incremental pair", err);
+        else
+            pass("8b. restore from the incremental pair");
+        chdb_destroy_query_result(r);
+
+        /* Four rows: three from the base, one only the increment carries. */
+        expect_scalar(*conn, "8c. base rows survived", "SELECT count() FROM `durable-obj``1`.t", "4\n");
+        expect_scalar(
+            *conn, "8d. the increment's own row", "SELECT name FROM `durable-obj``1`.t WHERE id = 4", "\"d\"\n");
     }
     {
         /* A base that is not there is an error, not a silent full backup. */
@@ -522,9 +552,9 @@ int main(void)
         chdb_result * r = chdb_backup_database_n(
             *conn, db, strlen(db), incr2, strlen(incr2), nobase, strlen(nobase));
         if (!chdb_result_error(r))
-            fail("8b. missing base refused", "expected an error, got success");
+            fail("8e. missing base refused", "expected an error, got success");
         else
-            pass("8b. missing base refused");
+            pass("8e. missing base refused");
         chdb_destroy_query_result(r);
     }
 

--- a/examples/runDurableAbiTest.sh
+++ b/examples/runDurableAbiTest.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+# check current os type, and make ldd command
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+# cd to the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+echo "Compile and link"
+${CC:-clang} chdbDurableAbiTest.c -o chdbDurableAbiTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbDurableAbiTest
+
+echo "Run it:"
+# The test resolves both directories against its working directory and creates
+# the data one itself; backups.allowed_path has to exist before the engine will
+# write into it.
+rm -rf chdb_durable_abi_test_db chdb_durable_abi_test_db2 chdb_durable_abi_test_backups
+mkdir chdb_durable_abi_test_backups
+./chdbDurableAbiTest
+rm -rf chdb_durable_abi_test_db chdb_durable_abi_test_db2 chdb_durable_abi_test_backups

--- a/examples/runDurableAbiTest.sh
+++ b/examples/runDurableAbiTest.sh
@@ -30,10 +30,8 @@ export ${LIB_PATH}=..
 ${LDD} chdbDurableAbiTest
 
 echo "Run it:"
-# The test resolves both directories against its working directory and creates
-# the data one itself; backups.allowed_path has to exist before the engine will
-# write into it.
+# The test resolves its directories against the working directory and creates
+# both itself, so this only has to clear whatever a previous run left behind.
 rm -rf chdb_durable_abi_test_db chdb_durable_abi_test_db2 chdb_durable_abi_test_backups
-mkdir chdb_durable_abi_test_backups
 ./chdbDurableAbiTest
 rm -rf chdb_durable_abi_test_db chdb_durable_abi_test_db2 chdb_durable_abi_test_backups

--- a/examples/runDurableAbiTest.sh
+++ b/examples/runDurableAbiTest.sh
@@ -18,6 +18,11 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR"
 
+# The statement table only means what it claims if the engine's parser list is
+# checked against it; a hand-written table cannot notice a new statement type.
+echo "Check statement coverage against the engine's parser list"
+python3 ../chdb/build/check_statement_coverage.py
+
 echo "Compile and link"
 ${CC:-clang} chdbDurableAbiTest.c -o chdbDurableAbiTest -I../programs/local/ -L../ -lchdb
 

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -10,6 +10,7 @@ if (OS_WASM)
         LocalServer.cpp
         EmbeddedServer.cpp
         ChdbClient.cpp
+        QueryClassifier.cpp
     )
 else()
     set (CLICKHOUSE_LOCAL_SOURCES
@@ -21,6 +22,7 @@ else()
         LocalServer.cpp
         EmbeddedServer.cpp
         ChdbClient.cpp
+        QueryClassifier.cpp
     )
 
     # Arrow C Data Interface API + ADBC driver, compiled into both libchdb

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -16,9 +16,15 @@
 #include <Core/Settings.h>
 #include <Core/Block.h>
 #include <Formats/FormatFactory.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadHelpers.h>
+#include <Parsers/ASTExplainQuery.h>
 #include <Parsers/ASTInsertQuery.h>
+#include <Parsers/TokenIterator.h>
 #include <Interpreters/InterpreterSetQuery.h>
+#include <QueryClassifier.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
 #include <Processors/Transforms/AddingDefaultsTransform.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipeline.h>
@@ -46,6 +52,8 @@ namespace Setting
     extern const SettingsUInt64 max_insert_block_size_bytes;
     extern const SettingsUInt64 min_insert_block_size_rows;
     extern const SettingsUInt64 min_insert_block_size_bytes;
+    extern const SettingsUInt64 max_parser_backtracks;
+    extern const SettingsUInt64 max_parser_depth;
 }
 
 ChdbClient::ChdbClient(EmbeddedServer & server_ref, int argc, char ** argv)
@@ -1085,6 +1093,120 @@ void ChdbClient::cancelInsertStreamWithoutLock()
         }
 #endif
     }
+}
+
+namespace
+{
+
+/// Where a parsed statement stops and the next one may begin.
+///
+/// For everything but an INSERT carrying its rows in the query text, the
+/// parser has already left `parsed_end` in the right place. An INSERT stops
+/// the parser at the first byte of the data, and the data is in whatever
+/// format the statement named, so finding its end means reading it the way the
+/// engine would. This mirrors ClientBase's own multi-query split; classifying
+/// a batch differently from how the client would run it is the one thing this
+/// must not do.
+const char * findStatementEnd(const IAST & ast, const char * parsed_end, const char * all_queries_end)
+{
+    const auto * insert = ast.as<ASTInsertQuery>();
+    /// `EXPLAIN INSERT ... VALUES ...` carries its rows the same way.
+    if (!insert)
+    {
+        if (const auto * explain = ast.as<ASTExplainQuery>(); explain && explain->getExplainedQuery())
+            insert = explain->getExplainedQuery()->as<ASTInsertQuery>();
+    }
+    if (!insert || !insert->data)
+        return parsed_end;
+
+    if (insert->format == "Values")
+    {
+        ReadBufferFromMemory data_in(insert->data, all_queries_end - insert->data);
+        skipBOMIfExists(data_in);
+        do
+        {
+            skipWhitespaceAndSQLComments(data_in);
+            if (data_in.eof() || *data_in.position() == ';')
+                break;
+        } while (ValuesBlockInputFormat::skipToNextRow(&data_in, 1, 0));
+        return insert->data + data_in.count();
+    }
+
+    /// Any other format is arbitrary bytes in which a `;` may well be data, so
+    /// the client's convention is that a blank line ends the statement.
+    const auto blank_line = std::string_view(insert->data, all_queries_end - insert->data).find("\n\n");
+    return blank_line == std::string_view::npos ? all_queries_end : insert->data + blank_line;
+}
+
+}
+
+chdb_query_class ChdbClient::classifyQuery(const char * sql, size_t sql_len, bool * out_has_secrets)
+{
+    if (out_has_secrets)
+        *out_has_secrets = false;
+
+    if (!sql || sql_len == 0)
+        return CHDB_QUERY_UNKNOWN;
+
+    std::lock_guard<std::mutex> lock(client_mutex);
+
+    const String text(sql, sql_len);
+    const char * pos = text.data();
+    const char * const end = pos + text.size();
+
+    auto result = CHDB_QUERY_READ_ONLY;
+    bool saw_statement = false;
+
+    try
+    {
+        const Settings & settings = client_context->getSettingsRef();
+        const auto max_parser_depth = static_cast<uint32_t>(settings[Setting::max_parser_depth]);
+        const auto max_parser_backtracks = static_cast<uint32_t>(settings[Setting::max_parser_backtracks]);
+
+        while (pos < end)
+        {
+            /// Step over the separators and any comment between statements, so
+            /// that a trailing `;` or `-- note` is end of input rather than a
+            /// statement that fails to parse.
+            Tokens separators(pos, end);
+            IParser::Pos separator_iterator(separators, max_parser_depth, max_parser_backtracks);
+            while (separator_iterator.isValid() && separator_iterator->type == TokenType::Semicolon)
+                ++separator_iterator;
+
+            pos = separator_iterator->begin;
+            if (pos >= end)
+                break;
+
+            ASTPtr ast = parseQuery(pos, end, settings, /*allow_multi_statements=*/true);
+            if (!ast)
+            {
+                if (out_has_secrets)
+                    *out_has_secrets = false;
+                return CHDB_QUERY_UNKNOWN;
+            }
+
+            saw_statement = true;
+            result = CHDB::combineQueryClass(result, CHDB::classifyStatement(*ast));
+            if (out_has_secrets && CHDB::statementHasSecrets(*ast))
+                *out_has_secrets = true;
+
+            pos = findStatementEnd(*ast, pos, end);
+        }
+    }
+    catch (...)
+    {
+        /// SQL we cannot parse is SQL we cannot vouch for.
+        if (out_has_secrets)
+            *out_has_secrets = false;
+        return CHDB_QUERY_UNKNOWN;
+    }
+
+    if (saw_statement)
+        return result;
+
+    if (out_has_secrets)
+        *out_has_secrets = false;
+    return CHDB_QUERY_UNKNOWN;
 }
 
 

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -1140,13 +1140,15 @@ const char * findStatementEnd(const IAST & ast, const char * parsed_end, const c
 
 }
 
-chdb_query_class ChdbClient::classifyQuery(const char * sql, size_t sql_len, bool * out_has_secrets)
+void ChdbClient::analyzeQuery(
+    const char * sql, size_t sql_len, std::string_view target_database, chdb_query_analysis_v1 & out)
 {
-    if (out_has_secrets)
-        *out_has_secrets = false;
+    out.statement_count = 0;
+    out.flags = 0;
+    out.query_class = CHDB_QUERY_UNKNOWN;
 
     if (!sql || sql_len == 0)
-        return CHDB_QUERY_UNKNOWN;
+        return;
 
     std::lock_guard<std::mutex> lock(client_mutex);
 
@@ -1155,13 +1157,21 @@ chdb_query_class ChdbClient::classifyQuery(const char * sql, size_t sql_len, boo
     const char * const end = pos + text.size();
 
     auto result = CHDB_QUERY_READ_ONLY;
-    bool saw_statement = false;
+    size_t statements = 0;
+    bool has_secrets = false;
+    bool writes_only_target = true;
+    bool changes_lifecycle = false;
 
     try
     {
         const Settings & settings = client_context->getSettingsRef();
         const auto max_parser_depth = static_cast<uint32_t>(settings[Setting::max_parser_depth]);
         const auto max_parser_backtracks = static_cast<uint32_t>(settings[Setting::max_parser_backtracks]);
+        /// Resolving an unqualified name is the difference between
+        /// `INSERT INTO wasm_modules` being a table write and being a write
+        /// into `system`; only the connection knows which.
+        const String current_database = client_context->getCurrentDatabase();
+        const String target(target_database);
 
         while (pos < end)
         {
@@ -1179,35 +1189,35 @@ chdb_query_class ChdbClient::classifyQuery(const char * sql, size_t sql_len, boo
 
             ASTPtr ast = parseQuery(pos, end, settings, /*allow_multi_statements=*/true);
             if (!ast)
-            {
-                if (out_has_secrets)
-                    *out_has_secrets = false;
-                return CHDB_QUERY_UNKNOWN;
-            }
+                return;
 
-            saw_statement = true;
-            result = CHDB::combineQueryClass(result, CHDB::classifyStatement(*ast));
-            if (out_has_secrets && CHDB::statementHasSecrets(*ast))
-                *out_has_secrets = true;
+            statements += CHDB::countExecutableStatements(*ast);
+            result = CHDB::combineQueryClass(result, CHDB::classifyStatement(*ast, current_database));
+            has_secrets |= CHDB::statementHasSecrets(*ast);
+            changes_lifecycle |= CHDB::changesDatabaseLifecycle(*ast);
+            writes_only_target &= CHDB::writesOnlyToDatabase(*ast, target, current_database);
 
             pos = findStatementEnd(*ast, pos, end);
         }
     }
     catch (...)
     {
-        /// SQL we cannot parse is SQL we cannot vouch for.
-        if (out_has_secrets)
-            *out_has_secrets = false;
-        return CHDB_QUERY_UNKNOWN;
+        /// SQL we cannot parse is SQL we cannot vouch for, and nothing was
+        /// proven about it -- leave the report at its refusing default.
+        return;
     }
 
-    if (saw_statement)
-        return result;
+    if (statements == 0)
+        return;
 
-    if (out_has_secrets)
-        *out_has_secrets = false;
-    return CHDB_QUERY_UNKNOWN;
+    out.statement_count = static_cast<uint32_t>(statements);
+    out.query_class = static_cast<uint32_t>(result);
+    if (has_secrets)
+        out.flags |= CHDB_QUERY_HAS_SECRETS;
+    if (changes_lifecycle)
+        out.flags |= CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE;
+    if (writes_only_target && !target_database.empty())
+        out.flags |= CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE;
 }
-
 
 } // namespace DB

--- a/programs/local/ChdbClient.h
+++ b/programs/local/ChdbClient.h
@@ -72,14 +72,18 @@ public:
     void cancelInsertStream(void * insert_stream);
 
     /// What `sql` would do, decided by this connection's parser and parser
-    /// settings without executing anything. Several statements classify as the
-    /// most restricted one among them; anything that fails to parse, and
-    /// anything the classifier does not recognise, is CHDB_QUERY_UNKNOWN.
+    /// settings without executing anything. Fills `out` with the class, the
+    /// number of executable statements, and the flags described in chdb.h.
     ///
-    /// `out_has_secrets`, when given, reports whether any statement in the
-    /// batch carries a credential in its text. It is set from the same parse,
-    /// and is false whenever the class is UNKNOWN -- nothing was proven.
-    chdb_query_class classifyQuery(const char * sql, size_t sql_len, bool * out_has_secrets = nullptr);
+    /// `target_database` is the database the caller considers its own; an
+    /// empty view means "do not judge containment", and the
+    /// WRITES_ONLY_TARGET_DATABASE flag is then never set. Unqualified names
+    /// resolve through this connection's current database, the way execution
+    /// would resolve them.
+    ///
+    /// Text that fails to parse yields UNKNOWN, a count of zero and no flags.
+    void analyzeQuery(
+        const char * sql, size_t sql_len, std::string_view target_database, chdb_query_analysis_v1 & out);
 
     size_t getStorageRowsRead() const;
     size_t getStorageBytesRead() const;

--- a/programs/local/ChdbClient.h
+++ b/programs/local/ChdbClient.h
@@ -5,6 +5,7 @@
 #include <Interpreters/Session.h>
 #include <Common/Config/ConfigProcessor.h>
 #include <Core/Names.h>
+#include "chdb.h"
 #include "QueryResult.h"
 #include "StreamingInsert.h"
 
@@ -69,6 +70,16 @@ public:
 
     /// Abort the INSERT (CH-default semantics: no special rollback) and join.
     void cancelInsertStream(void * insert_stream);
+
+    /// What `sql` would do, decided by this connection's parser and parser
+    /// settings without executing anything. Several statements classify as the
+    /// most restricted one among them; anything that fails to parse, and
+    /// anything the classifier does not recognise, is CHDB_QUERY_UNKNOWN.
+    ///
+    /// `out_has_secrets`, when given, reports whether any statement in the
+    /// batch carries a credential in its text. It is set from the same parse,
+    /// and is false whenever the class is UNKNOWN -- nothing was proven.
+    chdb_query_class classifyQuery(const char * sql, size_t sql_len, bool * out_has_secrets = nullptr);
 
     size_t getStorageRowsRead() const;
     size_t getStorageBytesRead() const;

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -682,6 +682,61 @@ void connection_wrapper::insert_cancel(streaming_insert_result * ins)
     chdb_stream_cancel_insert(ins->get_stream());
 }
 
+namespace
+{
+
+/// backup_database and restore_database return nothing, so the result exists
+/// only to carry an error. Raise it if there is one, and drop the result
+/// either way.
+void raiseOnEngineError(chdb_result * result)
+{
+    const auto & error_msg = CHDB::chdb_result_error_string(result);
+    if (error_msg.empty())
+    {
+        chdb_destroy_query_result(result);
+        return;
+    }
+
+    std::string msg_copy(error_msg);
+    chdb_destroy_query_result(result);
+    throw std::runtime_error(msg_copy);
+}
+
+}
+
+void connection_wrapper::backup_database(
+    const std::string & database, const std::string & file_path, const std::string & base_file_path)
+{
+    py::gil_scoped_release release;
+    raiseOnEngineError(chdb_backup_database_n(
+        *conn,
+        database.data(),
+        database.size(),
+        file_path.data(),
+        file_path.size(),
+        base_file_path.empty() ? nullptr : base_file_path.data(),
+        base_file_path.size()));
+}
+
+void connection_wrapper::restore_database(const std::string & database, const std::string & file_path)
+{
+    py::gil_scoped_release release;
+    raiseOnEngineError(
+        chdb_restore_database_n(*conn, database.data(), database.size(), file_path.data(), file_path.size()));
+}
+
+py::tuple connection_wrapper::classify_query(const std::string & sql)
+{
+    chdb_query_class query_class = CHDB_QUERY_UNKNOWN;
+    int has_secrets = 0;
+    {
+        py::gil_scoped_release release;
+        if (chdb_classify_query_n(*conn, sql.data(), sql.size(), &query_class, &has_secrets) != CHDBSuccess)
+            throw std::runtime_error("Invalid or closed connection");
+    }
+    return py::make_tuple(query_class, has_secrets != 0);
+}
+
 #if USE_CLIENT_AI
 void connection_wrapper::applyAIParams(std::map<std::string, std::string> & params)
 {
@@ -834,6 +889,35 @@ PYBIND11_MODULE(_chdb, m)
     /// This prevents use-after-free when CompiledFunctionHolder destructors
     /// try to access already-destroyed static CHJIT instances.
     py::module_::import("atexit").attr("register")(py::cpp_function(&chdb_cleanup_at_exit));
+
+    /// py::arithmetic() is what makes the documented ordering usable: without
+    /// it a pybind enum has no __lt__, and max() over a batch's classes fails.
+    py::enum_<chdb_query_class>(
+        m,
+        "query_class",
+        "What a statement does to state that outlives it, as decided by the ClickHouse parser. "
+        "The members compare in ascending order of restriction, so a batch of statements "
+        "classifies as max() over its members",
+        py::arithmetic())
+        .value("READ_ONLY", CHDB_QUERY_READ_ONLY, "Leaves no trace: SELECT, SHOW, DESCRIBE, EXPLAIN, EXISTS, CHECK")
+        .value(
+            "MUTATING",
+            CHDB_QUERY_MUTATING,
+            "Changes a database, and BACKUP DATABASE captures the change: INSERT, CREATE, ALTER, "
+            "DROP, TRUNCATE, RENAME, UPDATE, DELETE, OPTIMIZE")
+        .value(
+            "MUTATING_GLOBAL",
+            CHDB_QUERY_MUTATING_GLOBAL,
+            "Persistent and worth replaying, but outside every database a checkpoint could "
+            "capture: global UDFs, named collections, workloads, resources, access management, "
+            "writes into the system database")
+        .value(
+            "CONTROL",
+            CHDB_QUERY_CONTROL,
+            "Session-scoped, so replaying is meaningless, or not something to issue through a "
+            "managed connection: USE, SET, ATTACH, DETACH, SYSTEM, BACKUP, RESTORE, KILL, "
+            "transactions, and writes outside the engine such as INTO OUTFILE")
+        .value("UNKNOWN", CHDB_QUERY_UNKNOWN, "Did not parse, or parsed into a statement this version does not classify");
 
     py::class_<memoryview_wrapper>(m, "memoryview_wrapper")
         .def(py::init<std::shared_ptr<local_result_wrapper>>(), py::return_value_policy::take_ownership)
@@ -1009,7 +1093,32 @@ PYBIND11_MODULE(_chdb, m)
             "insert_cancel",
             &connection_wrapper::insert_cancel,
             py::arg("insert_result"),
-            "Abort a streaming INSERT without committing");
+            "Abort a streaming INSERT without committing")
+        .def(
+            "backup_database",
+            &connection_wrapper::backup_database,
+            py::arg("database"),
+            py::arg("file_path"),
+            py::arg("base_file_path") = "",
+            "Back a database up into file_path. The engine quotes both arguments, so neither can "
+            "alter the statement. file_path must be absolute, its directory must exist and be "
+            "covered by backups.allowed_path, and an existing file is never overwritten. Pass "
+            "base_file_path to write only what changed since that archive")
+        .def(
+            "restore_database",
+            &connection_wrapper::restore_database,
+            py::arg("database"),
+            py::arg("file_path"),
+            "Restore a database from an archive written by backup_database. Leaves the current "
+            "database of the session unchanged")
+        .def(
+            "classify_query",
+            &connection_wrapper::classify_query,
+            py::arg("sql"),
+            "Report what the SQL would do, without running it, as (query_class, has_secrets). "
+            "Several statements classify as the most restricted one among them; SQL that does not "
+            "parse classifies as UNKNOWN. has_secrets says whether the text carries a credential, "
+            "which a caller recording statements needs to know before it writes them down");
 
     CHDB::ChdbPyType::initialize(m);
     CHDB::PythonUDFRegistry::instance();

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -704,9 +704,19 @@ void raiseOnEngineError(chdb_result * result)
 
 }
 
+/// close() sets conn to nullptr, so every entry point has to look before it
+/// dereferences -- otherwise using a closed connection segfaults the
+/// interpreter instead of raising.
+void connection_wrapper::requireOpen() const
+{
+    if (!conn)
+        throw std::runtime_error("Connection is closed");
+}
+
 void connection_wrapper::backup_database(
     const std::string & database, const std::string & file_path, const std::string & base_file_path)
 {
+    requireOpen();
     py::gil_scoped_release release;
     raiseOnEngineError(chdb_backup_database_n(
         *conn,
@@ -720,21 +730,38 @@ void connection_wrapper::backup_database(
 
 void connection_wrapper::restore_database(const std::string & database, const std::string & file_path)
 {
+    requireOpen();
     py::gil_scoped_release release;
     raiseOnEngineError(
         chdb_restore_database_n(*conn, database.data(), database.size(), file_path.data(), file_path.size()));
 }
 
-py::tuple connection_wrapper::classify_query(const std::string & sql)
+py::dict connection_wrapper::classify_query(const std::string & sql, const std::string & target_database)
 {
-    chdb_query_class query_class = CHDB_QUERY_UNKNOWN;
-    int has_secrets = 0;
+    requireOpen();
+
+    chdb_query_analysis_v1 analysis{};
+    analysis.struct_size = sizeof(analysis);
     {
         py::gil_scoped_release release;
-        if (chdb_classify_query_n(*conn, sql.data(), sql.size(), &query_class, &has_secrets) != CHDBSuccess)
+        if (chdb_classify_query_n(
+                *conn,
+                sql.data(),
+                sql.size(),
+                target_database.empty() ? nullptr : target_database.data(),
+                target_database.size(),
+                &analysis)
+            != CHDBSuccess)
             throw std::runtime_error("Invalid or closed connection");
     }
-    return py::make_tuple(query_class, has_secrets != 0);
+
+    py::dict out;
+    out["query_class"] = static_cast<chdb_query_class>(analysis.query_class);
+    out["statement_count"] = analysis.statement_count;
+    out["has_secrets"] = (analysis.flags & CHDB_QUERY_HAS_SECRETS) != 0;
+    out["writes_only_target_database"] = (analysis.flags & CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE) != 0;
+    out["changes_database_lifecycle"] = (analysis.flags & CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE) != 0;
+    return out;
 }
 
 #if USE_CLIENT_AI
@@ -1115,10 +1142,14 @@ PYBIND11_MODULE(_chdb, m)
             "classify_query",
             &connection_wrapper::classify_query,
             py::arg("sql"),
-            "Report what the SQL would do, without running it, as (query_class, has_secrets). "
-            "Several statements classify as the most restricted one among them; SQL that does not "
-            "parse classifies as UNKNOWN. has_secrets says whether the text carries a credential, "
-            "which a caller recording statements needs to know before it writes them down");
+            py::arg("target_database") = "",
+            "Report what the SQL would do, without running it, as a dict of query_class, "
+            "statement_count, has_secrets, writes_only_target_database and "
+            "changes_database_lifecycle. A batch takes the most restricted class among its "
+            "members; SQL that does not parse reports UNKNOWN with a count of zero and no flags. "
+            "target_database is the database the caller owns, and is what "
+            "writes_only_target_database is judged against; unqualified names resolve through the "
+            "connection's current database first");
 
     CHDB::ChdbPyType::initialize(m);
     CHDB::PythonUDFRegistry::instance();

--- a/programs/local/LocalChdb.h
+++ b/programs/local/LocalChdb.h
@@ -66,6 +66,11 @@ public:
     void insert_append(streaming_insert_result * ins, const py::bytes & data);
     query_result * insert_done(streaming_insert_result * ins);
     void insert_cancel(streaming_insert_result * ins);
+    /// Durable-object primitives: the engine builds the BACKUP/RESTORE
+    /// statement from the parts, and classifies SQL without running it.
+    void backup_database(const std::string & database, const std::string & file_path, const std::string & base_file_path);
+    void restore_database(const std::string & database, const std::string & file_path);
+    py::tuple classify_query(const std::string & sql);
     std::string generate_sql(const std::string & prompt);
 
     // Move the private methods declarations here

--- a/programs/local/LocalChdb.h
+++ b/programs/local/LocalChdb.h
@@ -70,10 +70,11 @@ public:
     /// statement from the parts, and classifies SQL without running it.
     void backup_database(const std::string & database, const std::string & file_path, const std::string & base_file_path);
     void restore_database(const std::string & database, const std::string & file_path);
-    py::tuple classify_query(const std::string & sql);
+    py::dict classify_query(const std::string & sql, const std::string & target_database);
     std::string generate_sql(const std::string & prompt);
 
     // Move the private methods declarations here
+    void requireOpen() const;
     std::pair<std::string, std::map<std::string, std::string>> parse_connection_string(const std::string & conn_str);
     std::vector<std::string> build_clickhouse_args(const std::string & path, const std::map<std::string, std::string> & params);
 

--- a/programs/local/QueryClassifier.cpp
+++ b/programs/local/QueryClassifier.cpp
@@ -30,9 +30,13 @@
 #include <Parsers/ASTUseQuery.h>
 #include <Parsers/ASTWatchQuery.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Parsers/ASTRenameQuery.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTIdentifier.h>
+
+#include <set>
 #include <Parsers/ASTQueryWithTableAndOutput.h>
 #include <Parsers/IAST.h>
-#include <Parsers/Access/ASTCheckGrantQuery.h>
 #include <Parsers/Access/ASTCreateMaskingPolicyQuery.h>
 #include <Parsers/Access/ASTCreateQuotaQuery.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
@@ -76,7 +80,9 @@ bool isGlobalMutatingStatement(const IAST & ast)
         || ast.as<ASTCreateUserQuery>() || ast.as<ASTCreateRoleQuery>() || ast.as<ASTCreateQuotaQuery>()
         || ast.as<ASTCreateRowPolicyQuery>() || ast.as<ASTCreateMaskingPolicyQuery>()
         || ast.as<ASTCreateSettingsProfileQuery>() || ast.as<ASTDropAccessEntityQuery>()
-        || ast.as<ASTMoveAccessEntityQuery>() || ast.as<ASTGrantQuery>() || ast.as<ASTCheckGrantQuery>();
+        /// CHECK GRANT only evaluates an authorization and changes nothing;
+        /// its QueryKind::Check already lands it in READ_ONLY.
+        || ast.as<ASTMoveAccessEntityQuery>() || ast.as<ASTGrantQuery>();
 }
 
 /// Statements that either only touch the session, so replaying them is
@@ -94,19 +100,102 @@ bool isControlStatement(const IAST & ast)
         || ast.as<ASTHypotheticalIndexQuery>();
 }
 
-/// The `system` database is engine-owned: its storage engine refuses backups
-/// outright, so a write landing there survives nothing. It is also how some
-/// global objects get their payload -- a WebAssembly module arrives as
-/// `INSERT INTO system.wasm_modules`, and the bytes are written to the user
-/// scripts directory, not to any database. Treat writes there as global.
-bool writesToSystemDatabase(const IAST & ast)
+/// Every database a statement writes to, with unqualified names resolved the
+/// way execution would resolve them. Returns false when a write leaves the
+/// engine entirely -- a table function, an outfile -- because such a write
+/// belongs to no database and no caller can claim it lands in theirs.
+///
+/// `out_databases` is only added to; a false return means "and also somewhere
+/// outside", not that the collected set is meaningless.
+bool collectWrittenDatabases(const IAST & ast, const String & current_database, std::set<String> & out_databases)
 {
+    const auto resolve = [&](const String & explicit_database)
+    { return explicit_database.empty() ? current_database : explicit_database; };
+
+    if (ast.as<ASTParallelWithQuery>())
+    {
+        bool contained = true;
+        for (const auto & child : ast.children)
+        {
+            if (!child)
+                return false;
+            contained &= collectWrittenDatabases(*child, current_database, out_databases);
+        }
+        return contained;
+    }
+
+    /// A read that writes a file writes outside every database.
+    if (const auto * with_output = dynamic_cast<const ASTQueryWithOutput *>(&ast); with_output && with_output->out_file)
+        return false;
+
     if (const auto * insert = ast.as<ASTInsertQuery>())
-        return insert->getDatabase() == DatabaseCatalog::SYSTEM_DATABASE;
+    {
+        /// `INSERT INTO FUNCTION file(...)/s3(...)` names a sink, not a table.
+        if (insert->table_function)
+            return false;
+        out_databases.insert(resolve(insert->getDatabase()));
+        return true;
+    }
+
+    /// RENAME and EXCHANGE touch two objects per element, and either side may
+    /// sit in a different database.
+    if (const auto * rename = ast.as<ASTRenameQuery>())
+    {
+        for (const auto & element : rename->getElements())
+        {
+            out_databases.insert(resolve(element.from.getDatabase()));
+            out_databases.insert(resolve(element.to.getDatabase()));
+        }
+        return true;
+    }
+
+    /// `DROP TABLE a, b` keeps its targets in a list rather than in the
+    /// statement's own database/table fields.
+    if (const auto * drop = ast.as<ASTDropQuery>(); drop && drop->database_and_tables)
+    {
+        for (const auto & child : drop->database_and_tables->children)
+        {
+            String database;
+            if (const auto * identifier = child->as<ASTTableIdentifier>())
+                database = identifier->getDatabaseName();
+            out_databases.insert(resolve(database));
+        }
+        return true;
+    }
 
     if (const auto * with_table = dynamic_cast<const ASTQueryWithTableAndOutput *>(&ast))
-        return with_table->getDatabase() == DatabaseCatalog::SYSTEM_DATABASE;
+    {
+        out_databases.insert(resolve(with_table->getDatabase()));
+        return true;
+    }
 
+    /// A statement whose target this function does not know how to read is a
+    /// statement we cannot place. Saying "outside" keeps the caller honest.
+    return false;
+}
+
+/// Statement-level settings that would take a write off the connection's own
+/// synchronous-completion policy. A managed connection configures these once;
+/// a statement re-specifying any of them is changing the policy, whichever
+/// direction it moves, so the value is not inspected.
+bool overridesSynchronousCompletion(const IAST & ast)
+{
+    if (const auto * set = ast.as<ASTSetQuery>(); set && !set->is_standalone)
+    {
+        for (const auto & change : set->changes)
+        {
+            if (change.name == "async_insert" || change.name == "wait_for_async_insert"
+                || change.name == "mutations_sync" || change.name == "alter_sync"
+                || change.name == "lightweight_deletes_sync")
+                return true;
+        }
+    }
+
+    for (const auto & child : ast.children)
+    {
+        if (child && overridesSynchronousCompletion(*child))
+            return true;
+    }
     return false;
 }
 
@@ -183,7 +272,71 @@ bool statementHasSecrets(const IAST & ast)
     return ast.hasSecretParts();
 }
 
-chdb_query_class classifyStatement(const IAST & ast)
+bool changesDatabaseLifecycle(const IAST & ast)
+{
+    if (ast.as<ASTParallelWithQuery>())
+    {
+        for (const auto & child : ast.children)
+        {
+            if (child && changesDatabaseLifecycle(*child))
+                return true;
+        }
+        return false;
+    }
+
+    /// A database statement names a database and no table. ATTACH and DETACH
+    /// of a database count too: they change which databases exist.
+    if (const auto * create = ast.as<ASTCreateQuery>())
+        return create->getTable().empty() && !create->getDatabase().empty();
+
+    if (const auto * drop = ast.as<ASTDropQuery>())
+        return drop->getTable().empty() && !drop->getDatabase().empty() && !drop->database_and_tables;
+
+    if (const auto * rename = ast.as<ASTRenameQuery>())
+        return rename->database;
+
+    return false;
+}
+
+bool writesOnlyToDatabase(const IAST & ast, const String & target_database, const String & current_database)
+{
+    if (target_database.empty())
+        return false;
+
+    /// A statement that writes nothing is vacuously contained. Asking
+    /// collectWrittenDatabases() about a SELECT would take the "target I
+    /// cannot read" branch and answer no, which is the wrong kind of caution:
+    /// there is no write to place.
+    if (classifyStatement(ast, current_database) == CHDB_QUERY_READ_ONLY)
+        return true;
+
+    std::set<String> written;
+    if (!collectWrittenDatabases(ast, current_database, written))
+        return false;
+
+    for (const auto & database : written)
+    {
+        if (database != target_database)
+            return false;
+    }
+    /// A statement that writes nothing is vacuously contained.
+    return true;
+}
+
+size_t countExecutableStatements(const IAST & ast)
+{
+    if (!ast.as<ASTParallelWithQuery>())
+        return 1;
+
+    /// Both arms of `a PARALLEL WITH b` run, so the text is not one statement
+    /// a caller could replay on its own.
+    size_t count = 0;
+    for (const auto & child : ast.children)
+        count += child ? countExecutableStatements(*child) : 1;
+    return count;
+}
+
+chdb_query_class classifyStatement(const IAST & ast, const String & current_database)
 {
     /// `stmt1 PARALLEL WITH stmt2` is as restricted as its most restricted arm.
     if (ast.as<ASTParallelWithQuery>())
@@ -196,10 +349,16 @@ chdb_query_class classifyStatement(const IAST & ast)
         {
             if (!child)
                 return CHDB_QUERY_UNKNOWN;
-            result = combineQueryClass(result, classifyStatement(*child));
+            result = combineQueryClass(result, classifyStatement(*child, current_database));
         }
         return result;
     }
+
+    /// A statement-level setting that moves a write off the connection's
+    /// synchronous-completion policy is the connection's business, not the
+    /// statement's.
+    if (overridesSynchronousCompletion(ast))
+        return CHDB_QUERY_CONTROL;
 
     /// INTO OUTFILE turns any read into a filesystem write, which no database
     /// checkpoint carries. `as<>` is an exact-type match, so this one asks for
@@ -217,8 +376,13 @@ chdb_query_class classifyStatement(const IAST & ast)
         return CHDB_QUERY_MUTATING_GLOBAL;
 
     /// ATTACH shares ASTCreateQuery with CREATE, and DETACH shares ASTDropQuery
-    /// with DROP; both attach an object rather than define one.
-    if (const auto * create = ast.as<ASTCreateQuery>(); create && create->attach)
+    /// with DROP; both attach an object rather than define one. A temporary
+    /// table shares the AST too, and lives outside every database, so no
+    /// backup of one can hold it.
+    if (const auto * create = ast.as<ASTCreateQuery>(); create && (create->attach || create->isTemporary()))
+        return CHDB_QUERY_CONTROL;
+
+    if (const auto * drop = ast.as<ASTDropQuery>(); drop && drop->isTemporary())
         return CHDB_QUERY_CONTROL;
 
     if (const auto * drop = ast.as<ASTDropQuery>(); drop && drop->kind == ASTDropQuery::Kind::Detach)
@@ -249,12 +413,22 @@ chdb_query_class classifyStatement(const IAST & ast)
         result = classifyByQueryKind(ast.getQueryKind());
     }
 
-    /// A write is only MUTATING if a checkpoint of the database would hold it.
-    /// This has to sit after the ALTER branch as well as after the QueryKind
-    /// fallback: `ALTER TABLE system.x` reaches the database no backup covers
-    /// just as surely as `INSERT INTO system.x` does.
-    if (result == CHDB_QUERY_MUTATING && writesToSystemDatabase(ast))
-        return CHDB_QUERY_MUTATING_GLOBAL;
+    /// A write is only MUTATING if a checkpoint of some database would hold
+    /// it. The `system` database is engine-owned and its storage engine
+    /// refuses backups, so a write landing there survives nothing -- and an
+    /// unqualified name lands there whenever `system` is the current database,
+    /// which is exactly how a WebAssembly module gets uploaded.
+    ///
+    /// This sits after the ALTER branch as well as after the QueryKind
+    /// fallback: `ALTER TABLE system.x` reaches that database just as surely
+    /// as `INSERT INTO system.x` does.
+    if (result == CHDB_QUERY_MUTATING)
+    {
+        std::set<String> written;
+        collectWrittenDatabases(ast, current_database, written);
+        if (written.contains(DatabaseCatalog::SYSTEM_DATABASE))
+            return CHDB_QUERY_MUTATING_GLOBAL;
+    }
 
     return result;
 }

--- a/programs/local/QueryClassifier.cpp
+++ b/programs/local/QueryClassifier.cpp
@@ -163,6 +163,23 @@ bool collectWrittenDatabases(const IAST & ast, const String & current_database, 
         return true;
     }
 
+    /// `ALTER TABLE src MOVE PARTITION p TO TABLE dst.t` writes to two places,
+    /// and the destination is on the command rather than on the statement.
+    if (const auto * alter = ast.as<ASTAlterQuery>())
+    {
+        out_databases.insert(resolve(alter->getDatabase()));
+        if (alter->command_list)
+        {
+            for (const auto & child : alter->command_list->children)
+            {
+                const auto * command = child->as<ASTAlterCommand>();
+                if (command && !command->to_table.empty())
+                    out_databases.insert(resolve(command->to_database));
+            }
+        }
+        return true;
+    }
+
     if (const auto * with_table = dynamic_cast<const ASTQueryWithTableAndOutput *>(&ast))
     {
         out_databases.insert(resolve(with_table->getDatabase()));
@@ -182,11 +199,23 @@ bool overridesSynchronousCompletion(const IAST & ast)
 {
     if (const auto * set = ast.as<ASTSetQuery>(); set && !set->is_standalone)
     {
+        const auto guarded = [](const String & name)
+        {
+            return name == "async_insert" || name == "wait_for_async_insert" || name == "mutations_sync"
+                || name == "alter_sync" || name == "lightweight_deletes_sync";
+        };
+
         for (const auto & change : set->changes)
         {
-            if (change.name == "async_insert" || change.name == "wait_for_async_insert"
-                || change.name == "mutations_sync" || change.name == "alter_sync"
-                || change.name == "lightweight_deletes_sync")
+            if (guarded(change.name))
+                return true;
+        }
+        /// `SETTINGS async_insert = DEFAULT` resets the value the connection
+        /// chose, which is the same override by another spelling. The parser
+        /// files those under default_settings rather than changes.
+        for (const auto & name : set->default_settings)
+        {
+            if (guarded(name))
                 return true;
         }
     }
@@ -228,7 +257,6 @@ chdb_query_class classifyByQueryKind(IAST::QueryKind kind)
         case IAST::QueryKind::Rename:
         case IAST::QueryKind::Optimize:
         case IAST::QueryKind::Alter:
-        case IAST::QueryKind::Copy:
             return CHDB_QUERY_MUTATING;
 
         /// Reached only if an access statement grows an AST that
@@ -239,6 +267,10 @@ chdb_query_class classifyByQueryKind(IAST::QueryKind kind)
         case IAST::QueryKind::Move:
             return CHDB_QUERY_MUTATING_GLOBAL;
 
+        /// `COPY ... TO` writes a file no backup covers. The statement serves
+        /// the PostgreSQL wire protocol, which a managed connection does not
+        /// speak, so both directions refuse rather than split hairs.
+        case IAST::QueryKind::Copy:
         case IAST::QueryKind::System:
         case IAST::QueryKind::Set:
         case IAST::QueryKind::Use:

--- a/programs/local/QueryClassifier.cpp
+++ b/programs/local/QueryClassifier.cpp
@@ -1,0 +1,262 @@
+#include "QueryClassifier.h"
+
+#include <Parsers/ASTAlterNamedCollectionQuery.h>
+#include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTBackupQuery.h>
+#include <Parsers/ASTCreateFunctionWithDriverQuery.h>
+#include <Parsers/ASTCreateNamedCollectionQuery.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTCreateResourceQuery.h>
+#include <Parsers/ASTCreateSQLFunctionQuery.h>
+#include <Parsers/ASTCreateWasmFunctionQuery.h>
+#include <Parsers/ASTCreateWorkloadQuery.h>
+#include <Parsers/ASTDescribeCacheQuery.h>
+#include <Parsers/ASTDropFunctionQuery.h>
+#include <Parsers/ASTDropNamedCollectionQuery.h>
+#include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTDropResourceQuery.h>
+#include <Parsers/ASTDropWorkloadQuery.h>
+#include <Parsers/ASTHypotheticalIndexQuery.h>
+#include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTKillQueryQuery.h>
+#include <Parsers/ASTParallelWithQuery.h>
+#include <Parsers/ASTQueryWithOutput.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Parsers/ASTShowEngineQuery.h>
+#include <Parsers/ASTShowProcesslistQuery.h>
+#include <Parsers/ASTSnapshotQuery.h>
+#include <Parsers/ASTSystemQuery.h>
+#include <Parsers/ASTTransactionControl.h>
+#include <Parsers/ASTUseQuery.h>
+#include <Parsers/ASTWatchQuery.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Parsers/ASTQueryWithTableAndOutput.h>
+#include <Parsers/IAST.h>
+#include <Parsers/Access/ASTCheckGrantQuery.h>
+#include <Parsers/Access/ASTCreateMaskingPolicyQuery.h>
+#include <Parsers/Access/ASTCreateQuotaQuery.h>
+#include <Parsers/Access/ASTCreateRoleQuery.h>
+#include <Parsers/Access/ASTCreateRowPolicyQuery.h>
+#include <Parsers/Access/ASTCreateSettingsProfileQuery.h>
+#include <Parsers/Access/ASTCreateUserQuery.h>
+#include <Parsers/Access/ASTDropAccessEntityQuery.h>
+#include <Parsers/Access/ASTExecuteAsQuery.h>
+#include <Parsers/Access/ASTGrantQuery.h>
+#include <Parsers/Access/ASTMoveAccessEntityQuery.h>
+#include <Parsers/Access/ASTSetRoleQuery.h>
+#include <Parsers/Access/ASTShowAccessQuery.h>
+#include <Parsers/Access/ASTShowPrivilegesQuery.h>
+
+namespace CHDB
+{
+
+namespace
+{
+
+using namespace DB;
+
+/// Statements whose effect is persistent and worth replaying, but which no
+/// `BACKUP DATABASE` can carry, because what they change lives beside the
+/// databases rather than inside one. Several of these parse as CREATE or DROP
+/// and would otherwise be indistinguishable from a table definition.
+bool isGlobalMutatingStatement(const IAST & ast)
+{
+    return
+        /// Global UDFs: an SQL lambda, a WebAssembly function, a driver-backed
+        /// function, or a DROP of any of them.
+        ast.as<ASTCreateSQLFunctionQuery>() || ast.as<ASTCreateWasmFunctionQuery>()
+        || ast.as<ASTCreateFunctionWithDriverQuery>() || ast.as<ASTDropFunctionQuery>()
+        /// Named collections.
+        || ast.as<ASTCreateNamedCollectionQuery>() || ast.as<ASTDropNamedCollectionQuery>()
+        || ast.as<ASTAlterNamedCollectionQuery>()
+        /// Workload / resource scheduling objects.
+        || ast.as<ASTCreateWorkloadQuery>() || ast.as<ASTDropWorkloadQuery>() || ast.as<ASTCreateResourceQuery>()
+        || ast.as<ASTDropResourceQuery>()
+        /// Access management.
+        || ast.as<ASTCreateUserQuery>() || ast.as<ASTCreateRoleQuery>() || ast.as<ASTCreateQuotaQuery>()
+        || ast.as<ASTCreateRowPolicyQuery>() || ast.as<ASTCreateMaskingPolicyQuery>()
+        || ast.as<ASTCreateSettingsProfileQuery>() || ast.as<ASTDropAccessEntityQuery>()
+        || ast.as<ASTMoveAccessEntityQuery>() || ast.as<ASTGrantQuery>() || ast.as<ASTCheckGrantQuery>();
+}
+
+/// Statements that either only touch the session, so replaying them is
+/// meaningless, or that a managed connection should not be issuing at all.
+bool isControlStatement(const IAST & ast)
+{
+    return ast.as<ASTUseQuery>() || ast.as<ASTSetQuery>() || ast.as<ASTSetRoleQuery>() || ast.as<ASTSystemQuery>()
+        || ast.as<ASTBackupQuery>() || ast.as<ASTSnapshotQuery>() || ast.as<ASTKillQueryQuery>()
+        || ast.as<ASTTransactionControl>() || ast.as<ASTExecuteAsQuery>()
+        /// WATCH streams a live view for as long as the session lasts; it ends
+        /// no more than a SYSTEM statement does.
+        || ast.as<ASTWatchQuery>()
+        /// Advisor state for EXPLAIN, held outside the databases and outside
+        /// any backup.
+        || ast.as<ASTHypotheticalIndexQuery>();
+}
+
+/// The `system` database is engine-owned: its storage engine refuses backups
+/// outright, so a write landing there survives nothing. It is also how some
+/// global objects get their payload -- a WebAssembly module arrives as
+/// `INSERT INTO system.wasm_modules`, and the bytes are written to the user
+/// scripts directory, not to any database. Treat writes there as global.
+bool writesToSystemDatabase(const IAST & ast)
+{
+    if (const auto * insert = ast.as<ASTInsertQuery>())
+        return insert->getDatabase() == DatabaseCatalog::SYSTEM_DATABASE;
+
+    if (const auto * with_table = dynamic_cast<const ASTQueryWithTableAndOutput *>(&ast))
+        return with_table->getDatabase() == DatabaseCatalog::SYSTEM_DATABASE;
+
+    return false;
+}
+
+/// Reads that ClickHouse models as their own AST rather than through
+/// QueryKind, so they would otherwise fall through to QueryKind::None.
+bool isReadOnlyStatement(const IAST & ast)
+{
+    return ast.as<ASTShowProcesslistQuery>() || ast.as<ASTShowEnginesQuery>() || ast.as<ASTShowAccessQuery>()
+        || ast.as<ASTShowPrivilegesQuery>() || ast.as<ASTDescribeCacheQuery>();
+}
+
+chdb_query_class classifyByQueryKind(IAST::QueryKind kind)
+{
+    switch (kind)
+    {
+        case IAST::QueryKind::Select:
+        case IAST::QueryKind::Show:
+        case IAST::QueryKind::Exists:
+        case IAST::QueryKind::Describe:
+        case IAST::QueryKind::Explain:
+        case IAST::QueryKind::Check:
+            return CHDB_QUERY_READ_ONLY;
+
+        case IAST::QueryKind::Insert:
+        case IAST::QueryKind::Delete:
+        case IAST::QueryKind::Update:
+        case IAST::QueryKind::Create:
+        case IAST::QueryKind::Drop:
+        case IAST::QueryKind::Undrop:
+        case IAST::QueryKind::Rename:
+        case IAST::QueryKind::Optimize:
+        case IAST::QueryKind::Alter:
+        case IAST::QueryKind::Copy:
+            return CHDB_QUERY_MUTATING;
+
+        /// Reached only if an access statement grows an AST that
+        /// isGlobalMutatingStatement() has not been taught yet; the class is
+        /// the same either way.
+        case IAST::QueryKind::Grant:
+        case IAST::QueryKind::Revoke:
+        case IAST::QueryKind::Move:
+            return CHDB_QUERY_MUTATING_GLOBAL;
+
+        case IAST::QueryKind::System:
+        case IAST::QueryKind::Set:
+        case IAST::QueryKind::Use:
+        case IAST::QueryKind::Backup:
+        case IAST::QueryKind::Restore:
+        case IAST::QueryKind::KillQuery:
+        case IAST::QueryKind::ExternalDDL:
+        case IAST::QueryKind::Begin:
+        case IAST::QueryKind::Commit:
+        case IAST::QueryKind::Rollback:
+        case IAST::QueryKind::SetTransactionSnapshot:
+        case IAST::QueryKind::AsyncInsertFlush:
+        case IAST::QueryKind::Snapshot:
+            return CHDB_QUERY_CONTROL;
+
+        /// ParallelWithQuery is folded over its children before we get here;
+        /// reaching it means the fold missed a shape. None is either a
+        /// statement ClickHouse never gave a kind or one added since this
+        /// switch was written. Both refuse.
+        case IAST::QueryKind::ParallelWithQuery:
+        case IAST::QueryKind::None:
+            return CHDB_QUERY_UNKNOWN;
+    }
+    return CHDB_QUERY_UNKNOWN;
+}
+
+}
+
+bool statementHasSecrets(const IAST & ast)
+{
+    return ast.hasSecretParts();
+}
+
+chdb_query_class classifyStatement(const IAST & ast)
+{
+    /// `stmt1 PARALLEL WITH stmt2` is as restricted as its most restricted arm.
+    if (ast.as<ASTParallelWithQuery>())
+    {
+        if (ast.children.empty())
+            return CHDB_QUERY_UNKNOWN;
+
+        chdb_query_class result = CHDB_QUERY_READ_ONLY;
+        for (const auto & child : ast.children)
+        {
+            if (!child)
+                return CHDB_QUERY_UNKNOWN;
+            result = combineQueryClass(result, classifyStatement(*child));
+        }
+        return result;
+    }
+
+    /// INTO OUTFILE turns any read into a filesystem write, which no database
+    /// checkpoint carries. `as<>` is an exact-type match, so this one asks for
+    /// the base: every statement that can carry an out_file derives from it.
+    if (const auto * with_output = dynamic_cast<const ASTQueryWithOutput *>(&ast); with_output && with_output->out_file)
+        return CHDB_QUERY_CONTROL;
+
+    if (isControlStatement(ast))
+        return CHDB_QUERY_CONTROL;
+
+    if (isReadOnlyStatement(ast))
+        return CHDB_QUERY_READ_ONLY;
+
+    if (isGlobalMutatingStatement(ast))
+        return CHDB_QUERY_MUTATING_GLOBAL;
+
+    /// ATTACH shares ASTCreateQuery with CREATE, and DETACH shares ASTDropQuery
+    /// with DROP; both attach an object rather than define one.
+    if (const auto * create = ast.as<ASTCreateQuery>(); create && create->attach)
+        return CHDB_QUERY_CONTROL;
+
+    if (const auto * drop = ast.as<ASTDropQuery>(); drop && drop->kind == ASTDropQuery::Kind::Detach)
+        return CHDB_QUERY_CONTROL;
+
+    /// `INSERT INTO FUNCTION file(...)/s3(...)/remote(...)` writes somewhere
+    /// other than the database being backed up.
+    if (const auto * insert = ast.as<ASTInsertQuery>(); insert && insert->table_function)
+        return CHDB_QUERY_CONTROL;
+
+    auto result = CHDB_QUERY_UNKNOWN;
+    if (const auto * alter = ast.as<ASTAlterQuery>())
+    {
+        /// FREEZE/UNFREEZE hardlink parts outside the data directory, FETCH
+        /// pulls a part from a replica, MOVE PARTITION TO DISK relocates
+        /// storage: filesystem and cluster state, not table content.
+        if (alter->isFreezeAlter() || alter->isUnlockSnapshot() || alter->isFetchAlter()
+            || alter->isMovePartitionToDiskOrVolumeAlter())
+            return CHDB_QUERY_CONTROL;
+
+        if (alter->alter_object == ASTAlterQuery::AlterObjectType::UNKNOWN)
+            return CHDB_QUERY_UNKNOWN;
+
+        result = CHDB_QUERY_MUTATING;
+    }
+    else
+    {
+        result = classifyByQueryKind(ast.getQueryKind());
+    }
+
+    /// A write is only MUTATING if a checkpoint of the database would hold it.
+    /// This has to sit after the ALTER branch as well as after the QueryKind
+    /// fallback: `ALTER TABLE system.x` reaches the database no backup covers
+    /// just as surely as `INSERT INTO system.x` does.
+    if (result == CHDB_QUERY_MUTATING && writesToSystemDatabase(ast))
+        return CHDB_QUERY_MUTATING_GLOBAL;
+
+    return result;
+}
+
+}

--- a/programs/local/QueryClassifier.h
+++ b/programs/local/QueryClassifier.h
@@ -3,13 +3,14 @@
 #include "chdb.h"
 
 #include <Parsers/IAST_fwd.h>
+#include <base/types.h>
 
 namespace CHDB
 {
 
 /// What one parsed statement does to state that outlives it. See the
 /// chdb_query_class docs in chdb.h for the rule the mapping follows.
-chdb_query_class classifyStatement(const DB::IAST & ast);
+chdb_query_class classifyStatement(const DB::IAST & ast, const String & current_database);
 
 /// Whether the statement carries a credential in its text -- a named
 /// collection's key, a user's password, a table function's access key.
@@ -17,6 +18,23 @@ chdb_query_class classifyStatement(const DB::IAST & ast);
 /// a caller logging statements needs the same answer for the opposite
 /// reason, to keep the text out of durable storage.
 bool statementHasSecrets(const DB::IAST & ast);
+
+/// Whether the statement acts on a database as a whole -- creating, dropping
+/// or renaming the container rather than working inside it.
+bool changesDatabaseLifecycle(const DB::IAST & ast);
+
+/// Whether every persistent write the statement performs lands in
+/// `target_database`. Unqualified names resolve through `current_database`
+/// first, the way execution would resolve them.
+///
+/// False as soon as one write cannot be placed there, and false for writes
+/// that leave the engine entirely (a table function, an outfile). A statement
+/// that writes nothing is vacuously true.
+bool writesOnlyToDatabase(const DB::IAST & ast, const String & target_database, const String & current_database);
+
+/// How many executable statements one parsed top-level AST stands for. One,
+/// except for `a PARALLEL WITH b`, where both arms run.
+size_t countExecutableStatements(const DB::IAST & ast);
 
 /// The class of a batch is the class of its most restricted statement, which
 /// the chdb_query_class ordering makes a plain maximum.

--- a/programs/local/QueryClassifier.h
+++ b/programs/local/QueryClassifier.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "chdb.h"
+
+#include <Parsers/IAST_fwd.h>
+
+namespace CHDB
+{
+
+/// What one parsed statement does to state that outlives it. See the
+/// chdb_query_class docs in chdb.h for the rule the mapping follows.
+chdb_query_class classifyStatement(const DB::IAST & ast);
+
+/// Whether the statement carries a credential in its text -- a named
+/// collection's key, a user's password, a table function's access key.
+/// ClickHouse already tracks this so that SHOW CREATE can print `[HIDDEN]`;
+/// a caller logging statements needs the same answer for the opposite
+/// reason, to keep the text out of durable storage.
+bool statementHasSecrets(const DB::IAST & ast);
+
+/// The class of a batch is the class of its most restricted statement, which
+/// the chdb_query_class ordering makes a plain maximum.
+inline chdb_query_class combineQueryClass(chdb_query_class lhs, chdb_query_class rhs)
+{
+    return lhs > rhs ? lhs : rhs;
+}
+
+}

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -1508,9 +1508,21 @@ chdb_result * chdb_restore_database_n(
 }
 
 chdb_state chdb_classify_query_n(
-    chdb_connection conn, const char * sql, size_t sql_len, chdb_query_class * out_class, int * out_has_secrets)
+    chdb_connection conn,
+    const char * sql,
+    size_t sql_len,
+    const char * target_database,
+    size_t target_database_len,
+    chdb_query_analysis_v1 * out_analysis)
 {
-    if (!conn || !out_class)
+    if (!conn || !out_analysis)
+        return CHDBError;
+
+    /// The caller declares how much room it has. Anything smaller than the
+    /// header we would write past is a mismatched build, not a smaller
+    /// version -- refuse rather than scribble outside it.
+    const uint32_t declared_size = out_analysis->struct_size;
+    if (declared_size < sizeof(chdb_query_analysis_v1))
         return CHDBError;
 
     auto * connection = reinterpret_cast<chdb_conn *>(conn);
@@ -1520,10 +1532,12 @@ chdb_state chdb_classify_query_n(
     try
     {
         auto * client = static_cast<DB::ChdbClient *>(connection->server);
-        bool has_secrets = false;
-        *out_class = client->classifyQuery(sql, sql_len, out_has_secrets ? &has_secrets : nullptr);
-        if (out_has_secrets)
-            *out_has_secrets = has_secrets ? 1 : 0;
+        client->analyzeQuery(
+            sql,
+            sql_len,
+            std::string_view(target_database ? target_database : "", target_database ? target_database_len : 0),
+            *out_analysis);
+        out_analysis->struct_size = declared_size;
         return CHDBSuccess;
     }
     catch (...)
@@ -1531,6 +1545,7 @@ chdb_state chdb_classify_query_n(
         return CHDBError;
     }
 }
+
 
 void chdb_set_signal_handlers_enabled(int enabled)
 {

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -6,6 +6,7 @@
 #include <csignal>
 #include <cstddef>
 #include <cstring>
+#include <filesystem>
 #include <ChdbClient.h>
 #include <EmbeddedServer.h>
 #if USE_PYTHON
@@ -14,6 +15,7 @@
 #include <IO/SharedThreadPools.h>
 #include <Common/AsynchronousMetrics.h>
 #include <Common/MemoryTracker.h>
+#include <Common/quoteString.h>
 #include <Common/SignalHandlers.h>
 #include <Common/ThreadPool.h>
 #include <Common/ThreadStatus.h>
@@ -1368,6 +1370,166 @@ const char * chdb_result_error(chdb_result * result)
 const char * chdb_version(void)
 {
     return CHDB_VERSION;
+}
+
+namespace CHDB
+{
+namespace
+{
+
+/// Backup and restore differ only in the keyword and the direction word, so
+/// one builder writes both. The caller hands us a bare database name and a
+/// bare path; we quote each for the syntactic position it lands in, which is
+/// the whole point of taking them apart instead of accepting a SQL string.
+/// A path the engine will read the same way we do.
+///
+/// `backups.allowed_path` resolves a relative value against the data
+/// directory, and a relative archive path then resolves against *that*, so a
+/// caller passing `backups/x.tar.gz` lands two directories deeper than it
+/// meant and only finds out by looking. There is no reading of a relative
+/// path here that is both obvious and correct, so refuse it. Refuse a missing
+/// directory too: the engine's own message for it names the allow-list rather
+/// than the directory, which sends people to the wrong place.
+void checkArchivePath(std::string_view what, std::string_view file_path, bool must_exist)
+{
+    if (file_path.empty())
+        throw std::invalid_argument(std::string(what) + " must not be empty");
+    /// A null byte would end the string the lexer sees while leaving the rest
+    /// of the argument behind it, so refuse rather than truncate.
+    if (file_path.find('\0') != std::string_view::npos)
+        throw std::invalid_argument(std::string(what) + " must not contain a null byte");
+
+    const std::filesystem::path path{std::string(file_path)};
+    if (!path.is_absolute())
+        throw std::invalid_argument(
+            std::string(what) + " must be absolute: a relative path resolves against backups.allowed_path, "
+            "which itself resolves against the data directory");
+
+    const auto parent = path.parent_path();
+    std::error_code ec;
+    if (!std::filesystem::is_directory(parent, ec))
+        throw std::invalid_argument(
+            "Directory '" + parent.string() + "' does not exist; create it, or point " + std::string(what)
+            + " somewhere that does. It must also be covered by backups.allowed_path");
+
+    if (must_exist && !std::filesystem::is_regular_file(path, ec))
+        throw std::invalid_argument("Backup archive '" + path.string() + "' does not exist");
+}
+
+String buildBackupOrRestoreQuery(
+    bool restore, std::string_view database, std::string_view file_path, std::string_view base_file_path)
+{
+    if (database.empty())
+        throw std::invalid_argument("Database name must not be empty");
+    if (database.find('\0') != std::string_view::npos)
+        throw std::invalid_argument("Database name must not contain a null byte");
+
+    checkArchivePath(restore ? "Source archive path" : "Destination archive path", file_path, /*must_exist=*/restore);
+
+    String query = (restore ? "RESTORE DATABASE " : "BACKUP DATABASE ") + DB::backQuote(database)
+        + (restore ? " FROM File(" : " TO File(") + DB::quoteString(file_path) + ")";
+
+    if (!base_file_path.empty())
+    {
+        if (restore)
+            throw std::invalid_argument("A base archive applies to backup only; RESTORE reads the base named in the archive");
+
+        checkArchivePath("Base archive path", base_file_path, /*must_exist=*/true);
+        query += " SETTINGS base_backup = File(" + DB::quoteString(base_file_path) + ")";
+    }
+
+    return query;
+}
+
+chdb_result * runBackupOrRestore(
+    chdb_connection conn,
+    bool restore,
+    const char * database,
+    size_t database_len,
+    const char * file_path,
+    size_t file_path_len,
+    const char * base_file_path,
+    size_t base_file_path_len)
+{
+    if (!conn)
+        return reinterpret_cast<chdb_result *>(new MaterializedQueryResult("Unexpected null connection"));
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return reinterpret_cast<chdb_result *>(new MaterializedQueryResult("Invalid or closed connection"));
+
+    try
+    {
+        const auto query = buildBackupOrRestoreQuery(
+            restore,
+            std::string_view(database ? database : "", database ? database_len : 0),
+            std::string_view(file_path ? file_path : "", file_path ? file_path_len : 0),
+            std::string_view(base_file_path ? base_file_path : "", base_file_path ? base_file_path_len : 0));
+
+        /// Neither statement returns rows; the format only names the empty
+        /// buffer's encoding.
+        static constexpr std::string_view result_format = "CSV";
+        auto * client = static_cast<DB::ChdbClient *>(connection->server);
+        auto query_result
+            = client->executeMaterializedQuery(query.data(), query.size(), result_format.data(), result_format.size());
+        return reinterpret_cast<chdb_result *>(query_result.release());
+    }
+    catch (const std::exception & e)
+    {
+        return reinterpret_cast<chdb_result *>(new MaterializedQueryResult(std::string("Error: ") + e.what()));
+    }
+    catch (...)
+    {
+        return reinterpret_cast<chdb_result *>(new MaterializedQueryResult(DB::getCurrentExceptionMessage(true)));
+    }
+}
+
+}
+}
+
+chdb_result * chdb_backup_database_n(
+    chdb_connection conn,
+    const char * database,
+    size_t database_len,
+    const char * file_path,
+    size_t file_path_len,
+    const char * base_file_path,
+    size_t base_file_path_len)
+{
+    return CHDB::runBackupOrRestore(
+        conn, /*restore=*/false, database, database_len, file_path, file_path_len, base_file_path, base_file_path_len);
+}
+
+chdb_result * chdb_restore_database_n(
+    chdb_connection conn, const char * database, size_t database_len, const char * file_path, size_t file_path_len)
+{
+    return CHDB::runBackupOrRestore(
+        conn, /*restore=*/true, database, database_len, file_path, file_path_len, /*base_file_path=*/nullptr, 0);
+}
+
+chdb_state chdb_classify_query_n(
+    chdb_connection conn, const char * sql, size_t sql_len, chdb_query_class * out_class, int * out_has_secrets)
+{
+    if (!conn || !out_class)
+        return CHDBError;
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return CHDBError;
+
+    try
+    {
+        auto * client = static_cast<DB::ChdbClient *>(connection->server);
+        bool has_secrets = false;
+        *out_class = client->classifyQuery(sql, sql_len, out_has_secrets ? &has_secrets : nullptr);
+        if (out_has_secrets)
+            *out_has_secrets = has_secrets ? 1 : 0;
+        return CHDBSuccess;
+    }
+    catch (...)
+    {
+        return CHDBError;
+    }
 }
 
 void chdb_set_signal_handlers_enabled(int enabled)

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -125,6 +125,36 @@ typedef enum chdb_query_class
     CHDB_QUERY_UNKNOWN = 4
 } chdb_query_class;
 
+// Facts about a statement beyond its class -- see chdb_classify_query_n().
+typedef enum chdb_query_analysis_flag
+{
+    // The text carries a credential: a named collection's key, a password, an
+    // access key handed to a table function. Never set when the class is
+    // UNKNOWN, since nothing was proven about text that did not parse.
+    CHDB_QUERY_HAS_SECRETS = 1u << 0,
+    // Every persistent write the statement performs lands in the database the
+    // caller named. Set only when that can be proven: an unqualified name is
+    // resolved through the connection's current database first, and any write
+    // to another database, to `system`, to a table function, or to a file
+    // clears it. A statement that writes nothing sets it vacuously.
+    CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE = 1u << 1,
+    // The statement creates, drops or renames a database rather than acting
+    // inside one. That is a change to the container, which a caller managing
+    // an object per database has to handle itself rather than log.
+    CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE = 1u << 2
+} chdb_query_analysis_flag;
+
+// What chdb_classify_query_n() reports. Versioned by size: set struct_size to
+// sizeof the struct you compiled against, and a newer engine will fill only
+// the fields you have room for.
+typedef struct chdb_query_analysis_v1
+{
+    uint32_t struct_size;      // caller sets to sizeof(chdb_query_analysis_v1)
+    uint32_t statement_count;  // executable statements; PARALLEL WITH arms count
+    uint32_t flags;            // chdb_query_analysis_flag, OR-ed
+    uint32_t query_class;      // chdb_query_class, as a fixed-width ABI field
+} chdb_query_analysis_v1;
+
 // Opaque handle for query results.
 // Internal data structure managed by chDB implementation.
 // Users should only interact through API functions.
@@ -959,39 +989,52 @@ CHDB_EXPORT chdb_result * chdb_restore_database_n(
  * Says what a statement would do, without running it.
  *
  * Parses the SQL with the connection's own parser and settings -- the same
- * parser that would execute it -- and reports the effect class. Nothing is
+ * parser that would execute it -- and reports what it found. Nothing is
  * executed and the session is left untouched: no current database change, no
  * settings change, no query log entry.
  *
- * The input may hold several statements. Each is classified on its own and the
- * result is the maximum, so one CONTROL statement in a batch makes the batch
- * CONTROL. SQL that does not parse classifies as CHDB_QUERY_UNKNOWN and still
- * returns CHDBSuccess -- the class is the answer, not an error.
+ * The report answers the questions a caller has to settle before it decides
+ * whether to run a statement and whether to record it:
  *
- * out_has_secrets, when given, reports whether any statement in the input
- * carries a credential in its text -- a named collection's key, a user's
- * password, an access key handed to a table function. A caller that records
- * statements needs this: the engine redacts secrets when it prints a statement
- * back, but a log of the text the caller submitted has no such protection, and
- * a durable log outlives the statement by design. It is false whenever the
- * class is UNKNOWN, since nothing was proven about text that did not parse.
- * Pass NULL if you do not need it; the answer costs nothing extra when you do.
+ *   statement_count  How many executable statements the text holds. Zero for
+ *                    empty input or text that did not parse. A batch is more
+ *                    than one, and so is `a PARALLEL WITH b`, because both
+ *                    arms execute. A caller that logs statements one at a
+ *                    time needs this: only a count of one is a statement it
+ *                    can replay on its own.
+ *   query_class      What the statement does to state that outlives it; see
+ *                    chdb_query_class. A batch takes the maximum over its
+ *                    members.
+ *   flags            See chdb_query_analysis_flag.
  *
- * @param conn Connection supplying the parser dialect and parser settings
- * @param sql SQL text to classify (may contain null bytes)
+ * target_database names the database the caller considers its own, and is
+ * what CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE is judged against. Pass NULL to
+ * skip that judgement, in which case the flag is never set.
+ *
+ * SQL that does not parse reports CHDB_QUERY_UNKNOWN with no flags and a count
+ * of zero, and still returns CHDBSuccess -- what it is, is the answer, not an
+ * error.
+ *
+ * @param conn Connection supplying the parser dialect, parser settings, and
+ *             the current database used to resolve unqualified names
+ * @param sql SQL text to analyse (may contain null bytes)
  * @param sql_len Length of sql in bytes
- * @param out_class Receives the class; written on success only
- * @param out_has_secrets Receives 1 if any statement carries a credential,
- *                        0 otherwise; may be NULL
- * @return CHDBSuccess, or CHDBError if conn or out_class is null or the
- *         connection is closed
+ * @param target_database The caller's own database, unquoted; may be NULL
+ * @param target_database_len Length of target_database in bytes
+ * @param out_analysis Receives the report. Set out_analysis->struct_size to
+ *                     sizeof(chdb_query_analysis_v1) before the call; every
+ *                     field that fits is written on success
+ * @return CHDBSuccess, or CHDBError if conn or out_analysis is null, the
+ *         connection is closed, or struct_size is smaller than this engine's
+ *         minimum
  */
 CHDB_EXPORT chdb_state chdb_classify_query_n(
     chdb_connection conn,
     const char * sql,
     size_t sql_len,
-    chdb_query_class * out_class,
-    int * out_has_secrets);
+    const char * target_database,
+    size_t target_database_len,
+    chdb_query_analysis_v1 * out_analysis);
 
 //===--------------------------------------------------------------------===//
 // Signal Handler Control

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -80,6 +80,51 @@ typedef enum chdb_state
     CHDBError = 1
 } chdb_state;
 
+// What a statement does to state that outlives it, as decided by the
+// ClickHouse parser -- see chdb_classify_query_n().
+//
+// The classes answer two questions a caller replaying statements has to keep
+// apart: does this change anything that outlives the statement, and would
+// `BACKUP DATABASE <db>` carry the change?
+//
+//                            outlives it?   `BACKUP DATABASE` carries it?
+//   READ_ONLY                     no              --
+//   MUTATING                      yes             yes
+//   MUTATING_GLOBAL               yes             NO
+//   CONTROL                    session only, or not replayable at all
+//
+// MUTATING_GLOBAL is the class that catches people out. `CREATE FUNCTION`,
+// `CREATE USER` and a named collection all change something real and are
+// worth replaying, but they live beside the databases rather than inside one,
+// so a checkpoint of the database does not hold them. A caller that files
+// them with the MUTATING statements and later checkpoints loses them without
+// an error -- the failure surfaces much later, somewhere else. Keep them
+// where a checkpoint cannot truncate them.
+//
+// Values ascend by how restricted the statement is, so a batch of statements
+// classifies as the maximum over its members.
+typedef enum chdb_query_class
+{
+    // SELECT, SHOW, DESCRIBE, EXPLAIN, EXISTS, CHECK: leaves no trace.
+    CHDB_QUERY_READ_ONLY = 0,
+    // INSERT, CREATE, ALTER, DROP, TRUNCATE, RENAME, UPDATE, DELETE, OPTIMIZE:
+    // changes a database, and `BACKUP DATABASE` captures the change.
+    CHDB_QUERY_MUTATING = 1,
+    // Global UDFs, named collections, workloads, resources, access management,
+    // and writes into the `system` database: persistent, replayable, and
+    // outside every database a checkpoint could capture.
+    CHDB_QUERY_MUTATING_GLOBAL = 2,
+    // USE, SET, ATTACH, DETACH, SYSTEM, BACKUP, RESTORE, KILL, transaction
+    // control, and statements writing outside the engine altogether
+    // (INTO OUTFILE, INSERT INTO FUNCTION): either session-scoped, so
+    // replaying makes no sense, or not something a caller should be issuing
+    // through a managed connection at all.
+    CHDB_QUERY_CONTROL = 3,
+    // Did not parse, or parsed into a statement this version does not classify.
+    // Callers gating writes on the class must treat it as a refusal.
+    CHDB_QUERY_UNKNOWN = 4
+} chdb_query_class;
+
 // Opaque handle for query results.
 // Internal data structure managed by chDB implementation.
 // Users should only interact through API functions.
@@ -824,6 +869,129 @@ CHDB_EXPORT chdb_state chdb_arrow_array_scan(
  * @return CHDBSuccess on success, CHDBError on failure
  */
 CHDB_EXPORT chdb_state chdb_arrow_unregister_table(chdb_connection conn, const char * table_name);
+
+//===--------------------------------------------------------------------===//
+// Backup, Restore and Statement Classification
+//===--------------------------------------------------------------------===//
+
+/**
+ * Backs a database up into a single archive file.
+ *
+ * The database name and the destination path are separate arguments and chDB
+ * quotes each one for the position it goes in, so a caller never builds
+ * `BACKUP ...` text and a name holding a backtick, a quote or a path holding
+ * an apostrophe cannot change what runs.
+ *
+ * The destination is subject to the `backups.allowed_path` configuration
+ * parameter, exactly as a hand-written `BACKUP ... TO File(...)` is; a
+ * connection that never set it cannot write a backup anywhere. Set it when
+ * connecting, e.g. `--backups.allowed_path=/var/lib/chdb/backups`.
+ *
+ * file_path must be absolute and its directory must already exist. Both are
+ * checked here rather than left to the engine: `backups.allowed_path`
+ * resolves a relative value against the data directory and a relative
+ * file_path then resolves against that, so a relative path lands somewhere no
+ * caller intended, and the engine reports a missing directory by naming the
+ * allow-list rather than the directory.
+ *
+ * An existing destination is never overwritten -- the call fails instead. Give
+ * every backup its own name and delete the ones you no longer want.
+ *
+ * Passing base_file_path makes the backup incremental against that archive:
+ * only what changed since it is written, and the new archive records the base
+ * it needs. Note that the recorded reference is the base's path as given here,
+ * so a caller that moves its archives between machines or into object storage
+ * has to keep that path reachable, or stay with full backups. NULL, or a
+ * length of zero, means a full backup.
+ *
+ * @param conn Connection whose engine performs the backup
+ * @param database Database name, unquoted (e.g. `my-db`, not `` `my-db` ``)
+ * @param database_len Length of database in bytes
+ * @param file_path Destination archive path, unquoted and absolute
+ * @param file_path_len Length of file_path in bytes
+ * @param base_file_path Existing archive to make this backup incremental
+ *                       against, unquoted and absolute; NULL for a full backup
+ * @param base_file_path_len Length of base_file_path in bytes; 0 for a full backup
+ * @return Query result; check chdb_result_error() and destroy it with
+ *         chdb_destroy_query_result() as for any other result
+ */
+CHDB_EXPORT chdb_result * chdb_backup_database_n(
+    chdb_connection conn,
+    const char * database,
+    size_t database_len,
+    const char * file_path,
+    size_t file_path_len,
+    const char * base_file_path,
+    size_t base_file_path_len);
+
+/**
+ * Restores a database from an archive written by chdb_backup_database_n().
+ *
+ * Quoting, the absolute-path requirement, the `backups.allowed_path`
+ * constraint and the result lifecycle match chdb_backup_database_n(); the
+ * archive itself must exist. The current database of the session is left
+ * alone: restoring into `mem` does not make `mem` current, so a caller that
+ * wants to query the restored database has to say so.
+ *
+ * An incremental archive names its base internally, so there is no base
+ * argument here -- but that name is the path the backup was written against,
+ * and the restore fails if nothing is there.
+ *
+ * RESTORE appends to an existing table rather than replacing it, so restore
+ * into a database that does not already hold the tables in the archive.
+ *
+ * @param conn Connection whose engine performs the restore
+ * @param database Database name, unquoted
+ * @param database_len Length of database in bytes
+ * @param file_path Source archive path, unquoted
+ * @param file_path_len Length of file_path in bytes
+ * @return Query result; check chdb_result_error() and destroy it with
+ *         chdb_destroy_query_result()
+ */
+CHDB_EXPORT chdb_result * chdb_restore_database_n(
+    chdb_connection conn,
+    const char * database,
+    size_t database_len,
+    const char * file_path,
+    size_t file_path_len);
+
+/**
+ * Says what a statement would do, without running it.
+ *
+ * Parses the SQL with the connection's own parser and settings -- the same
+ * parser that would execute it -- and reports the effect class. Nothing is
+ * executed and the session is left untouched: no current database change, no
+ * settings change, no query log entry.
+ *
+ * The input may hold several statements. Each is classified on its own and the
+ * result is the maximum, so one CONTROL statement in a batch makes the batch
+ * CONTROL. SQL that does not parse classifies as CHDB_QUERY_UNKNOWN and still
+ * returns CHDBSuccess -- the class is the answer, not an error.
+ *
+ * out_has_secrets, when given, reports whether any statement in the input
+ * carries a credential in its text -- a named collection's key, a user's
+ * password, an access key handed to a table function. A caller that records
+ * statements needs this: the engine redacts secrets when it prints a statement
+ * back, but a log of the text the caller submitted has no such protection, and
+ * a durable log outlives the statement by design. It is false whenever the
+ * class is UNKNOWN, since nothing was proven about text that did not parse.
+ * Pass NULL if you do not need it; the answer costs nothing extra when you do.
+ *
+ * @param conn Connection supplying the parser dialect and parser settings
+ * @param sql SQL text to classify (may contain null bytes)
+ * @param sql_len Length of sql in bytes
+ * @param out_class Receives the class; written on success only
+ * @param out_has_secrets Receives 1 if any statement carries a credential,
+ *                        0 otherwise; may be NULL
+ * @return CHDBSuccess, or CHDBError if conn or out_class is null or the
+ *         connection is closed
+ */
+CHDB_EXPORT chdb_state chdb_classify_query_n(
+    chdb_connection conn,
+    const char * sql,
+    size_t sql_len,
+    chdb_query_class * out_class,
+    int * out_has_secrets);
 
 //===--------------------------------------------------------------------===//
 // Signal Handler Control

--- a/tests/test_durable_backup_restore_classify.py
+++ b/tests/test_durable_backup_restore_classify.py
@@ -1,0 +1,386 @@
+#!python3
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from chdb import _chdb
+from chdb.state.sqlitelike import connect
+
+
+READ_ONLY = _chdb.query_class.READ_ONLY
+MUTATING = _chdb.query_class.MUTATING
+MUTATING_GLOBAL = _chdb.query_class.MUTATING_GLOBAL
+CONTROL = _chdb.query_class.CONTROL
+UNKNOWN = _chdb.query_class.UNKNOWN
+
+# A database name that a naive f-string would get wrong twice over: the dash
+# forces backticks, and the backtick inside has to be doubled.
+AWKWARD_DB = "durable-obj`1"
+AWKWARD_DB_SQL = "`durable-obj``1`"
+
+
+class DurablePrimitivesTestCase(unittest.TestCase):
+    """One connection with a scratch data directory and a backups directory."""
+
+    def setUp(self):
+        self.work = tempfile.mkdtemp(prefix="chdb-durable-")
+        # Absolute and already created: a relative backups.allowed_path would
+        # resolve against the data directory, and the engine does not create it.
+        self.backups = os.path.join(self.work, "backups")
+        os.makedirs(self.backups)
+        self.conn = connect(
+            f"{os.path.join(self.work, 'db')}?backups.allowed_path={self.backups}"
+        )
+
+    def tearDown(self):
+        self.conn.close()
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def scalar(self, sql):
+        return str(self.conn.query(sql, "CSV")).strip()
+
+    def classify(self, sql):
+        query_class, _has_secrets = self.conn._conn.classify_query(sql)
+        return query_class
+
+    def has_secrets(self, sql):
+        _query_class, has_secrets = self.conn._conn.classify_query(sql)
+        return has_secrets
+
+    def backup(self, database, file_path, base_file_path=""):
+        self.conn._conn.backup_database(database, file_path, base_file_path)
+
+    def restore(self, database, file_path):
+        self.conn._conn.restore_database(database, file_path)
+
+    def seed_awkward_database(self):
+        self.conn.query(f"CREATE DATABASE {AWKWARD_DB_SQL}")
+        self.conn.query(
+            f"CREATE TABLE {AWKWARD_DB_SQL}.t (id UInt32, name String) "
+            "ENGINE = MergeTree ORDER BY id"
+        )
+        self.conn.query(f"INSERT INTO {AWKWARD_DB_SQL}.t VALUES (1,'a'),(2,'b'),(3,'c')")
+
+
+class TestClassifyQuery(DurablePrimitivesTestCase):
+    """classify_query reports a statement's effect using the engine's own
+    parser, so a control plane never has to keep a list of SQL prefixes."""
+
+    def test_reads_are_read_only(self):
+        for sql in (
+            "SELECT 1",
+            "SELECT count() FROM system.numbers LIMIT 1",
+            "SHOW DATABASES",
+            "DESCRIBE TABLE system.one",
+            "EXPLAIN SELECT 1",
+            "EXISTS TABLE system.one",
+        ):
+            with self.subTest(sql=sql):
+                self.assertEqual(self.classify(sql), READ_ONLY)
+
+    def test_writes_the_backup_captures_are_mutating(self):
+        for sql in (
+            "INSERT INTO t VALUES (1)",
+            "CREATE TABLE t (id UInt32) ENGINE = Memory",
+            "CREATE DATABASE d",
+            "ALTER TABLE t UPDATE id = 2 WHERE id = 1",
+            "ALTER TABLE t ADD COLUMN c String",
+            "DROP TABLE t",
+            "TRUNCATE TABLE t",
+            "RENAME TABLE t TO u",
+            "OPTIMIZE TABLE t FINAL",
+            "DELETE FROM t WHERE id = 1",
+            "UNDROP TABLE t",
+        ):
+            with self.subTest(sql=sql):
+                self.assertEqual(self.classify(sql), MUTATING)
+
+    def test_session_and_server_statements_are_control(self):
+        for sql in (
+            "USE other",
+            "SET max_threads = 4",
+            "ATTACH TABLE t",
+            "DETACH TABLE t",
+            "SYSTEM DROP MARK CACHE",
+            "BACKUP DATABASE d TO File('x')",
+            "RESTORE DATABASE d FROM File('x')",
+            "KILL QUERY WHERE query_id = 'x'",
+            "BEGIN TRANSACTION",
+        ):
+            with self.subTest(sql=sql):
+                self.assertEqual(self.classify(sql), CONTROL)
+
+    def test_state_a_checkpoint_would_not_carry_is_global(self):
+        """These change something real and are worth replaying, but they live
+        beside the databases, so `BACKUP DATABASE` does not capture them. A
+        caller that filed them with the MUTATING statements would lose them at
+        the next checkpoint, without an error."""
+        for sql in (
+            "CREATE FUNCTION f AS (x) -> x + 1",
+            "DROP FUNCTION f",
+            "CREATE USER u IDENTIFIED WITH no_password",
+            "GRANT SELECT ON *.* TO u",
+            "REVOKE SELECT ON *.* FROM u",
+            "CREATE ROLE r",
+            "CREATE QUOTA q",
+            "CREATE ROW POLICY p ON t",
+            "CREATE SETTINGS PROFILE sp",
+            "DROP USER u",
+            "CREATE NAMED COLLECTION nc AS a = 1",
+            "DROP NAMED COLLECTION nc",
+            "ALTER NAMED COLLECTION nc SET a = 2",
+            "CREATE WORKLOAD w",
+            "CREATE RESOURCE r (WRITE DISK d)",
+            # A WebAssembly module arrives this way; the bytes land in the user
+            # scripts directory, which no database backup reaches.
+            "INSERT INTO system.wasm_modules VALUES ('m', 'bytes')",
+            # Reaching `system` is global whatever the verb is.
+            "ALTER TABLE system.t MODIFY COLUMN c String",
+            "DROP TABLE system.t",
+            "TRUNCATE TABLE system.t",
+        ):
+            with self.subTest(sql=sql):
+                self.assertEqual(self.classify(sql), MUTATING_GLOBAL)
+
+    def test_the_two_mutating_classes_are_told_apart(self):
+        """The whole point of the split: same keyword, different fate at the
+        next checkpoint."""
+        self.assertEqual(self.classify("CREATE TABLE t (a Int32) ENGINE = Memory"), MUTATING)
+        self.assertEqual(self.classify("CREATE FUNCTION f AS (x) -> x + 1"), MUTATING_GLOBAL)
+        self.assertEqual(self.classify("DROP TABLE t"), MUTATING)
+        self.assertEqual(self.classify("DROP FUNCTION f"), MUTATING_GLOBAL)
+        self.assertEqual(self.classify("INSERT INTO t VALUES (1)"), MUTATING)
+        self.assertEqual(
+            self.classify("INSERT INTO system.wasm_modules VALUES ('m','b')"), MUTATING_GLOBAL
+        )
+
+    def test_writing_outside_the_database_is_control(self):
+        self.assertEqual(self.classify("SELECT 1 INTO OUTFILE 'o.csv'"), CONTROL)
+        self.assertEqual(
+            self.classify("INSERT INTO FUNCTION file('o.csv') SELECT 1"), CONTROL
+        )
+
+    def test_unparseable_sql_is_unknown(self):
+        self.assertEqual(self.classify("SELECT FROM WHERE (("), UNKNOWN)
+        self.assertEqual(self.classify(""), UNKNOWN)
+        self.assertEqual(self.classify("   "), UNKNOWN)
+        self.assertEqual(self.classify("-- only a comment"), UNKNOWN)
+
+    def test_batch_takes_the_most_restricted_statement(self):
+        self.assertEqual(self.classify("SELECT 1; SELECT 2"), READ_ONLY)
+        self.assertEqual(self.classify("SELECT 1; INSERT INTO t VALUES (1)"), MUTATING)
+        self.assertEqual(self.classify("INSERT INTO t VALUES (1); USE other"), CONTROL)
+        self.assertEqual(self.classify("SELECT 1; SELECT FROM WHERE (("), UNKNOWN)
+
+    def test_trailing_separators_are_not_statements(self):
+        self.assertEqual(self.classify("SELECT 1;"), READ_ONLY)
+        self.assertEqual(self.classify("SELECT 1; -- done"), READ_ONLY)
+        self.assertEqual(self.classify("  SELECT 1  ;  "), READ_ONLY)
+
+    def test_a_statement_cannot_hide_behind_inlined_rows(self):
+        """The rows of an INSERT are data, not SQL, but whatever follows them
+        is SQL again and has to be classified too."""
+        self.assertEqual(self.classify("INSERT INTO t VALUES (1); USE other"), CONTROL)
+        self.assertEqual(
+            self.classify("INSERT INTO t FORMAT CSV\n1\n\nUSE other"), CONTROL
+        )
+        self.assertEqual(
+            self.classify("EXPLAIN INSERT INTO t VALUES (1); USE other"), CONTROL
+        )
+
+    def test_the_classes_are_ordered_so_a_caller_can_fold_a_batch(self):
+        """A control plane that classifies statements one at a time needs to
+        combine the answers, and the ordering is what lets it use max()."""
+        self.assertLess(READ_ONLY, MUTATING)
+        self.assertLess(MUTATING, MUTATING_GLOBAL)
+        self.assertLess(MUTATING_GLOBAL, CONTROL)
+        self.assertLess(CONTROL, UNKNOWN)
+        self.assertEqual(max([READ_ONLY, CONTROL, MUTATING]), CONTROL)
+        self.assertEqual(max([READ_ONLY, MUTATING_GLOBAL, MUTATING]), MUTATING_GLOBAL)
+
+    def test_secrets_in_the_text_are_reported(self):
+        """The engine redacts a credential when it prints a statement back, but
+        a caller's log of what it submitted has no such protection -- and a
+        durable log outlives the statement by design."""
+        for sql in (
+            "CREATE NAMED COLLECTION nc AS access_key_id = 'AKIA', secret_access_key = 's3cr3t'",
+            "CREATE USER u IDENTIFIED WITH sha256_password BY 'hunter2'",
+            "SELECT * FROM s3('https://b/k', 'AKIA', 's3cr3t')",
+        ):
+            with self.subTest(sql=sql):
+                self.assertTrue(self.has_secrets(sql))
+
+        for sql in (
+            "SELECT 1",
+            "INSERT INTO t VALUES (1)",
+            "CREATE FUNCTION f AS (x) -> x + 1",
+            "CREATE USER u IDENTIFIED WITH no_password",
+        ):
+            with self.subTest(sql=sql):
+                self.assertFalse(self.has_secrets(sql))
+
+    def test_one_secret_taints_the_whole_batch(self):
+        self.assertTrue(
+            self.has_secrets("SELECT 1; CREATE USER u IDENTIFIED WITH sha256_password BY 'p'")
+        )
+
+    def test_unparseable_text_claims_no_secret(self):
+        """Nothing was proven about text that did not parse, so it must not
+        report a clean bill of health it cannot back up -- the class is UNKNOWN,
+        which is the refusal; has_secrets stays false rather than guessing."""
+        self.assertEqual(self.classify("SELECT FROM WHERE (("), UNKNOWN)
+        self.assertFalse(self.has_secrets("SELECT FROM WHERE (("))
+
+    def test_classifying_does_not_execute(self):
+        self.conn.query("CREATE TABLE probe (id UInt32) ENGINE = Memory")
+        self.assertEqual(self.classify("INSERT INTO probe VALUES (1)"), MUTATING)
+        self.assertEqual(self.classify("DROP TABLE probe"), MUTATING)
+        self.assertEqual(self.scalar("SELECT count() FROM probe"), "0")
+
+    def test_classifying_does_not_change_the_session(self):
+        before = self.scalar("SELECT currentDatabase()")
+        self.assertEqual(self.classify("USE system"), CONTROL)
+        self.assertEqual(self.scalar("SELECT currentDatabase()"), before)
+
+
+class TestBackupAndRestore(DurablePrimitivesTestCase):
+    """backup_database / restore_database take the database and the path apart
+    so the engine can quote each, which is what makes them safe to call with
+    names a control plane did not choose."""
+
+    def test_round_trip_of_an_awkward_name_and_path(self):
+        self.seed_awkward_database()
+        archive = os.path.join(self.backups, "it's a backup.tar.gz")
+
+        self.backup(AWKWARD_DB, archive)
+        self.assertTrue(os.path.exists(archive))
+
+        self.conn.query(f"DROP DATABASE {AWKWARD_DB_SQL}")
+        self.restore(AWKWARD_DB, archive)
+
+        self.assertEqual(self.scalar(f"SELECT count() FROM {AWKWARD_DB_SQL}.t"), "3")
+        self.assertEqual(
+            self.scalar(f"SELECT name FROM {AWKWARD_DB_SQL}.t ORDER BY id"),
+            '"a"\n"b"\n"c"',
+        )
+
+    def test_restore_leaves_the_current_database_alone(self):
+        self.seed_awkward_database()
+        archive = os.path.join(self.backups, "current-db.tar.gz")
+        self.backup(AWKWARD_DB, archive)
+        self.conn.query(f"DROP DATABASE {AWKWARD_DB_SQL}")
+
+        before = self.scalar("SELECT currentDatabase()")
+        self.restore(AWKWARD_DB, archive)
+        self.assertEqual(self.scalar("SELECT currentDatabase()"), before)
+
+    def test_an_existing_destination_is_refused_not_overwritten(self):
+        self.seed_awkward_database()
+        archive = os.path.join(self.backups, "once.tar.gz")
+        self.backup(AWKWARD_DB, archive)
+        first_size = os.path.getsize(archive)
+
+        with self.assertRaises(RuntimeError):
+            self.backup(AWKWARD_DB, archive)
+        self.assertEqual(os.path.getsize(archive), first_size)
+
+    def test_a_path_outside_allowed_path_is_refused(self):
+        self.seed_awkward_database()
+        outside = os.path.join(self.work, "escape.tar.gz")
+        with self.assertRaises(RuntimeError):
+            self.backup(AWKWARD_DB, outside)
+        self.assertFalse(os.path.exists(outside))
+
+    def test_a_quote_in_the_name_cannot_end_the_statement(self):
+        """The classic injection shape: if the name were pasted into the SQL,
+        the trailing DROP would run. It has to be read as part of the name,
+        which does not exist, so the backup fails and nothing is dropped."""
+        self.seed_awkward_database()
+        with self.assertRaises(RuntimeError):
+            self.backup(
+                f"x` TO File('{self.backups}/inj.tar.gz'); DROP DATABASE {AWKWARD_DB_SQL} --",
+                os.path.join(self.backups, "injection.tar.gz"),
+            )
+        self.assertEqual(self.scalar(f"SELECT count() FROM {AWKWARD_DB_SQL}.t"), "3")
+
+    def test_empty_arguments_are_refused(self):
+        self.seed_awkward_database()
+        with self.assertRaises(RuntimeError):
+            self.backup("", os.path.join(self.backups, "empty-db.tar.gz"))
+        with self.assertRaises(RuntimeError):
+            self.backup(AWKWARD_DB, "")
+
+    def test_a_non_ascii_name_and_path_round_trip(self):
+        self.conn.query("CREATE DATABASE `数据库-α`")
+        self.conn.query(
+            "CREATE TABLE `数据库-α`.`данные` (id UInt32) ENGINE = MergeTree ORDER BY id"
+        )
+        self.conn.query("INSERT INTO `数据库-α`.`данные` VALUES (10),(20)")
+
+        archive = os.path.join(self.backups, "备份-β.tar.gz")
+        self.backup("数据库-α", archive)
+        self.conn.query("DROP DATABASE `数据库-α`")
+        self.restore("数据库-α", archive)
+
+        self.assertEqual(self.scalar("SELECT sum(id) FROM `数据库-α`.`данные`"), "30")
+
+    def test_restore_brings_back_the_schema(self):
+        self.seed_awkward_database()
+        archive = os.path.join(self.backups, "schema.tar.gz")
+        self.backup(AWKWARD_DB, archive)
+        self.conn.query(f"DROP DATABASE {AWKWARD_DB_SQL}")
+        self.restore(AWKWARD_DB, archive)
+
+        self.assertEqual(
+            self.scalar(
+                "SELECT name, type FROM system.columns "
+                f"WHERE database = '{AWKWARD_DB}' AND table = 't' ORDER BY position"
+            ),
+            '"id","UInt32"\n"name","String"',
+        )
+
+    def test_a_relative_path_is_refused_rather_than_resolved(self):
+        """backups.allowed_path resolves a relative value against the data
+        directory and a relative archive path then resolves against that, so a
+        relative path lands somewhere the caller did not mean."""
+        self.seed_awkward_database()
+        with self.assertRaises(RuntimeError):
+            self.backup(AWKWARD_DB, "backups/relative.tar.gz")
+
+    def test_a_missing_directory_is_refused(self):
+        self.seed_awkward_database()
+        with self.assertRaises(RuntimeError):
+            self.backup(AWKWARD_DB, os.path.join(self.backups, "no-such-dir", "x.tar.gz"))
+
+    def test_an_incremental_backup_is_smaller_than_its_base(self):
+        self.conn.query("CREATE DATABASE big")
+        self.conn.query("CREATE TABLE big.t (id UInt32) ENGINE = MergeTree ORDER BY id")
+        self.conn.query("INSERT INTO big.t SELECT number FROM numbers(100000)")
+
+        base = os.path.join(self.backups, "base.tar.gz")
+        self.backup("big", base)
+
+        self.conn.query("INSERT INTO big.t SELECT number FROM numbers(10)")
+        incr = os.path.join(self.backups, "incr.tar.gz")
+        self.backup("big", incr, base_file_path=base)
+
+        self.assertLess(os.path.getsize(incr), os.path.getsize(base) // 10)
+
+    def test_an_incremental_backup_needs_its_base_to_exist(self):
+        self.seed_awkward_database()
+        with self.assertRaises(RuntimeError):
+            self.backup(
+                AWKWARD_DB,
+                os.path.join(self.backups, "orphan.tar.gz"),
+                base_file_path=os.path.join(self.backups, "not-a-base.tar.gz"),
+            )
+
+    def test_restoring_a_missing_archive_reports_an_error(self):
+        with self.assertRaises(RuntimeError):
+            self.restore(AWKWARD_DB, os.path.join(self.backups, "not-there.tar.gz"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_durable_backup_restore_classify.py
+++ b/tests/test_durable_backup_restore_classify.py
@@ -41,13 +41,23 @@ class DurablePrimitivesTestCase(unittest.TestCase):
     def scalar(self, sql):
         return str(self.conn.query(sql, "CSV")).strip()
 
+    def analyze(self, sql, target_database=""):
+        return self.conn._conn.classify_query(sql, target_database)
+
     def classify(self, sql):
-        query_class, _has_secrets = self.conn._conn.classify_query(sql)
-        return query_class
+        return self.analyze(sql)["query_class"]
 
     def has_secrets(self, sql):
-        _query_class, has_secrets = self.conn._conn.classify_query(sql)
-        return has_secrets
+        return self.analyze(sql)["has_secrets"]
+
+    def statement_count(self, sql):
+        return self.analyze(sql)["statement_count"]
+
+    def writes_only(self, sql, target_database):
+        return self.analyze(sql, target_database)["writes_only_target_database"]
+
+    def changes_lifecycle(self, sql):
+        return self.analyze(sql, "mem")["changes_database_lifecycle"]
 
     def backup(self, database, file_path, base_file_path=""):
         self.conn._conn.backup_database(database, file_path, base_file_path)
@@ -154,6 +164,81 @@ class TestClassifyQuery(DurablePrimitivesTestCase):
         self.assertEqual(self.classify("INSERT INTO t VALUES (1)"), MUTATING)
         self.assertEqual(
             self.classify("INSERT INTO system.wasm_modules VALUES ('m','b')"), MUTATING_GLOBAL
+        )
+
+    def test_a_check_only_evaluates(self):
+        """CHECK GRANT asks whether a privilege exists; it changes nothing."""
+        self.assertEqual(self.classify("CHECK GRANT SELECT ON *.*"), READ_ONLY)
+
+    def test_a_temporary_table_is_outside_every_database(self):
+        """No BACKUP DATABASE holds it, so it is not a persistent write."""
+        self.assertEqual(self.classify("CREATE TEMPORARY TABLE tmp (a Int32)"), CONTROL)
+        self.assertEqual(self.classify("DROP TEMPORARY TABLE tmp"), CONTROL)
+
+    def test_statement_count(self):
+        """Only a count of one is a statement a caller can replay on its own."""
+        self.assertEqual(self.statement_count("SELECT 1"), 1)
+        self.assertEqual(self.statement_count("SELECT 1; SELECT 2"), 2)
+        self.assertEqual(self.statement_count("SELECT 1;"), 1)
+        self.assertEqual(self.statement_count("SELECT 1; -- done"), 1)
+        self.assertEqual(self.statement_count("INSERT INTO t VALUES (1),(2)"), 1)
+        self.assertEqual(self.statement_count("INSERT INTO t VALUES (1); SELECT 1"), 2)
+        # Both arms of PARALLEL WITH run.
+        self.assertEqual(self.statement_count("SELECT 1 PARALLEL WITH SELECT 2"), 2)
+        self.assertEqual(self.statement_count("SELECT FROM WHERE (("), 0)
+        self.assertEqual(self.statement_count(""), 0)
+
+    def test_write_containment_resolves_unqualified_names(self):
+        """An unqualified name is resolved through the connection's current
+        database before being judged -- that is the difference between a table
+        write and a write into `system`."""
+        self.assertTrue(self.writes_only("INSERT INTO mem.t VALUES (1)", "mem"))
+        self.assertFalse(self.writes_only("INSERT INTO other.t VALUES (1)", "mem"))
+        self.assertFalse(
+            self.writes_only("INSERT INTO system.wasm_modules VALUES ('m','b')", "mem")
+        )
+        self.assertFalse(self.writes_only("INSERT INTO FUNCTION file('o.csv') SELECT 1", "mem"))
+        self.assertFalse(self.writes_only("SELECT 1 INTO OUTFILE 'o.csv'", "mem"))
+        # RENAME and EXCHANGE touch two objects, either of which may stray.
+        self.assertTrue(self.writes_only("RENAME TABLE mem.a TO mem.b", "mem"))
+        self.assertFalse(self.writes_only("RENAME TABLE mem.a TO other.b", "mem"))
+        self.assertFalse(self.writes_only("EXCHANGE TABLES mem.a AND other.b", "mem"))
+        # A multi-target DROP keeps its targets in a list.
+        self.assertTrue(self.writes_only("DROP TABLE mem.a, mem.b", "mem"))
+        self.assertFalse(self.writes_only("DROP TABLE mem.a, other.b", "mem"))
+        # A statement that writes nothing is vacuously contained.
+        self.assertTrue(self.writes_only("SELECT 1", "mem"))
+        # No target named means the question was not asked.
+        self.assertFalse(self.writes_only("INSERT INTO mem.t VALUES (1)", ""))
+
+    def test_unqualified_write_follows_the_current_database(self):
+        self.conn.query("CREATE DATABASE mem")
+        self.conn.query("USE mem")
+        self.assertTrue(self.writes_only("INSERT INTO t VALUES (1)", "mem"))
+        self.assertFalse(self.writes_only("INSERT INTO t VALUES (1)", "other"))
+
+    def test_database_lifecycle(self):
+        """Acting on the container is not the same as acting inside it."""
+        self.assertTrue(self.changes_lifecycle("CREATE DATABASE d"))
+        self.assertTrue(self.changes_lifecycle("DROP DATABASE d"))
+        self.assertTrue(self.changes_lifecycle("RENAME DATABASE a TO b"))
+        self.assertFalse(self.changes_lifecycle("CREATE TABLE mem.t (a Int32) ENGINE = Memory"))
+        self.assertFalse(self.changes_lifecycle("DROP TABLE mem.t"))
+        self.assertFalse(self.changes_lifecycle("INSERT INTO mem.t VALUES (1)"))
+
+    def test_a_statement_setting_cannot_move_a_write_off_the_sync_policy(self):
+        """A managed connection configures synchronous completion once; a
+        statement re-specifying it is changing the connection's policy."""
+        for sql in (
+            "INSERT INTO t SETTINGS async_insert = 1 VALUES (1)",
+            "INSERT INTO t SETTINGS wait_for_async_insert = 0 VALUES (1)",
+            "ALTER TABLE t UPDATE a = 1 WHERE 1 SETTINGS mutations_sync = 0",
+        ):
+            with self.subTest(sql=sql):
+                self.assertEqual(self.classify(sql), CONTROL)
+        # An unrelated setting is nobody's business but the statement's.
+        self.assertEqual(
+            self.classify("INSERT INTO t SETTINGS max_threads = 4 VALUES (1)"), MUTATING
         )
 
     def test_writing_outside_the_database_is_control(self):
@@ -376,6 +461,21 @@ class TestBackupAndRestore(DurablePrimitivesTestCase):
                 os.path.join(self.backups, "orphan.tar.gz"),
                 base_file_path=os.path.join(self.backups, "not-a-base.tar.gz"),
             )
+
+    def test_using_a_closed_connection_raises_rather_than_crashes(self):
+        """close() drops the native handle; the three entry points have to look
+        before they dereference it."""
+        # The engine allows one data path per process, so reuse this case's
+        # own connection rather than opening a second one.
+        inner = self.conn._conn
+        self.conn.close()
+        with self.assertRaises(RuntimeError):
+            inner.classify_query("SELECT 1", "")
+        with self.assertRaises(RuntimeError):
+            inner.backup_database("mem", os.path.join(self.backups, "x.tar.gz"), "")
+        with self.assertRaises(RuntimeError):
+            inner.restore_database("mem", os.path.join(self.backups, "x.tar.gz"))
+        # tearDown closes again; that must stay harmless.
 
     def test_restoring_a_missing_archive_reports_an_error(self):
         with self.assertRaises(RuntimeError):

--- a/tests/test_durable_backup_restore_classify.py
+++ b/tests/test_durable_backup_restore_classify.py
@@ -206,6 +206,14 @@ class TestClassifyQuery(DurablePrimitivesTestCase):
         # A multi-target DROP keeps its targets in a list.
         self.assertTrue(self.writes_only("DROP TABLE mem.a, mem.b", "mem"))
         self.assertFalse(self.writes_only("DROP TABLE mem.a, other.b", "mem"))
+        # A partition move names its destination on the command, not on the
+        # statement, so the source alone does not settle it.
+        self.assertTrue(
+            self.writes_only("ALTER TABLE mem.a MOVE PARTITION 1 TO TABLE mem.b", "mem")
+        )
+        self.assertFalse(
+            self.writes_only("ALTER TABLE mem.a MOVE PARTITION 1 TO TABLE other.b", "mem")
+        )
         # A statement that writes nothing is vacuously contained.
         self.assertTrue(self.writes_only("SELECT 1", "mem"))
         # No target named means the question was not asked.
@@ -236,6 +244,11 @@ class TestClassifyQuery(DurablePrimitivesTestCase):
         ):
             with self.subTest(sql=sql):
                 self.assertEqual(self.classify(sql), CONTROL)
+        # `= DEFAULT` resets the value the connection chose, which is the same
+        # override by another spelling; the parser files it separately.
+        self.assertEqual(
+            self.classify("INSERT INTO t SETTINGS async_insert = DEFAULT VALUES (1)"), CONTROL
+        )
         # An unrelated setting is nobody's business but the statement's.
         self.assertEqual(
             self.classify("INSERT INTO t SETTINGS max_threads = 4 VALUES (1)"), MUTATING


### PR DESCRIPTION
A durable-object control plane keeps the leases, the manifest and the WAL.
Three things it cannot do from outside the engine, and this adds them.

**It cannot quote.** Pasting a database name into `BACKUP DATABASE ... TO File(...)`
means every binding reimplements backtick doubling and quote escaping, and each gets
its own chance to be wrong on a name it did not choose. `chdb_backup_database_n` and
`chdb_restore_database_n` take the name and the path apart and quote each for the
position it lands in. Backup also takes an optional base archive for an incremental
backup.

**It cannot tell a read from a write.** Deciding by method name lets
`query("INSERT ...")` slip past the WAL; deciding by SQL prefix means every binding
keeps a list and they drift. `chdb_classify_query_n` asks the parser.

**It cannot see a credential.** The engine redacts secrets when it prints a statement
back, but a caller's log of what it *submitted* has no such protection, and a durable
log outlives the statement by design. Classification reports this from the same parse.

## The classification, and why it has five classes

The line that matters is between `MUTATING` and `MUTATING_GLOBAL`: both change
something persistent and both are worth replaying, but only the first survives a
checkpoint. `MUTATING` is what `BACKUP DATABASE <db>` captures; `MUTATING_GLOBAL` is
everything living beside the databases — global UDFs, named collections, workloads,
resources, access entities, and writes into `system`.

Collapsing them is how a caller loses a `CREATE FUNCTION`: it goes into the log, the
log is truncated at the next checkpoint, and the function is gone with no error at the
moment it is lost. The failure surfaces much later, somewhere else.

`INSERT INTO system.*` earns its place in that class the hard way — a WebAssembly
module's bytecode arrives exactly that way, and by statement shape it is an ordinary
INSERT. Reaching `system` is global whatever the verb is, so ALTER/DROP/TRUNCATE
against it land there too.

`CONTROL` is what remains: session state where replay is meaningless, and operations a
managed connection should not be issuing. `UNKNOWN` is a refusal, so a statement type
added upstream arrives as one rather than as an assumption.

## Guards that are ours rather than the engine's

A relative archive path resolves against `backups.allowed_path`, which itself resolves
against the data directory, so it lands two levels from where anyone meant — refused.
A missing directory is reported by naming the directory, not the allow-list.

## Scope

No object storage, no lease, no manifest, no WAL. `backups.allowed_path` still bounds
where a backup may be written; an existing destination is refused rather than
overwritten. The Python module exposes the same surface through `_chdb.connect`, so a
binding built on the wheel does not have to reach for ctypes.

## Verification

Built from scratch with `chdb/build.sh` (`rm -rf buildlib libchdb.so` first), then:

- **All 15 C example suites CI runs** — 15/15, not just the new one, to show the
  existing C ABI is undisturbed.
- `examples/chdbDurableAbiTest.c` — 61 checks, wired into all four wheel jobs.
  Includes a table asserting the class of 96 statement shapes, checked against the
  engine rather than trusted: `chdb/build/check_statement_coverage.py` reads the
  alternatives out of `ParserQuery::parseImpl` and
  `ParserQueryWithOutput::parseImpl` and fails when one has no row (61 of 62
  covered, 1 exempted with its reason). That is what makes a statement type added
  upstream show up as a failure rather than as an `UNKNOWN` in someone's log --
  the earlier hand-written table could not do it, and `ParserCopyQuery` had in
  fact been sitting in the engine unlisted.
- `tests/test_durable_backup_restore_classify.py` plus 14 existing Python suites —
  15/15.

The statement-shape table is also what caught the last bug before it shipped: `ALTER`
was returning early and skipping the `system`-database check, so `ALTER TABLE system.x`
classified as `MUTATING`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add backup, restore, and query-classification APIs to `chdb`
> - Adds C API endpoints and Python bindings for database backup, restore, and non-executing SQL classification.
> - `chdb_classify_query_n` analyzes SQL without executing it, reporting an aggregate query class, statement count, secret presence, and database write containment.
> - Backup and restore APIs validate archive paths, construct quoted SQL, and execute it through `ChdbClient`.
> - Includes an integration test in [chdbDurableAbiTest.c](https://github.com/chdb-io/chdb-core/pull/202/files#diff-33d7236710d0b197000898557b43feccb17421674f527ab285725a96e20b1193) and unit tests in [test_durable_backup_restore_classify.py](https://github.com/chdb-io/chdb-core/pull/202/files#diff-abf7e66f8af5297ec9c4b64e05c2562a3ec8f13be9c1b90831ac27e73849c833).
> - Risk: New export symbols added to [libchdb_export.map](https://github.com/chdb-io/chdb-core/pull/202/files#diff-156efc9693ef47f927530d543f60933b17c03acd829f795406e5058274456ba1) and [libchdb_export_macos.txt](https://github.com/chdb-io/chdb-core/pull/202/files#diff-15eaa3cdc7590e402df88e3753ea54aa874ca02eff5c42346f2cc66a7e4b0381) alter the libchdb ABI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba83b3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
