### PR TITLE
Support Optional[X] / X | None annotations in Python UDFs

### DIFF
--- a/chdb/udf/udf.py
+++ b/chdb/udf/udf.py
@@ -21,11 +21,14 @@ def func(arg_types=None, return_type=None, *, on_null=None, on_error=None):
             - A ChdbType instance: e.g. ``INT64``
             - A type string: e.g. ``"Int64"``
             - A Python type: e.g. ``int``, ``float``, ``str``
+            - ``Optional[X]`` / ``X | None``: treated as ``X`` (every UDF argument is
+              Nullable regardless, so the ``None`` member only selects the base type).
             - ``None`` (default): inferred from parameter type annotations.
             If provided, must specify types for ALL parameters.
         return_type: ClickHouse return type. Optional. Accepts:
             - A ChdbType instance: e.g. ``INT64``, ``STRING``, ``FLOAT64``
             - A type string: e.g. ``"Int64"``, ``"String"``, ``"DateTime64(3)"``
+            - A Python type, optionally wrapped as ``Optional[X]`` / ``X | None``.
             - ``None`` (default): inferred from the function's return type annotation.
         on_null (str): How to handle NULL inputs. Keyword-only. Accepts:
             - ``"skip"`` (default): return NULL without calling the function.

--- a/programs/local/ChdbGlobalFunctions.cpp
+++ b/programs/local/ChdbGlobalFunctions.cpp
@@ -14,8 +14,11 @@ namespace CHDB
 namespace
 {
 
-std::shared_ptr<ChdbPyType> toChdbPyType(const py::object & obj)
+std::shared_ptr<ChdbPyType> toChdbPyType(const py::object & raw_obj)
 {
+    /// Accept Optional[X] / X | None here too, so an explicit return_type may spell
+    /// the same thing an annotation can; the engine makes the type Nullable regardless.
+    auto obj = unwrapOptionalAnnotation(raw_obj);
     if (py::isinstance<ChdbPyType>(obj))
         return obj.cast<std::shared_ptr<ChdbPyType>>();
     if (py::isinstance<py::str>(obj))

--- a/programs/local/PythonScalarUDF.cpp
+++ b/programs/local/PythonScalarUDF.cpp
@@ -127,11 +127,12 @@ DB::DataTypePtr fromPythonType(const py::object & annotation)
 /// Python `bytes` value rather than a UTF-8-decoded `str`.
 bool isBytesLikeAnnotation(const py::object & annotation)
 {
-    if (!py::isinstance<py::type>(annotation))
+    auto resolved = unwrapOptionalAnnotation(annotation);
+    if (!py::isinstance<py::type>(resolved))
         return false;
 
     auto builtins = py::module_::import("builtins");
-    return annotation.is(builtins.attr("bytes")) || annotation.is(builtins.attr("bytearray"));
+    return resolved.is(builtins.attr("bytes")) || resolved.is(builtins.attr("bytearray"));
 }
 
 DB::DataTypePtr fromString(const py::object & annotation)
@@ -152,21 +153,70 @@ DB::DataTypePtr fromChdbPyType(const py::object & annotation)
 
 } // anonymous namespace
 
+py::object unwrapOptionalAnnotation(const py::object & annotation)
+{
+    auto typing_module = py::module_::import("typing");
+    auto origin = typing_module.attr("get_origin")(annotation);
+
+    if (origin.is_none())
+        return annotation;
+
+    /// typing.Optional[X] and typing.Union[...] both report typing.Union as origin;
+    /// PEP 604 unions (X | None) report types.UnionType (Python 3.10+).
+    bool is_union = origin.is(typing_module.attr("Union"));
+    if (!is_union)
+    {
+        auto types_module = py::module_::import("types");
+        if (py::hasattr(types_module, "UnionType"))
+            is_union = origin.is(types_module.attr("UnionType"));
+    }
+
+    if (!is_union)
+        return annotation;
+
+    /// Keep the single non-None member as the base type. The engine already makes
+    /// every UDF argument and return type Nullable (see inferReturnType and the
+    /// return_type_ constructor initializer), so the None member carries no extra
+    /// meaning beyond selecting X. Multi-member unions like Union[int, str] are
+    /// ambiguous and rejected.
+    auto none_type = py::none().get_type();
+    py::object base;
+    size_t non_none_count = 0;
+    for (auto member : typing_module.attr("get_args")(annotation))
+    {
+        auto member_type = py::reinterpret_borrow<py::object>(member);
+        if (member_type.is(none_type))
+            continue;
+        base = member_type;
+        ++non_none_count;
+    }
+
+    if (non_none_count == 1)
+        return base;
+
+    throw DB::Exception(
+        DB::ErrorCodes::BAD_ARGUMENTS,
+        "Unsupported Python UDF union type annotation '{}': only Optional[X] "
+        "(equivalently Union[X, None] or X | None) is supported",
+        String(py::str(annotation)));
+}
+
 DB::DataTypePtr annotationToDataType(const py::object & annotation)
 {
-    auto type_object = getPythonObjectType(annotation);
+    auto resolved = unwrapOptionalAnnotation(annotation);
+    auto type_object = getPythonObjectType(resolved);
     switch (type_object)
     {
         case PythonTypeObject::BASE:
-            return fromPythonType(annotation);
+            return fromPythonType(resolved);
         case PythonTypeObject::STRING:
-            return fromString(annotation);
+            return fromString(resolved);
         case PythonTypeObject::TYPE:
-            return fromChdbPyType(annotation);
+            return fromChdbPyType(resolved);
         case PythonTypeObject::INVALID:
         default:
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unknown Python UDF type annotation: {}",
-                String(py::str(annotation.get_type())));
+                String(py::str(resolved.get_type())));
     }
 }
 

