### PR TITLE
Add Python 3.15 to the wheel build matrix

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -121,7 +121,14 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14
+          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
+          # (2026-10-01) fall back to the release candidate; the symlink lets the
+          # bare "3.15" used by pyenv global/shell below resolve to it.
+          pyenv install 3.15:latest || {
+            pyenv install 3.15.0rc2
+            ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
+          }
+          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           # Verify installations
           echo "Installed versions:"
@@ -134,7 +141,7 @@ jobs:
           pyenv versions
           echo ""
           echo "Verifying all required Python versions are available:"
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
             if ! pyenv versions --bare | grep -q "^$version"; then
               echo "ERROR: Python $version is not installed!"
               exit 1
@@ -146,6 +153,8 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          # 3.15 is left out here: pandas/pyarrow publish no cp315 wheels yet, so 3.15
+          # only gets the dependency-free import smoke test in the wheel test step.
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "Installing dependencies for Python $version"
             pyenv shell $version
@@ -441,7 +450,18 @@ jobs:
             sudo ln -sf /usr/bin/lldb-21 /usr/bin/lldb || true
           fi
 
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
+            if [[ "$version" == "3.15" ]]; then
+              # No pandas/pyarrow cp315 wheels yet (pandas 3.1 / pyarrow 26.0.0 will ship
+              # them): install without deps and only check that the wheel imports and
+              # queries, which is what loads libpybind11nonlimitedapi_chdb_3.15. Fold 3.15
+              # into the full matrix below once those wheels exist.
+              pyenv shell $version
+              python -m pip install dist/*.whl --force-reinstall --no-deps
+              python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"
+              pyenv shell --unset
+              continue
+            fi
             # pandas 3.x requires Python >=3.11
             if [[ "$version" == "3.9" || "$version" == "3.10" ]]; then
               PANDAS_CONSTRAINTS=("pandas<3.0")

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -130,13 +130,18 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
-          # (2026-10-01) fall back to the release candidate; the symlink lets the
-          # bare "3.15" used by pyenv global/shell below resolve to it.
-          pyenv install 3.15:latest || {
+          # pyenv's ":latest" resolver skips pre-releases, so until 3.15.0 final
+          # ships (2026-10-01) install the release candidate and symlink it as
+          # "3.15" so the bare version used by pyenv global/shell below resolves.
+          # Probe with the pyenv binary, not the shell function from `pyenv init`:
+          # that function runs `command pyenv ...`, and under macOS 14's bash 3.2
+          # `set -e` fires inside it even on the failing side of an if/||.
+          if "$HOME/.pyenv/bin/pyenv" latest -k 3.15 >/dev/null 2>&1; then
+            pyenv install 3.15:latest
+          else
             pyenv install 3.15.0rc2
             ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
-          }
+          fi
           pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           # Verify installations

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -107,7 +107,14 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14
+          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
+          # (2026-10-01) fall back to the release candidate; the symlink lets the
+          # bare "3.15" used by pyenv global/shell below resolve to it.
+          pyenv install 3.15:latest || {
+            pyenv install 3.15.0rc2
+            ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
+          }
+          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           # Verify installations
           echo "Installed versions:"
@@ -120,7 +127,7 @@ jobs:
           pyenv versions
           echo ""
           echo "Verifying all required Python versions are available:"
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
             if ! pyenv versions --bare | grep -q "^$version"; then
               echo "ERROR: Python $version is not installed!"
               exit 1
@@ -132,6 +139,8 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          # 3.15 is left out here: pandas/pyarrow publish no cp315 wheels yet, so 3.15
+          # only gets the dependency-free import smoke test in the wheel test step.
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "Installing dependencies for Python $version"
             pyenv shell $version
@@ -425,7 +434,18 @@ jobs:
             sudo ln -sf /usr/bin/lldb-21 /usr/bin/lldb || true
           fi
 
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
+            if [[ "$version" == "3.15" ]]; then
+              # No pandas/pyarrow cp315 wheels yet (pandas 3.1 / pyarrow 26.0.0 will ship
+              # them): install without deps and only check that the wheel imports and
+              # queries, which is what loads libpybind11nonlimitedapi_chdb_3.15. Fold 3.15
+              # into the full matrix below once those wheels exist.
+              pyenv shell $version
+              python -m pip install dist/*.whl --force-reinstall --no-deps
+              python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"
+              pyenv shell --unset
+              continue
+            fi
             # pandas 3.x requires Python >=3.11
             if [[ "$version" == "3.9" || "$version" == "3.10" ]]; then
               PANDAS_CONSTRAINTS=("pandas<3.0")

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -116,13 +116,18 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
-          # (2026-10-01) fall back to the release candidate; the symlink lets the
-          # bare "3.15" used by pyenv global/shell below resolve to it.
-          pyenv install 3.15:latest || {
+          # pyenv's ":latest" resolver skips pre-releases, so until 3.15.0 final
+          # ships (2026-10-01) install the release candidate and symlink it as
+          # "3.15" so the bare version used by pyenv global/shell below resolves.
+          # Probe with the pyenv binary, not the shell function from `pyenv init`:
+          # that function runs `command pyenv ...`, and under macOS 14's bash 3.2
+          # `set -e` fires inside it even on the failing side of an if/||.
+          if "$HOME/.pyenv/bin/pyenv" latest -k 3.15 >/dev/null 2>&1; then
+            pyenv install 3.15:latest
+          else
             pyenv install 3.15.0rc2
             ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
-          }
+          fi
           pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           # Verify installations

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -242,13 +242,18 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
-          # (2026-10-01) fall back to the release candidate; the symlink lets the
-          # bare "3.15" used by pyenv global/shell below resolve to it.
-          pyenv install 3.15:latest || {
+          # pyenv's ":latest" resolver skips pre-releases, so until 3.15.0 final
+          # ships (2026-10-01) install the release candidate and symlink it as
+          # "3.15" so the bare version used by pyenv global/shell below resolves.
+          # Probe with the pyenv binary, not the shell function from `pyenv init`:
+          # that function runs `command pyenv ...`, and under macOS 14's bash 3.2
+          # `set -e` fires inside it even on the failing side of an if/||.
+          if "$HOME/.pyenv/bin/pyenv" latest -k 3.15 >/dev/null 2>&1; then
+            pyenv install 3.15:latest
+          else
             pyenv install 3.15.0rc2
             ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
-          }
+          fi
           pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           echo "Installed versions:"

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -166,6 +166,7 @@ jobs:
             ./chdb/libpybind11nonlimitedapi_chdb_3.12.dylib
             ./chdb/libpybind11nonlimitedapi_chdb_3.13.dylib
             ./chdb/libpybind11nonlimitedapi_chdb_3.14.dylib
+            ./chdb/libpybind11nonlimitedapi_chdb_3.15.dylib
           retention-days: 1
       # ---------------------------------------------------------------------
       # chdb-core-lite cross-compile: only the Python module (_chdb.abi3.so);
@@ -224,7 +225,14 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14
+          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
+          # (2026-10-01) fall back to the release candidate; the symlink lets the
+          # bare "3.15" used by pyenv global/shell below resolve to it.
+          pyenv install 3.15:latest || {
+            pyenv install 3.15.0rc2
+            ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
+          }
+          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           echo "Installed versions:"
           pyenv versions
@@ -236,7 +244,7 @@ jobs:
           pyenv versions
           echo ""
           echo "Verifying all required Python versions are available:"
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
             if ! pyenv versions --bare | grep -q "^$version"; then
               echo "ERROR: Python $version is not installed!"
               exit 1
@@ -248,6 +256,8 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          # 3.15 is left out here: pandas/pyarrow publish no cp315 wheels yet, so 3.15
+          # only gets the dependency-free import smoke test in the wheel test step.
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "Installing dependencies for Python $version"
             pyenv shell $version
@@ -295,7 +305,7 @@ jobs:
           [ -f ./artifacts/libchdb.a ] && mv ./artifacts/libchdb.a ./
           mv ./artifacts/chdb/_chdb.abi3.so ./chdb/
           mv ./artifacts/chdb/libpybind11nonlimitedapi_stubs.dylib ./chdb/
-          for v in 9 10 11 12 13 14; do
+          for v in 9 10 11 12 13 14 15; do
             mv ./artifacts/chdb/libpybind11nonlimitedapi_chdb_3.${v}.dylib ./chdb/
           done
           cp -a ./artifacts/libchdb.so.dSYM ./
@@ -450,7 +460,18 @@ jobs:
 
           DEBUG_MODE="${{ env.EFFECTIVE_DEBUG_MODE }}"
 
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
+            if [[ "$version" == "3.15" ]]; then
+              # No pandas/pyarrow cp315 wheels yet (pandas 3.1 / pyarrow 26.0.0 will ship
+              # them): install without deps and only check that the wheel imports and
+              # queries, which is what loads libpybind11nonlimitedapi_chdb_3.15. Fold 3.15
+              # into the full matrix below once those wheels exist.
+              pyenv shell $version
+              python -m pip install dist/*.whl --force-reinstall --no-deps
+              python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"
+              pyenv shell --unset
+              continue
+            fi
             # pandas 3.x requires Python >=3.11
             if [[ "$version" == "3.9" || "$version" == "3.10" ]]; then
               PANDAS_CONSTRAINTS=("pandas<3.0")

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -242,13 +242,18 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
-          # (2026-10-01) fall back to the release candidate; the symlink lets the
-          # bare "3.15" used by pyenv global/shell below resolve to it.
-          pyenv install 3.15:latest || {
+          # pyenv's ":latest" resolver skips pre-releases, so until 3.15.0 final
+          # ships (2026-10-01) install the release candidate and symlink it as
+          # "3.15" so the bare version used by pyenv global/shell below resolves.
+          # Probe with the pyenv binary, not the shell function from `pyenv init`:
+          # that function runs `command pyenv ...`, and under macOS 14's bash 3.2
+          # `set -e` fires inside it even on the failing side of an if/||.
+          if "$HOME/.pyenv/bin/pyenv" latest -k 3.15 >/dev/null 2>&1; then
+            pyenv install 3.15:latest
+          else
             pyenv install 3.15.0rc2
             ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
-          }
+          fi
           pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           echo "Installed versions:"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -166,6 +166,7 @@ jobs:
             ./chdb/libpybind11nonlimitedapi_chdb_3.12.dylib
             ./chdb/libpybind11nonlimitedapi_chdb_3.13.dylib
             ./chdb/libpybind11nonlimitedapi_chdb_3.14.dylib
+            ./chdb/libpybind11nonlimitedapi_chdb_3.15.dylib
           retention-days: 1
       # ---------------------------------------------------------------------
       # chdb-core-lite cross-compile: only the Python module (_chdb.abi3.so);
@@ -224,7 +225,14 @@ jobs:
           pyenv install 3.12:latest
           pyenv install 3.13:latest
           pyenv install 3.14:latest
-          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14
+          # pyenv's ":latest" skips pre-releases, so until 3.15.0 final ships
+          # (2026-10-01) fall back to the release candidate; the symlink lets the
+          # bare "3.15" used by pyenv global/shell below resolve to it.
+          pyenv install 3.15:latest || {
+            pyenv install 3.15.0rc2
+            ln -s "$HOME/.pyenv/versions/3.15.0rc2" "$HOME/.pyenv/versions/3.15"
+          }
+          pyenv global 3.9 3.10 3.11 3.12 3.13 3.14 3.15
 
           echo "Installed versions:"
           pyenv versions
@@ -236,7 +244,7 @@ jobs:
           pyenv versions
           echo ""
           echo "Verifying all required Python versions are available:"
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
             if ! pyenv versions --bare | grep -q "^$version"; then
               echo "ERROR: Python $version is not installed!"
               exit 1
@@ -248,6 +256,8 @@ jobs:
         run: |
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+          # 3.15 is left out here: pandas/pyarrow publish no cp315 wheels yet, so 3.15
+          # only gets the dependency-free import smoke test in the wheel test step.
           for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
             echo "Installing dependencies for Python $version"
             pyenv shell $version
@@ -295,7 +305,7 @@ jobs:
           [ -f ./artifacts/libchdb.a ] && mv ./artifacts/libchdb.a ./
           mv ./artifacts/chdb/_chdb.abi3.so ./chdb/
           mv ./artifacts/chdb/libpybind11nonlimitedapi_stubs.dylib ./chdb/
-          for v in 9 10 11 12 13 14; do
+          for v in 9 10 11 12 13 14 15; do
             mv ./artifacts/chdb/libpybind11nonlimitedapi_chdb_3.${v}.dylib ./chdb/
           done
           cp -a ./artifacts/libchdb.so.dSYM ./
@@ -451,7 +461,18 @@ jobs:
 
           DEBUG_MODE="${{ env.EFFECTIVE_DEBUG_MODE }}"
 
-          for version in 3.9 3.10 3.11 3.12 3.13 3.14; do
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.15; do
+            if [[ "$version" == "3.15" ]]; then
+              # No pandas/pyarrow cp315 wheels yet (pandas 3.1 / pyarrow 26.0.0 will ship
+              # them): install without deps and only check that the wheel imports and
+              # queries, which is what loads libpybind11nonlimitedapi_chdb_3.15. Fold 3.15
+              # into the full matrix below once those wheels exist.
+              pyenv shell $version
+              python -m pip install dist/*.whl --force-reinstall --no-deps
+              python -c "import chdb; res = chdb.query('select 1112222222,555', 'CSV'); print(f'Python $version: {res}')"
+              pyenv shell --unset
+              continue
+            fi
             # pandas 3.x requires Python >=3.11
             if [[ "$version" == "3.9" || "$version" == "3.10" ]]; then
               PANDAS_CONSTRAINTS=("pandas<3.0")

--- a/chdb/build/download_python_headers.sh
+++ b/chdb/build/download_python_headers.sh
@@ -14,6 +14,8 @@ declare -A VERSION_MAP=(
     ["3.12"]="3.12.10:3.12:3.12"
     ["3.13"]="3.13.9:3.13:3.13"
     ["3.14"]="3.14.0:3.14:3.14"
+    # 3.15.0 final is due 2026-10-01; bump to it once python.org ships the installer.
+    ["3.15"]="3.15.0rc2:3.15:3.15"
     ["3.13t"]="3.13.9:3.13t:3.13"
     ["3.14t"]="3.14.0:3.14t:3.14"
 )
@@ -37,6 +39,7 @@ else
         "${VERSION_MAP[3.12]}"
         "${VERSION_MAP[3.13]}"
         "${VERSION_MAP[3.14]}"
+        "${VERSION_MAP[3.15]}"
     )
 fi
 
@@ -66,7 +69,10 @@ for entry in "${VERSIONS[@]}"; do
     mkdir -p "$WORK_DIR"
     cd "$WORK_DIR"
 
-    PKG_URL="https://www.python.org/ftp/python/${FULL_VER}/python-${FULL_VER}-macos11.pkg"
+    # python.org keeps pre-releases under the final version's directory
+    # (e.g. .../3.15.0/python-3.15.0rc2-macos11.pkg).
+    DIR_VER="$(sed -E 's/(a|b|rc)[0-9]+$//' <<< "$FULL_VER")"
+    PKG_URL="https://www.python.org/ftp/python/${DIR_VER}/python-${FULL_VER}-macos11.pkg"
 
     echo "Downloading: $PKG_URL"
     if wget -q --spider "$PKG_URL" 2>/dev/null; then

--- a/chdb/build_pybind11.sh
+++ b/chdb/build_pybind11.sh
@@ -133,7 +133,7 @@ build_all_pybind11_nonlimitedapi() {
     if [ -n "${CHDB_PYBIND11_PYTHON_VERSIONS:-}" ]; then
         read -r -a python_versions <<< "${CHDB_PYBIND11_PYTHON_VERSIONS}"
     else
-        python_versions=("3.9" "3.10" "3.11" "3.12" "3.13" "3.14")
+        python_versions=("3.9" "3.10" "3.11" "3.12" "3.13" "3.14" "3.15")
     fi
 
     echo "Building pybind11 nonlimitedapi libraries for all Python versions..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: C++",
     "Topic :: Software Development :: Libraries",
     "Topic :: Database",

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
+    Programming Language :: Python :: 3.15
     Topic :: Database
     Topic :: Scientific/Engineering :: Information Analysis
 


### PR DESCRIPTION
Closes #206.

Python 3.15.0rc2 is the final RC (ABI frozen); 3.15.0 is due 2026-10-01. The abi3 wheel already installs on 3.15, and `import chdb` then exits with status 1 because `libpybind11nonlimitedapi_chdb_3.15` is not in the wheel. This builds and ships it.

- `chdb/build_pybind11.sh`, `chdb/build/download_python_headers.sh`: add 3.15 (3.15.0rc2 until the final). python.org keeps pre-release installers under the final version's directory, so the download URL now strips the rc suffix for the directory part.
- Wheel workflows: install 3.15 with pyenv. `pyenv install 3.15:latest` skips pre-releases, so it falls back to `3.15.0rc2` plus a `versions/3.15` symlink that lets the bare `3.15` in `pyenv global`/`pyenv shell` resolve; the fallback is a no-op once 3.15.0 is released. macOS: add the new dylib to the build artifacts.
- 3.15 runs a dependency-free import/query smoke test only, which is exactly what loads the new shim; pandas and pyarrow have no cp315 wheels yet. Fold 3.15 into the full matrix once they do.
- Classifiers: `Programming Language :: Python :: 3.15`.

No C++ changes are needed for the GIL wheels (details in #206, including the free-threaded 3.15t follow-up).

Checked locally: the patched header download works for 3.15.0rc2; the pyenv fallback and symlink resolve `3.15` in a scratch `PYENV_ROOT`; the released 26.7.0 wheel imports and runs a CSV query with pandas/pyarrow absent, which is what the 3.15 smoke step does.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Python 3.15 to Linux and macOS wheel build matrix
> - Provisions, verifies, and smoke-tests Python 3.15 in the Linux arm64/x86 and macOS arm64/x86 cross-build workflows in [`.github/workflows/`](https://github.com/chdb-io/chdb-core/pull/207/files#diff-34eabc9eab844921f0551e189f19feb0c375e9bad5f65c243ce27686bc909a9a).
> - Installs 3.15 using the latest stable release when available, or a release-candidate fallback; verifies it in the required pyenv version list.
> - Skips the existing pandas/pyarrow test matrix for 3.15 because those wheels are not yet published; runs a minimal `chdb` import and query smoke test instead.
> - Extends [download_python_headers.sh](https://github.com/chdb-io/chdb-core/pull/207/files#diff-23d9a576fd00cef5d9ecd61e17b16e74f23f6f06b4d8da76a57c8501f32902b2) and [build_pybind11.sh](https://github.com/chdb-io/chdb-core/pull/207/files#diff-24dfae789952964f53d0f6b29142f14ea0cbdbe9c581c1e51908d2b2a5c65c83) to handle 3.15 headers and pybind11 libraries, and adds 3.15 classifiers to [pyproject.toml](https://github.com/chdb-io/chdb-core/pull/207/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and [setup.cfg](https://github.com/chdb-io/chdb-core/pull/207/files#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52).
> - Risk: stable 3.15 may not yet exist when builds run; the release-candidate fallback assumes a specific pre-release version, which may need manual bumps once a newer RC or stable ships.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0e7557.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->