### PR TITLE
Raise ChdbError from the query APIs

### DIFF
--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -259,11 +259,12 @@ def query(sql, output_format="CSV", path="", udf_path="", params=None, options=N
         try:
             if lower_output_format in _df_format:
                 res = conn.query_df(sql, params=params)
-                return result_func(res)
-
-            res = conn.query(sql, output_format, params=params)
-
-            if res.has_error():
+            else:
+                res = conn.query(sql, output_format, params=params)
+        except RuntimeError as e:
+            raise ChdbError(str(e)) from e.with_traceback(None)
+        else:
+            if lower_output_format not in _df_format and res.has_error():
                 raise ChdbError(res.error_message())
             return result_func(res)
         finally:

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -3,12 +3,14 @@ import os
 import threading
 
 
-class ChdbError(Exception):
+class ChdbError(RuntimeError):
     """Base exception class for chDB-related errors.
 
     This exception is raised when chDB query execution fails or encounters
-    an error. It inherits from the standard Python Exception class and
-    provides error information from the underlying ClickHouse engine.
+    an error. It inherits from RuntimeError, so code that caught the
+    RuntimeError previously raised by the connection/session APIs keeps
+    working, and provides error information from the underlying ClickHouse
+    engine.
 
     The exception message typically contains detailed error information
     from ClickHouse, including syntax errors, type mismatches, missing

--- a/chdb/__init__.py
+++ b/chdb/__init__.py
@@ -3,41 +3,7 @@ import os
 import threading
 
 
-class ChdbError(RuntimeError):
-    """Base exception class for chDB-related errors.
-
-    This exception is raised when chDB query execution fails or encounters
-    an error. It inherits from RuntimeError, so code that caught the
-    RuntimeError previously raised by the connection/session APIs keeps
-    working, and provides error information from the underlying ClickHouse
-    engine.
-
-    The exception message typically contains detailed error information
-    from ClickHouse, including syntax errors, type mismatches, missing
-    tables/columns, and other query execution issues.
-
-    Attributes:
-        args: Tuple containing the error message and any additional arguments
-
-    Examples:
-        >>> try:
-        ...     result = chdb.query("SELECT * FROM non_existent_table")
-        ... except chdb.ChdbError as e:
-        ...     print(f"Query failed: {e}")
-        Query failed: Table 'non_existent_table' doesn't exist
-
-        >>> try:
-        ...     result = chdb.query("SELECT invalid_syntax FROM")
-        ... except chdb.ChdbError as e:
-        ...     print(f"Syntax error: {e}")
-        Syntax error: Syntax error near 'FROM'
-
-    Note:
-        This exception is automatically raised by chdb.query() and related
-        functions when the underlying ClickHouse engine reports an error.
-        You should catch this exception when handling potentially failing
-        queries to provide appropriate error handling in your application.
-    """
+from ._exceptions import ChdbError
 
 
 _arrow_format = set({"arrowtable"})

--- a/chdb/_exceptions.py
+++ b/chdb/_exceptions.py
@@ -1,0 +1,43 @@
+"""The exception the chDB engine raises.
+
+Kept out of ``chdb/__init__.py`` because the chdb wrapper package ships its own
+``chdb/__init__.py`` that shadows this one, so the engine would otherwise raise
+whichever class that file happens to define.
+"""
+
+
+class ChdbError(RuntimeError):
+    """Base exception class for chDB-related errors.
+
+    This exception is raised when chDB query execution fails or encounters
+    an error. It inherits from RuntimeError, so code that caught the
+    RuntimeError previously raised by the connection/session APIs keeps
+    working, and provides error information from the underlying ClickHouse
+    engine.
+
+    The exception message typically contains detailed error information
+    from ClickHouse, including syntax errors, type mismatches, missing
+    tables/columns, and other query execution issues.
+
+    Attributes:
+        args: Tuple containing the error message and any additional arguments
+
+    Examples:
+        >>> try:
+        ...     result = chdb.query("SELECT * FROM non_existent_table")
+        ... except chdb.ChdbError as e:
+        ...     print(f"Query failed: {e}")
+        Query failed: Table 'non_existent_table' doesn't exist
+
+        >>> try:
+        ...     result = chdb.query("SELECT invalid_syntax FROM")
+        ... except chdb.ChdbError as e:
+        ...     print(f"Syntax error: {e}")
+        Syntax error: Syntax error near 'FROM'
+
+    Note:
+        This exception is automatically raised by chdb.query() and related
+        functions when the underlying ClickHouse engine reports an error.
+        You should catch this exception when handling potentially failing
+        queries to provide appropriate error handling in your application.
+    """

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -4,6 +4,7 @@ from typing import Optional, Any
 import sys
 from decimal import Decimal
 from urllib.parse import parse_qsl
+import chdb
 from chdb import _chdb
 from chdb.progress_display import (
     get_notebook_display as _get_notebook_display,
@@ -711,7 +712,7 @@ class Connection:
             - arrowtable format returns pyarrow.Table
 
         Raises:
-            RuntimeError: If query execution fails
+            ChdbError: If query execution fails
             ImportError: If required packages for format are not installed
 
         .. warning::
@@ -754,6 +755,8 @@ class Connection:
             else:
                 result = self._conn.query(query, format, params=params or {})
             return result_func(result)
+        except RuntimeError as e:
+            raise chdb.ChdbError(str(e)) from e
         finally:
             self._cleanup_auto_progress_callback(progress_callback)
 
@@ -814,7 +817,7 @@ class Connection:
             - PyArrow RecordBatch streaming (Arrow format only)
 
         Raises:
-            RuntimeError: If query execution fails
+            ChdbError: If query execution fails
             ImportError: If required packages for format are not installed
 
         .. note::
@@ -860,6 +863,9 @@ class Connection:
         progress_callback = self._setup_auto_progress_callback()
         try:
             c_stream_result = self._conn.send_query(query, format, params=params or {})
+        except RuntimeError as e:
+            self._cleanup_auto_progress_callback(progress_callback)
+            raise chdb.ChdbError(str(e)) from e
         except Exception:
             self._cleanup_auto_progress_callback(progress_callback)
             raise

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -755,7 +755,7 @@ class Connection:
             else:
                 result = self._conn.query(query, format, params=params or {})
         except RuntimeError as e:
-            raise chdb.ChdbError(str(e)) from e
+            raise chdb.ChdbError(str(e)) from e.with_traceback(None)
         else:
             return result_func(result)
         finally:
@@ -866,7 +866,7 @@ class Connection:
             c_stream_result = self._conn.send_query(query, format, params=params or {})
         except RuntimeError as e:
             self._cleanup_auto_progress_callback(progress_callback)
-            raise chdb.ChdbError(str(e)) from e
+            raise chdb.ChdbError(str(e)) from e.with_traceback(None)
         except Exception:
             self._cleanup_auto_progress_callback(progress_callback)
             raise

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -141,7 +141,7 @@ class StreamingResult:
             or None if no more data is available
 
         Raises:
-            RuntimeError: If the streaming query encounters an error
+            ChdbError: If the streaming query encounters an error
 
         .. note::
             Once the stream is exhausted (returns None), subsequent calls will
@@ -179,7 +179,7 @@ class StreamingResult:
         except Exception as e:
             self._exhausted = True
             self._cleanup_progress_callback_once()
-            raise RuntimeError(f"Streaming query failed: {str(e)}") from e
+            raise chdb.ChdbError(f"Streaming query failed: {str(e)}") from e.with_traceback(None)
 
     def __iter__(self):
         return self
@@ -228,7 +228,7 @@ class StreamingResult:
         data can be fetched from this result.
 
         Raises:
-            RuntimeError: If cancellation fails on the server side
+            ChdbError: If cancellation fails on the server side
 
         .. note::
             This method is idempotent - calling it multiple times is safe
@@ -252,7 +252,7 @@ class StreamingResult:
             try:
                 self._conn.streaming_cancel_query(self._result)
             except Exception as e:
-                raise RuntimeError(f"Failed to cancel streaming query: {str(e)}") from e
+                raise chdb.ChdbError(f"Failed to cancel streaming query: {str(e)}") from e.with_traceback(None)
             finally:
                 self._cleanup_progress_callback_once()
         else:
@@ -1051,7 +1051,7 @@ class Cursor:
             query (str): SQL query string to execute
 
         Raises:
-            Exception: If query execution fails or result parsing fails
+            ChdbError: If query execution fails
 
         .. note::
             This method follows DB-API 2.0 specifications for cursor.execute().
@@ -1092,7 +1092,7 @@ class Cursor:
         self._cursor.execute(query)
         result_mv = self._cursor.get_memview()
         if self._cursor.has_error():
-            raise Exception(self._cursor.error_message())
+            raise chdb.ChdbError(self._cursor.error_message())
         if self._cursor.data_size() == 0:
             self._current_table = None
             self._current_row = 0

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -754,9 +754,10 @@ class Connection:
                 result = self._conn.query_df(query, params=params or {})
             else:
                 result = self._conn.query(query, format, params=params or {})
-            return result_func(result)
         except RuntimeError as e:
             raise chdb.ChdbError(str(e)) from e
+        else:
+            return result_func(result)
         finally:
             self._cleanup_auto_progress_callback(progress_callback)
 

--- a/chdb/state/sqlitelike.py
+++ b/chdb/state/sqlitelike.py
@@ -4,8 +4,8 @@ from typing import Optional, Any
 import sys
 from decimal import Decimal
 from urllib.parse import parse_qsl
-import chdb
 from chdb import _chdb
+from chdb._exceptions import ChdbError
 from chdb.progress_display import (
     get_notebook_display as _get_notebook_display,
     is_notebook as _is_notebook,
@@ -179,7 +179,7 @@ class StreamingResult:
         except Exception as e:
             self._exhausted = True
             self._cleanup_progress_callback_once()
-            raise chdb.ChdbError(f"Streaming query failed: {str(e)}") from e.with_traceback(None)
+            raise ChdbError(f"Streaming query failed: {str(e)}") from e.with_traceback(None)
 
     def __iter__(self):
         return self
@@ -252,7 +252,7 @@ class StreamingResult:
             try:
                 self._conn.streaming_cancel_query(self._result)
             except Exception as e:
-                raise chdb.ChdbError(f"Failed to cancel streaming query: {str(e)}") from e.with_traceback(None)
+                raise ChdbError(f"Failed to cancel streaming query: {str(e)}") from e.with_traceback(None)
             finally:
                 self._cleanup_progress_callback_once()
         else:
@@ -755,7 +755,7 @@ class Connection:
             else:
                 result = self._conn.query(query, format, params=params or {})
         except RuntimeError as e:
-            raise chdb.ChdbError(str(e)) from e.with_traceback(None)
+            raise ChdbError(str(e)) from e.with_traceback(None)
         else:
             return result_func(result)
         finally:
@@ -866,7 +866,7 @@ class Connection:
             c_stream_result = self._conn.send_query(query, format, params=params or {})
         except RuntimeError as e:
             self._cleanup_auto_progress_callback(progress_callback)
-            raise chdb.ChdbError(str(e)) from e.with_traceback(None)
+            raise ChdbError(str(e)) from e.with_traceback(None)
         except Exception:
             self._cleanup_auto_progress_callback(progress_callback)
             raise
@@ -1092,7 +1092,7 @@ class Cursor:
         self._cursor.execute(query)
         result_mv = self._cursor.get_memview()
         if self._cursor.has_error():
-            raise chdb.ChdbError(self._cursor.error_message())
+            raise ChdbError(self._cursor.error_message())
         if self._cursor.data_size() == 0:
             self._current_table = None
             self._current_row = 0

--- a/tests/test_session_chdb_error.py
+++ b/tests/test_session_chdb_error.py
@@ -1,25 +1,20 @@
 #!/usr/bin/env python3
 
-import shutil
 import unittest
 
 import chdb
 from chdb import session
-
-test_dir = ".test_session_chdb_error"
 
 
 class TestSessionChdbError(unittest.TestCase):
     """The connection/session APIs must raise ChdbError, like chdb.query does."""
 
     def setUp(self) -> None:
-        shutil.rmtree(test_dir, ignore_errors=True)
-        self.sess = session.Session(test_dir)
+        self.sess = session.Session()
         return super().setUp()
 
     def tearDown(self) -> None:
         self.sess.close()
-        shutil.rmtree(test_dir, ignore_errors=True)
         return super().tearDown()
 
     def test_chdb_error_is_a_runtime_error(self):

--- a/tests/test_session_chdb_error.py
+++ b/tests/test_session_chdb_error.py
@@ -36,6 +36,20 @@ class TestSessionChdbError(unittest.TestCase):
         with self.assertRaises(chdb.ChdbError):
             self.sess.send_query("SELECT bad syntax FROM", "CSV")
 
+    def test_send_query_deferred_error_raises_chdb_error(self):
+        # semantic errors only surface once the stream is consumed
+        stream = self.sess.send_query("SELECT * FROM nonexistent_table_xyz", "CSV")
+        with self.assertRaises(chdb.ChdbError):
+            stream.fetch()
+
+    def test_cursor_execute_raises_chdb_error(self):
+        conn = chdb.connect(":memory:")
+        try:
+            with self.assertRaises(chdb.ChdbError):
+                conn.cursor().execute("SELECT * FROM nonexistent_table_xyz")
+        finally:
+            conn.close()
+
     def test_stateless_query_still_raises_chdb_error(self):
         with self.assertRaises(chdb.ChdbError):
             chdb.query("SELECT * FROM nonexistent_table_xyz")

--- a/tests/test_session_chdb_error.py
+++ b/tests/test_session_chdb_error.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import shutil
+import unittest
+
+import chdb
+from chdb import session
+
+test_dir = ".test_session_chdb_error"
+
+
+class TestSessionChdbError(unittest.TestCase):
+    """The connection/session APIs must raise ChdbError, like chdb.query does."""
+
+    def setUp(self) -> None:
+        shutil.rmtree(test_dir, ignore_errors=True)
+        self.sess = session.Session(test_dir)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self.sess.close()
+        shutil.rmtree(test_dir, ignore_errors=True)
+        return super().tearDown()
+
+    def test_chdb_error_is_a_runtime_error(self):
+        # backward compatibility: callers catching RuntimeError keep working
+        self.assertTrue(issubclass(chdb.ChdbError, RuntimeError))
+
+    def test_session_query_raises_chdb_error(self):
+        with self.assertRaises(chdb.ChdbError):
+            self.sess.query("SELECT * FROM nonexistent_table_xyz")
+
+    def test_session_query_error_message_preserved(self):
+        with self.assertRaises(chdb.ChdbError) as ctx:
+            self.sess.query("SELECT * FROM nonexistent_table_xyz")
+        self.assertIn("nonexistent_table_xyz", str(ctx.exception))
+
+    def test_connection_send_query_raises_chdb_error(self):
+        with self.assertRaises(chdb.ChdbError):
+            self.sess.send_query("SELECT bad syntax FROM", "CSV")
+
+    def test_stateless_query_still_raises_chdb_error(self):
+        with self.assertRaises(chdb.ChdbError):
+            chdb.query("SELECT * FROM nonexistent_table_xyz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_chdb_error.py
+++ b/tests/test_session_chdb_error.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import gc
 import unittest
+import weakref
 
 import chdb
 from chdb import session
@@ -37,6 +39,23 @@ class TestSessionChdbError(unittest.TestCase):
     def test_stateless_query_still_raises_chdb_error(self):
         with self.assertRaises(chdb.ChdbError):
             chdb.query("SELECT * FROM nonexistent_table_xyz")
+
+    def test_kept_error_does_not_keep_session_alive(self):
+        # unittest.assertRaises keeps the exception without its traceback; the
+        # chained engine error must not pin the session through its own one
+        sess = session.Session()
+        ref = weakref.ref(sess)
+        gc.disable()
+        try:
+            try:
+                sess.query("SELECT * FROM nonexistent_table_xyz")
+            except chdb.ChdbError as e:
+                kept = e.with_traceback(None)
+            del sess
+            self.assertIsNone(ref(), "session pinned by the kept ChdbError")
+            self.assertIsInstance(kept, chdb.ChdbError)
+        finally:
+            gc.enable()
 
 
 if __name__ == "__main__":

--- a/tests/test_session_chdb_error.py
+++ b/tests/test_session_chdb_error.py
@@ -50,6 +50,24 @@ class TestSessionChdbError(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_unstreamable_query_is_catchable_as_runtime_error(self):
+        # chdb's datastore falls back to a non-streaming query by catching
+        # RuntimeError from send_query, so this has to stay a RuntimeError
+        with self.assertRaises(RuntimeError):
+            self.sess.send_query("CREATE TABLE t_unstreamable (a Int32) ENGINE = Memory", "CSV")
+
+    def test_error_survives_a_shadowed_chdb_error(self):
+        # the chdb wrapper ships a chdb/__init__.py that shadows chdb-core's
+        # and defines its own ChdbError(Exception), so the engine must not
+        # raise whatever that name happens to point at
+        shadowed = type("ChdbError", (Exception,), {})
+        original, chdb.ChdbError = chdb.ChdbError, shadowed
+        try:
+            with self.assertRaises(RuntimeError):
+                self.sess.query("SELECT * FROM nonexistent_table_xyz")
+        finally:
+            chdb.ChdbError = original
+
     def test_stateless_query_still_raises_chdb_error(self):
         with self.assertRaises(chdb.ChdbError):
             chdb.query("SELECT * FROM nonexistent_table_xyz")


### PR DESCRIPTION
Engine errors from `chdb.query()`, `Connection.query` and `Connection.send_query` (and therefore `Session`) are now raised as `ChdbError`. The stateless wrapper had a `raise ChdbError` behind `has_error()`, but the binding throws `RuntimeError` before that branch is reached, so none of the APIs actually raised `ChdbError`.

Errors that only surface on `StreamingResult.fetch()`/iteration (`send_query` defers semantic errors such as an unknown table to the first fetch) and from `Cursor.execute` are raised as `ChdbError` as well.

`ChdbError` now subclasses `RuntimeError`, so existing callers that catch `RuntimeError` keep working.

The chained engine error is raised without its traceback. Keeping it pinned the calling frames, and through them the connection, for as long as the `ChdbError` was held (as `unittest.assertRaises` does), which left the engine path locked across tests.

Fixes #203

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `ChdbError` instead of `RuntimeError` from query APIs
> - Adds a shared `ChdbError` class in [chdb/_exceptions.py](https://github.com/chdb-io/chdb-core/pull/204/files#diff-1e39913b74bf3393969e7f9b00d78fc63d02e0474e4d485246a63b6f5e78db30) that subclasses `RuntimeError`, so existing `RuntimeError` handlers still work
> - Updates `chdb.query`, `Connection.query`, `Connection.send_query`, `Cursor.execute`, and the `StreamingResult` cancellation handler to raise `ChdbError` for query failures, chaining the original error as the cause
> - Adds tests in [tests/test_session_chdb_error.py](https://github.com/chdb-io/chdb-core/pull/204/files#diff-607b561af55c94e955b38fcfec8c0ffd1c1b1ee6516881d389929ff729bb69b2) covering the new exception type, error message preservation, backward compatibility with `RuntimeError`, and session cleanup after errors
> - Behavioral Change: callers that branch on `type(e) is RuntimeError` rather than `isinstance(e, RuntimeError)` will stop matching query failures; use `isinstance` or catch `chdb.ChdbError`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b11ba8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