--- a/programs/local/PythonScalarUDF.h
+++ b/programs/local/PythonScalarUDF.h
@@ -72,4 +72,9 @@ private:
 
 DB::DataTypePtr annotationToDataType(const py::object & annotation);
 
+/// If the annotation is `Optional[X]` / `Union[X, None]` (or PEP 604 `X | None`),
+/// returns the inner base type `X`; any other annotation is returned unchanged.
+/// A union with more than one non-None member (e.g. `Union[int, str]`) is rejected.
+py::object unwrapOptionalAnnotation(const py::object & annotation);
+
 } // namespace CHDB

--- a/tests/test_func_udf_types.py
+++ b/tests/test_func_udf_types.py
@@ -1,8 +1,10 @@
 #!python3
 
 import os
+import sys
 import unittest
 import datetime
+from typing import Optional, Union
 import chdb
 from chdb import func
 from chdb.sqltypes import (
@@ -4898,6 +4900,215 @@ class TestBytesUDF(unittest.TestCase):
         ret = self.session.query("SELECT hex(bytes_echo(unhex('0001FFFE')))", "CSV")
         self.assertEqual(str(ret).strip(), '"0001FFFE"')
         chdb.drop_function("bytes_echo")
+
+
+class TestOptionalAnnotationUDF(unittest.TestCase):
+    """Optional[X] / Union[X, None] / PEP 604 X | None annotations (chdb-core#188).
+
+    Every UDF argument and return type is Nullable engine-side, so ``Optional[X]``
+    maps one-to-one onto that: the annotation only selects the base type ``X`` and
+    is otherwise identical to a bare ``X``. Multi-member unions (e.g.
+    ``Union[int, str]``) stay ambiguous and are rejected at registration.
+    """
+
+    def setUp(self):
+        self.session = Session()
+
+    def tearDown(self):
+        self.session.close()
+
+    # ── the exact issue repro: Optional[str] arg + return, both inferred ──
+
+    def test_optional_str_annotation_infers_string(self):
+        # Before the fix this raised at registration:
+        #   RuntimeError: Failed to create function 'opt_echo':
+        #     Unknown Python UDF type annotation: <class 'typing.Union'>
+        @func()
+        def opt_echo(x: Optional[str]) -> Optional[str]:
+            return x
+
+        ret = self.session.query("SELECT opt_echo('hello')", "CSV")
+        self.assertEqual(str(ret).strip(), '"hello"')
+        chdb.drop_function("opt_echo")
+
+    def test_optional_int_annotation_infers_int64(self):
+        @func()
+        def opt_inc(x: Optional[int]) -> Optional[int]:
+            return None if x is None else x + 1
+
+        ret = self.session.query("SELECT opt_inc(toInt64(5))", "CSV")
+        self.assertEqual(str(ret).strip(), "6")
+        ret = self.session.query("SELECT opt_inc(toInt64(-3))", "CSV")
+        self.assertEqual(str(ret).strip(), "-2")
+        chdb.drop_function("opt_inc")
+
+    def test_optional_float_annotation_infers_float64(self):
+        @func()
+        def opt_half(x: Optional[float]) -> Optional[float]:
+            return None if x is None else x / 2
+
+        ret = self.session.query("SELECT opt_half(toFloat64(9))", "CSV")
+        self.assertEqual(str(ret).strip(), "4.5")
+        chdb.drop_function("opt_half")
+
+    def test_optional_date_annotation_infers_date(self):
+        @func()
+        def opt_day(d: Optional[datetime.date]) -> Optional[datetime.date]:
+            return d
+
+        ret = self.session.query("SELECT opt_day(toDate('2020-01-15'))", "CSV")
+        self.assertEqual(str(ret).strip(), '"2020-01-15"')
+        chdb.drop_function("opt_day")
+
+    # ── typing.Union[X, None] spelled explicitly (same as Optional[X]) ──
+
+    def test_union_x_none_equivalent_to_optional(self):
+        def union_echo(x: Union[str, None]) -> Union[str, None]:
+            return x
+
+        chdb.create_function("union_echo", union_echo)
+        ret = self.session.query("SELECT union_echo('hey')", "CSV")
+        self.assertEqual(str(ret).strip(), '"hey"')
+        chdb.drop_function("union_echo")
+
+    def test_union_none_x_order_independent(self):
+        # None first: Union[None, int] must also resolve to the base type.
+        def union_inc(x: Union[None, int]) -> Union[None, int]:
+            return None if x is None else x + 1
+
+        chdb.create_function("union_inc", union_inc)
+        ret = self.session.query("SELECT union_inc(toInt64(7))", "CSV")
+        self.assertEqual(str(ret).strip(), "8")
+        chdb.drop_function("union_inc")
+
+    # ── PEP 604 (X | None), Python 3.10+ only ──
+
+    @unittest.skipIf(sys.version_info < (3, 10), "PEP 604 X | None requires Python 3.10+")
+    def test_pep604_union_infers_types(self):
+        # Defined inside the (skipped-on-3.9) method so the file still imports on
+        # 3.9, where `int | None` at def-time would raise TypeError.
+        def pep604_inc(x: int | None) -> int | None:  # noqa: E999
+            return None if x is None else x + 1
+
+        chdb.create_function("pep604_inc", pep604_inc)
+        ret = self.session.query("SELECT pep604_inc(toInt64(4))", "CSV")
+        self.assertEqual(str(ret).strip(), "5")
+        chdb.drop_function("pep604_inc")
+
+    # ── Optional return actually yields SQL NULL (Nullable return path) ──
+
+    def test_optional_return_none_yields_sql_null(self):
+        @func()
+        def opt_maybe(x: Optional[int]) -> Optional[int]:
+            return None if x > 10 else x
+
+        # non-None value returned verbatim
+        ret = self.session.query("SELECT opt_maybe(toInt64(5))", "CSV")
+        self.assertEqual(str(ret).strip(), "5")
+        # None returned → NULL
+        ret = self.session.query("SELECT opt_maybe(toInt64(20))", "CSV")
+        self.assertEqual(str(ret).strip(), "\\N")
+        chdb.drop_function("opt_maybe")
+
+    # ── Optional arg + on_null="pass": the motivating use case (handle x is None) ──
+
+    def test_optional_arg_on_null_pass_receives_none(self):
+        @func(on_null="pass")
+        def opt_none_to_zero(x: Optional[int]) -> int:
+            return 0 if x is None else x + 1
+
+        ret = self.session.query("SELECT opt_none_to_zero(NULL)", "CSV")
+        self.assertEqual(str(ret).strip(), "0")
+        ret = self.session.query("SELECT opt_none_to_zero(toInt64(9))", "CSV")
+        self.assertEqual(str(ret).strip(), "10")
+        chdb.drop_function("opt_none_to_zero")
+
+    def test_optional_arg_on_null_pass_mixed_column(self):
+        @func(on_null="pass")
+        def opt_double(x: Optional[int]) -> Optional[int]:
+            return None if x is None else x * 2
+
+        ret = self.session.query(
+            "SELECT opt_double(x) FROM "
+            "(SELECT CAST(arrayJoin([1, NULL, 3]) AS Nullable(Int64)) AS x)",
+            "CSV",
+        )
+        self.assertEqual(str(ret).strip(), "2\n\\N\n6")
+        chdb.drop_function("opt_double")
+
+    # ── Optional[bytes]: the arg still receives raw bytes, not a decoded str ──
+
+    def test_optional_bytes_arg_receives_bytes(self):
+        def kind(x: Optional[bytes]) -> str:
+            return type(x).__name__
+
+        chdb.create_function("opt_bytes_kind", kind)
+        ret = self.session.query("SELECT opt_bytes_kind('abc')", "CSV")
+        self.assertEqual(str(ret).strip(), '"bytes"')
+        chdb.drop_function("opt_bytes_kind")
+
+    def test_optional_bytes_round_trip_binary_safe(self):
+        def echo(x: Optional[bytes]) -> Optional[bytes]:
+            return x
+
+        chdb.create_function("opt_bytes_echo", echo)
+        ret = self.session.query("SELECT hex(opt_bytes_echo(unhex('0001FFFE')))", "CSV")
+        self.assertEqual(str(ret).strip(), '"0001FFFE"')
+        chdb.drop_function("opt_bytes_echo")
+
+    # ── Optional in the explicit arg_types / return_type params, not annotations ──
+
+    def test_explicit_arg_types_optional(self):
+        chdb.create_function(
+            "opt_arg_explicit", lambda x: x + 1, arg_types=[Optional[int]], return_type=INT64)
+        ret = self.session.query("SELECT opt_arg_explicit(toInt64(9))", "CSV")
+        self.assertEqual(str(ret).strip(), "10")
+        chdb.drop_function("opt_arg_explicit")
+
+    def test_explicit_return_type_optional(self):
+        chdb.create_function(
+            "opt_ret_explicit", lambda: "hi", arg_types=[], return_type=Optional[str])
+        ret = self.session.query("SELECT opt_ret_explicit()", "CSV")
+        self.assertEqual(str(ret).strip(), '"hi"')
+        chdb.drop_function("opt_ret_explicit")
+
+    # ── decorator still returns a normally-callable Python function ──
+
+    def test_optional_preserves_python_callability(self):
+        @func()
+        def opt_call(x: Optional[int]) -> Optional[int]:
+            return None if x is None else x + 1
+
+        self.assertEqual(opt_call(5), 6)
+        self.assertIsNone(opt_call(None))
+        chdb.drop_function("opt_call")
+
+    # ── multi-member unions stay ambiguous → rejected at registration ──
+
+    def test_multi_member_union_arg_rejected(self):
+        def bad(x: Union[int, str]) -> int:
+            return 0
+
+        with self.assertRaisesRegex(RuntimeError, "union type annotation"):
+            chdb.create_function("bad_union_arg", bad)
+
+    def test_multi_member_union_return_rejected(self):
+        def bad_ret() -> Union[int, str]:
+            return 0
+
+        with self.assertRaisesRegex(RuntimeError, "union type annotation"):
+            chdb.create_function("bad_union_ret", bad_ret)
+
+    def test_multi_member_union_explicit_arg_types_rejected(self):
+        # Distinct C++ path (resolveArgTypes) from the inferred-annotation path.
+        with self.assertRaisesRegex(RuntimeError, "union type annotation"):
+            chdb.create_function(
+                "bad_union_arg_explicit", lambda x: x, arg_types=[Union[int, str]], return_type=INT64)
+
+    def test_multi_member_union_explicit_return_type_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "union type annotation"):
+            chdb.create_function(
+                "bad_union_explicit", lambda x: x, arg_types=[INT64], return_type=Union[int, str])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #188.

## Problem

Registering a UDF with idiomatic optional annotations failed at registration:

```python
from typing import Optional
import chdb

@chdb.func()
def opt_echo(x: Optional[str]) -> Optional[str]:
    return x
# RuntimeError: Failed to create function 'opt_echo':
#   Unknown Python UDF type annotation: <class 'typing.Union'>
```

`getPythonObjectType()` classified `typing.Optional[str]` (= `Union[str, None]`) as
`INVALID`, so `annotationToDataType()` threw.

## Fix

Add `unwrapOptionalAnnotation()`: using `typing.get_origin`/`get_args` it recognizes
`Optional[X]` / `Union[X, None]` and PEP 604 `X | None` (`types.UnionType`), and returns
the single non-`None` member `X`. Any non-union annotation passes through unchanged, and a
multi-member union such as `Union[int, str]` stays ambiguous and is rejected.

No runtime behavior change is needed: the engine already wraps every UDF argument and
return type with `makeNullable`, so "can be None" is universally true — the annotation only
needs to select the base type. The unwrap is applied at every site that turns an annotation
into a type:

- `annotationToDataType()` — inferred argument types and inferred return type
- `isBytesLikeAnnotation()` — so `Optional[bytes]` still delivers a raw `bytes` value
- `toChdbPyType()` — explicit `return_type=` / `arg_types=` may spell the same thing an
  annotation can

This matches chdb-io/chdb#629, which already translates `Optional[X]` as `X` when
deploying chDB UDFs to remote ClickHouse servers.

## Tests

New `TestOptionalAnnotationUDF` in `tests/test_func_udf_types.py` (19 cases):

- inference for `Optional[str|int|float|date]`
- `Union[X, None]` in both member orders and PEP 604 `X | None` (skipped < 3.10, and
  defined inside the test so the file still imports on 3.9)
- `Optional` return actually producing SQL `NULL`
- `Optional` argument with `on_null="pass"` receiving `None` (the motivating use case)
- `Optional[bytes]` argument still receiving raw bytes; binary-safe round trip
- explicit `arg_types=[Optional[int]]` and `return_type=Optional[str]`
- multi-member `Union[int, str]` rejected on all four paths (inferred arg, inferred
  return, explicit `return_type=`, explicit `arg_types=`)

All 19 new tests plus the existing 575 UDF tests pass; both touched translation units
compile clean under `-Weverything -Werror`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Optional[X]` and `X | None` annotation support to Python UDFs
> - Adds `unwrapOptionalAnnotation` in [PythonScalarUDF.cpp](https://github.com/chdb-io/chdb-core/pull/205/files#diff-15a92bfc453d48a634f28e83e87266a457063d77479647d9c25962db9e75494f) to strip the `None` member from `typing.Union`, `Union[X, None]`, and PEP 604 `X | None` forms before type inference and explicit-type checks.
> - Updates `annotationToDataType`, `isBytesLikeAnnotation`, and `toChdbPyType` to resolve through the unwrapped inner type so `Optional[bytes]` still receives raw bytes and inferred/explicit types map to their base.
> - Adds `TestOptionalAnnotationUDF` in [test_func_udf_types.py](https://github.com/chdb-io/chdb-core/pull/205/files#diff-b3ba44e9eabe389a489366eb771a7113fcd1ee927af4c00904d034a5a5e1b346) covering inferred and explicit Optional types, PEP 604 unions, NULL handling, bytes round-trips, and registration rejection for ambiguous unions.
> - Behavioral Change: `unwrapOptionalAnnotation` now raises `BAD_ARGUMENTS` for unions with zero or multiple non-None members (e.g. `Union[int, str]`); registrations that previously may have fallen through to a different error path will now fail explicitly at unwrap time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d71808d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->