### PR TITLE
Harden CI workflows against self-hosted runner infrastructure failures

### DIFF
--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -28,14 +28,20 @@
 #      fatal: Unable to create '.../.git/modules/contrib/llvm-project/index.lock': File exists.
 #      fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
 #
-#    The normal path is the plain update. Only when it fails, the workspace is
-#    known to be damaged and no other git process is running, so: stale locks are
-#    removed, submodule clones without a usable repository are deleted, and the
-#    update is retried once with --force. --force makes git run every checkout
-#    even when the submodule's HEAD already matches: submodules are cloned with
-#    --no-checkout and populated afterwards, and an aborted update leaves the
-#    cloned ones with the right HEAD and an empty working tree, which a plain
-#    update would consider up to date.
+#    Every update runs with --force. Submodules are cloned with --no-checkout and
+#    populated afterwards; when an update is aborted in between (one clone failing
+#    twice aborts before any checkout), the cloned submodules are left with HEAD
+#    at the remote tip and an empty working tree. 24 of the 139 submodules are
+#    pinned at that tip, so a plain update considers them up to date and the
+#    build fails much later ("Cannot find source file: contrib/librdkafka/src/
+#    cJSON.c"). --force runs the checkout regardless, as actions/checkout does.
+#
+#    If the update still fails, the workspace is known to be damaged and no other
+#    git process is running: stale locks are removed, submodule clones without a
+#    usable repository are deleted, and the update is retried once.
+#
+# SUBMODULE_DEPTH=N makes the clones shallow (the wasm job used actions/checkout's
+# default of 1 before it moved to this script).
 
 set -euo pipefail
 
@@ -70,9 +76,16 @@ remove_broken_clones() {
     done
 }
 
-if ! git submodule update --init --recursive --jobs 4; then
-    echo "::warning::git submodule update failed, cleaning up stale submodule state and retrying once with --force"
+depth_arg=${SUBMODULE_DEPTH:+--depth=$SUBMODULE_DEPTH}
+
+update() {
+    # shellcheck disable=SC2086  # depth_arg is a single token or empty
+    git submodule update --init --recursive --force --jobs 4 $depth_arg
+}
+
+if ! update; then
+    echo "::warning::git submodule update failed, cleaning up stale submodule state and retrying once"
     remove_stale_locks
     remove_broken_clones
-    git submodule update --init --recursive --force --jobs 4
+    update
 fi

--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Initialise and update all submodules on a CI runner.
+#
+#   GITHUB_TOKEN=... .github/scripts/update-submodules.sh
+#
+# A bare `git submodule update` clones the ~140 contrib repositories anonymously:
+# actions/checkout only configures its token for the superproject, and submodule
+# clones do not inherit that config. Every self-hosted runner leaves through the
+# same NAT address, and one main-push + PR fan-out (a dozen jobs x 4 parallel
+# clones) is enough for GitHub to start answering unauthenticated requests with
+# HTTP 401:
+#
+#   fatal: could not read Username for 'https://github.com': No such device or address
+#   fatal: expected flush after ref listing
+#
+# When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
+# GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
+
+set -euo pipefail
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+    GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+    export GIT_CONFIG_VALUE_0
+fi
+
+git submodule update --init --recursive --jobs 4

--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -4,18 +4,30 @@
 #
 #   GITHUB_TOKEN=... .github/scripts/update-submodules.sh
 #
-# A bare `git submodule update` clones the ~140 contrib repositories anonymously:
-# actions/checkout only configures its token for the superproject, and submodule
-# clones do not inherit that config. Every self-hosted runner leaves through the
-# same NAT address, and one main-push + PR fan-out (a dozen jobs x 4 parallel
-# clones) is enough for GitHub to start answering unauthenticated requests with
-# HTTP 401:
+# Two things go wrong with a bare `git submodule update` on the self-hosted pool:
 #
-#   fatal: could not read Username for 'https://github.com': No such device or address
-#   fatal: expected flush after ref listing
+# 1. The clones are anonymous. actions/checkout only configures its token for the
+#    superproject, and submodule clones do not inherit that config. Every runner
+#    leaves through the same NAT address, and one main-push + PR fan-out (a dozen
+#    jobs x 4 parallel clones of ~140 contrib repositories) is enough for GitHub
+#    to start answering unauthenticated requests with HTTP 401:
 #
-# When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
-# GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
+#      fatal: could not read Username for 'https://github.com': No such device or address
+#      fatal: expected flush after ref listing
+#
+#    When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
+#    GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
+#
+# 2. Runners are reused. A job cancelled (or killed) in the middle of a checkout
+#    leaves lock files and half-cloned repositories under .git/modules, which
+#    actions/checkout does not clean up (it only resets the superproject):
+#
+#      fatal: Unable to create '.../.git/modules/contrib/llvm-project/index.lock': File exists.
+#      fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
+#
+#    Stale locks are removed up front (no other git process runs at this point).
+#    If the update still fails, submodule clones without a usable HEAD are deleted
+#    and the update is retried once.
 
 set -euo pipefail
 
@@ -26,4 +38,35 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
     export GIT_CONFIG_VALUE_0
 fi
 
-git submodule update --init --recursive --jobs 4
+remove_stale_locks() {
+    [ -d .git/modules ] || return 0
+    find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
+}
+
+# Delete submodule clones whose repository has no usable HEAD (interrupted clone).
+remove_broken_clones() {
+    [ -f .gitmodules ] || return 0
+    git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r key path; do
+        name=${key#submodule.}
+        name=${name%.path}
+        gitdir=".git/modules/$name"
+        [ -d "$gitdir" ] || continue
+        if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+            echo "Removing broken submodule clone: $path"
+            rm -rf "$path" "$gitdir"
+        fi
+    done
+}
+
+update() {
+    git submodule update --init --recursive --jobs 4
+}
+
+remove_stale_locks
+if ! update; then
+    echo "::warning::git submodule update failed, cleaning up stale submodule state and retrying once"
+    remove_stale_locks
+    remove_broken_clones
+    update
+fi

--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -4,18 +4,38 @@
 #
 #   GITHUB_TOKEN=... .github/scripts/update-submodules.sh
 #
-# A bare `git submodule update` clones the ~140 contrib repositories anonymously:
-# actions/checkout only configures its token for the superproject, and submodule
-# clones do not inherit that config. Every self-hosted runner leaves through the
-# same NAT address, and one main-push + PR fan-out (a dozen jobs x 4 parallel
-# clones) is enough for GitHub to start answering unauthenticated requests with
-# HTTP 401:
+# Two things go wrong with a bare `git submodule update` on the self-hosted pool:
 #
-#   fatal: could not read Username for 'https://github.com': No such device or address
-#   fatal: expected flush after ref listing
+# 1. The clones are anonymous. actions/checkout only configures its token for the
+#    superproject, and submodule clones do not inherit that config. Every runner
+#    leaves through the same NAT address, and one main-push + PR fan-out (a dozen
+#    jobs x 4 parallel clones of ~140 contrib repositories) is enough for GitHub
+#    to start answering unauthenticated requests with HTTP 401:
 #
-# When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
-# GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
+#      fatal: could not read Username for 'https://github.com': No such device or address
+#      fatal: expected flush after ref listing
+#
+#    When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
+#    GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
+#    Never combine it with the credential actions/checkout persists in the
+#    superproject: git then sends two Authorization headers and GitHub answers 400.
+#    Submodule clones are fresh repositories, so they only ever see this one.
+#
+# 2. Runners are reused. A job cancelled (or killed) in the middle of a checkout
+#    leaves lock files and half-cloned repositories under .git/modules, which
+#    actions/checkout does not clean up (it only resets the superproject):
+#
+#      fatal: Unable to create '.../.git/modules/contrib/llvm-project/index.lock': File exists.
+#      fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
+#
+#    The normal path is the plain update. Only when it fails, the workspace is
+#    known to be damaged and no other git process is running, so: stale locks are
+#    removed, submodule clones without a usable repository are deleted, and the
+#    update is retried once with --force. --force makes git run every checkout
+#    even when the submodule's HEAD already matches: submodules are cloned with
+#    --no-checkout and populated afterwards, and an aborted update leaves the
+#    cloned ones with the right HEAD and an empty working tree, which a plain
+#    update would consider up to date.
 
 set -euo pipefail
 
@@ -26,4 +46,33 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
     export GIT_CONFIG_VALUE_0
 fi
 
-git submodule update --init --recursive --jobs 4
+remove_stale_locks() {
+    [ -d .git/modules ] || return 0
+    find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
+}
+
+# Delete submodule clones whose repository is unusable: a gitdir without a
+# resolvable HEAD (interrupted clone) or a working tree whose gitdir is gone.
+remove_broken_clones() {
+    [ -f .gitmodules ] || return 0
+    git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r key path; do
+        name=${key#submodule.}
+        name=${name%.path}
+        gitdir=".git/modules/$name"
+        if [ -d "$gitdir" ]; then
+            git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1 && continue
+        elif [ ! -e "$path/.git" ]; then
+            continue
+        fi
+        echo "Removing broken submodule clone: $path"
+        rm -rf "$path" "$gitdir"
+    done
+}
+
+if ! git submodule update --init --recursive --jobs 4; then
+    echo "::warning::git submodule update failed, cleaning up stale submodule state and retrying once with --force"
+    remove_stale_locks
+    remove_broken_clones
+    git submodule update --init --recursive --force --jobs 4
+fi

--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -26,17 +26,8 @@
 #      fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
 #
 #    Stale locks are removed up front (no other git process runs at this point).
-#    If the update still fails, submodule clones without a usable repository are
-#    deleted and the update is retried once.
-#
-# 3. A plain `git submodule update` trusts HEAD. Submodules are cloned with
-#    --no-checkout and populated afterwards, and when a run aborts in between
-#    (one clone failing twice aborts the whole update before any checkout) every
-#    submodule that was cloned is left with HEAD at the remote tip and an empty
-#    working tree. For submodules pinned at that tip the next update sees the
-#    right HEAD and does nothing, and the build fails much later with
-#    "Cannot find source file: contrib/librdkafka/src/cJSON.c". --force makes
-#    git run the checkout regardless (actions/checkout does the same).
+#    If the update still fails, submodule clones without a usable HEAD are deleted
+#    and the update is retried once.
 
 set -euo pipefail
 
@@ -52,8 +43,7 @@ remove_stale_locks() {
     find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
 }
 
-# Delete submodule clones whose repository is unusable: a gitdir without a
-# resolvable HEAD (interrupted clone) or a working tree whose gitdir is gone.
+# Delete submodule clones whose repository has no usable HEAD (interrupted clone).
 remove_broken_clones() {
     [ -f .gitmodules ] || return 0
     git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
@@ -61,18 +51,16 @@ remove_broken_clones() {
         name=${key#submodule.}
         name=${name%.path}
         gitdir=".git/modules/$name"
-        if [ -d "$gitdir" ]; then
-            git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1 && continue
-        elif [ ! -e "$path/.git" ]; then
-            continue
+        [ -d "$gitdir" ] || continue
+        if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+            echo "Removing broken submodule clone: $path"
+            rm -rf "$path" "$gitdir"
         fi
-        echo "Removing broken submodule clone: $path"
-        rm -rf "$path" "$gitdir"
     done
 }
 
 update() {
-    git submodule update --init --recursive --force --jobs 4
+    git submodule update --init --recursive --jobs 4
 }
 
 remove_stale_locks

--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -4,30 +4,18 @@
 #
 #   GITHUB_TOKEN=... .github/scripts/update-submodules.sh
 #
-# Two things go wrong with a bare `git submodule update` on the self-hosted pool:
+# A bare `git submodule update` clones the ~140 contrib repositories anonymously:
+# actions/checkout only configures its token for the superproject, and submodule
+# clones do not inherit that config. Every self-hosted runner leaves through the
+# same NAT address, and one main-push + PR fan-out (a dozen jobs x 4 parallel
+# clones) is enough for GitHub to start answering unauthenticated requests with
+# HTTP 401:
 #
-# 1. The clones are anonymous. actions/checkout only configures its token for the
-#    superproject, and submodule clones do not inherit that config. Every runner
-#    leaves through the same NAT address, and one main-push + PR fan-out (a dozen
-#    jobs x 4 parallel clones of ~140 contrib repositories) is enough for GitHub
-#    to start answering unauthenticated requests with HTTP 401:
+#   fatal: could not read Username for 'https://github.com': No such device or address
+#   fatal: expected flush after ref listing
 #
-#      fatal: could not read Username for 'https://github.com': No such device or address
-#      fatal: expected flush after ref listing
-#
-#    When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
-#    GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
-#
-# 2. Runners are reused. A job cancelled (or killed) in the middle of a checkout
-#    leaves lock files and half-cloned repositories under .git/modules, which
-#    actions/checkout does not clean up (it only resets the superproject):
-#
-#      fatal: Unable to create '.../.git/modules/contrib/llvm-project/index.lock': File exists.
-#      fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
-#
-#    Stale locks are removed up front (no other git process runs at this point).
-#    If the update still fails, submodule clones without a usable HEAD are deleted
-#    and the update is retried once.
+# When GITHUB_TOKEN is set it is sent as the same header actions/checkout uses.
+# GIT_CONFIG_* is inherited by the clone subprocesses and never written to disk.
 
 set -euo pipefail
 
@@ -38,35 +26,4 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
     export GIT_CONFIG_VALUE_0
 fi
 
-remove_stale_locks() {
-    [ -d .git/modules ] || return 0
-    find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
-}
-
-# Delete submodule clones whose repository has no usable HEAD (interrupted clone).
-remove_broken_clones() {
-    [ -f .gitmodules ] || return 0
-    git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
-    while read -r key path; do
-        name=${key#submodule.}
-        name=${name%.path}
-        gitdir=".git/modules/$name"
-        [ -d "$gitdir" ] || continue
-        if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
-            echo "Removing broken submodule clone: $path"
-            rm -rf "$path" "$gitdir"
-        fi
-    done
-}
-
-update() {
-    git submodule update --init --recursive --jobs 4
-}
-
-remove_stale_locks
-if ! update; then
-    echo "::warning::git submodule update failed, cleaning up stale submodule state and retrying once"
-    remove_stale_locks
-    remove_broken_clones
-    update
-fi
+git submodule update --init --recursive --jobs 4

--- a/.github/scripts/update-submodules.sh
+++ b/.github/scripts/update-submodules.sh
@@ -26,8 +26,17 @@
 #      fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
 #
 #    Stale locks are removed up front (no other git process runs at this point).
-#    If the update still fails, submodule clones without a usable HEAD are deleted
-#    and the update is retried once.
+#    If the update still fails, submodule clones without a usable repository are
+#    deleted and the update is retried once.
+#
+# 3. A plain `git submodule update` trusts HEAD. Submodules are cloned with
+#    --no-checkout and populated afterwards, and when a run aborts in between
+#    (one clone failing twice aborts the whole update before any checkout) every
+#    submodule that was cloned is left with HEAD at the remote tip and an empty
+#    working tree. For submodules pinned at that tip the next update sees the
+#    right HEAD and does nothing, and the build fails much later with
+#    "Cannot find source file: contrib/librdkafka/src/cJSON.c". --force makes
+#    git run the checkout regardless (actions/checkout does the same).
 
 set -euo pipefail
 
@@ -43,7 +52,8 @@ remove_stale_locks() {
     find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
 }
 
-# Delete submodule clones whose repository has no usable HEAD (interrupted clone).
+# Delete submodule clones whose repository is unusable: a gitdir without a
+# resolvable HEAD (interrupted clone) or a working tree whose gitdir is gone.
 remove_broken_clones() {
     [ -f .gitmodules ] || return 0
     git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
@@ -51,16 +61,18 @@ remove_broken_clones() {
         name=${key#submodule.}
         name=${name%.path}
         gitdir=".git/modules/$name"
-        [ -d "$gitdir" ] || continue
-        if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
-            echo "Removing broken submodule clone: $path"
-            rm -rf "$path" "$gitdir"
+        if [ -d "$gitdir" ]; then
+            git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1 && continue
+        elif [ ! -e "$path/.git" ]; then
+            continue
         fi
+        echo "Removing broken submodule clone: $path"
+        rm -rf "$path" "$gitdir"
     done
 }
 
 update() {
-    git submodule update --init --recursive --jobs 4
+    git submodule update --init --recursive --force --jobs 4
 }
 
 remove_stale_locks

--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -46,6 +46,17 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 600
     steps:
+      - name: Keep unattended-upgrades from killing the job
+        # The runner image runs unattended-upgrades with needrestart in automatic mode.
+        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
+        # actions.runner.*.service and the job dies with "The runner has received a
+        # shutdown signal". Turn the timers off for the rest of this instance's life
+        # and make needrestart only list what it would restart. An upgrade that is
+        # already running is left alone: interrupting dpkg corrupts the package database.
+        run: |
+          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
+          sudo mkdir -p /etc/needrestart/conf.d
+          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           # Fresh self-hosted runners often have unattended-upgrades holding the

--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -68,9 +68,18 @@ jobs:
           sudo chmod +x /usr/local/bin/gh
           gh --version
       - name: Setup pyenv (base Python for tooling)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           rm -rf $HOME/.pyenv
-          curl https://pyenv.run | bash
+          # Clone pyenv itself with the job token. `curl https://pyenv.run | bash` clones
+          # pyenv plus four unused plugins anonymously, and anonymous clones get
+          # rate-limited on the self-hosted pool's shared egress IP
+          # ("could not read Username for 'https://github.com'").
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')" \
+            git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           # build_and_test_ft_linux.sh resolves & installs the FT (`t`) versions
@@ -105,7 +114,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update submodules
-        run: git submodule update --init --recursive --jobs 4
+        # Authenticated clones; see the script header.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/update-submodules.sh
       - name: Update version for release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/build_ft_wheels.yml
+++ b/.github/workflows/build_ft_wheels.yml
@@ -46,17 +46,6 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 600
     steps:
-      - name: Keep unattended-upgrades from killing the job
-        # The runner image runs unattended-upgrades with needrestart in automatic mode.
-        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
-        # actions.runner.*.service and the job dies with "The runner has received a
-        # shutdown signal". Turn the timers off for the rest of this instance's life
-        # and make needrestart only list what it would restart. An upgrade that is
-        # already running is left alone: interrupting dpkg corrupts the package database.
-        run: |
-          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
-          sudo mkdir -p /etc/needrestart/conf.d
-          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           # Fresh self-hosted runners often have unattended-upgrades holding the

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -206,6 +206,7 @@ jobs:
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y git
           git --version
       - uses: actions/checkout@v7
+        id: checkout
         with:
           fetch-depth: 0
       - name: Update submodules
@@ -710,7 +711,7 @@ jobs:
           pyenv shell --unset
         continue-on-error: false
       - name: Restore pyproject.toml (chdb-core-lite build mutates it in place)
-        if: always()
+        if: always() && steps.checkout.outcome == 'success'
         run: |
           git checkout -- pyproject.toml
       - name: Check and upload core files if present

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -42,6 +42,17 @@ jobs:
     runs-on: [self-hosted, linux, arm64, ubuntu-latest]
     if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Keep unattended-upgrades from killing the job
+        # The runner image runs unattended-upgrades with needrestart in automatic mode.
+        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
+        # actions.runner.*.service and the job dies with "The runner has received a
+        # shutdown signal". Turn the timers off for the rest of this instance's life
+        # and make needrestart only list what it would restart. An upgrade that is
+        # already running is left alone: interrupting dpkg corrupts the package database.
+        run: |
+          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
+          sudo mkdir -p /etc/needrestart/conf.d
+          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Check CPU capabilities and requirements
         run: |
           echo "=== CPU Information ==="

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -42,17 +42,6 @@ jobs:
     runs-on: [self-hosted, linux, arm64, ubuntu-latest]
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - name: Keep unattended-upgrades from killing the job
-        # The runner image runs unattended-upgrades with needrestart in automatic mode.
-        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
-        # actions.runner.*.service and the job dies with "The runner has received a
-        # shutdown signal". Turn the timers off for the rest of this instance's life
-        # and make needrestart only list what it would restart. An upgrade that is
-        # already running is left alone: interrupting dpkg corrupts the package database.
-        run: |
-          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
-          sudo mkdir -p /etc/needrestart/conf.d
-          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Check CPU capabilities and requirements
         run: |
           echo "=== CPU Information ==="

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -108,10 +108,19 @@ jobs:
           fi
         continue-on-error: true
       - name: Setup pyenv
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Remove existing pyenv installation if present
           rm -rf $HOME/.pyenv
-          curl https://pyenv.run | bash
+          # Clone pyenv itself with the job token. `curl https://pyenv.run | bash` clones
+          # pyenv plus four unused plugins anonymously, and anonymous clones get
+          # rate-limited on the self-hosted pool's shared egress IP
+          # ("could not read Username for 'https://github.com'").
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')" \
+            git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           # Python 3.8 removed
@@ -189,8 +198,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update submodules
-        run: |
-          git submodule update --init --recursive --jobs 4
+        # Authenticated clones; see the script header.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/update-submodules.sh
       - name: Update version for release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -42,6 +42,17 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Keep unattended-upgrades from killing the job
+        # The runner image runs unattended-upgrades with needrestart in automatic mode.
+        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
+        # actions.runner.*.service and the job dies with "The runner has received a
+        # shutdown signal". Turn the timers off for the rest of this instance's life
+        # and make needrestart only list what it would restart. An upgrade that is
+        # already running is left alone: interrupting dpkg corrupts the package database.
+        run: |
+          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
+          sudo mkdir -p /etc/needrestart/conf.d
+          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -42,17 +42,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - name: Keep unattended-upgrades from killing the job
-        # The runner image runs unattended-upgrades with needrestart in automatic mode.
-        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
-        # actions.runner.*.service and the job dies with "The runner has received a
-        # shutdown signal". Turn the timers off for the rest of this instance's life
-        # and make needrestart only list what it would restart. An upgrade that is
-        # already running is left alone: interrupting dpkg corrupts the package database.
-        run: |
-          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
-          sudo mkdir -p /etc/needrestart/conf.d
-          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -191,6 +191,7 @@ jobs:
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y git
           git --version
       - uses: actions/checkout@v7
+        id: checkout
         with:
           fetch-depth: 0
       - name: Update submodules
@@ -695,7 +696,7 @@ jobs:
           pyenv shell --unset
         continue-on-error: false
       - name: Restore pyproject.toml (chdb-core-lite build mutates it in place)
-        if: always()
+        if: always() && steps.checkout.outcome == 'success'
         run: |
           git checkout -- pyproject.toml
       - name: Check and upload core files if present

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -94,10 +94,19 @@ jobs:
           fi
         continue-on-error: true
       - name: Setup pyenv
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Remove existing pyenv installation if present
           rm -rf $HOME/.pyenv
-          curl https://pyenv.run | bash
+          # Clone pyenv itself with the job token. `curl https://pyenv.run | bash` clones
+          # pyenv plus four unused plugins anonymously, and anonymous clones get
+          # rate-limited on the self-hosted pool's shared egress IP
+          # ("could not read Username for 'https://github.com'").
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')" \
+            git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           # Python 3.8 removed
@@ -174,8 +183,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update submodules
-        run: |
-          git submodule update --init --recursive --jobs 4
+        # Authenticated clones; see the script header.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/update-submodules.sh
       - name: Update version for release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -84,8 +84,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update submodules
-        run: |
-          git submodule update --init --recursive --jobs 4
+        # Authenticated clones; see the script header.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/update-submodules.sh
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
@@ -213,8 +215,17 @@ jobs:
             echo "This is an x86_64 (Intel) machine"
           fi
       - name: Setup pyenv
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl https://pyenv.run | bash
+          # Clone pyenv itself with the job token. `curl https://pyenv.run | bash` clones
+          # pyenv plus four unused plugins anonymously, and anonymous clones get
+          # rate-limited on the self-hosted pool's shared egress IP
+          # ("could not read Username for 'https://github.com'").
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')" \
+            git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
 

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -132,6 +132,9 @@ jobs:
 
       - name: Run chdb/build_mac_on_linux.sh
         timeout-minutes: 600
+        env:
+          # For the cctools clones in chdb/build/install_cctools.sh.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           source ~/.cargo/env
           # Use Debug for crash analysis when DEBUG_MODE is enabled
@@ -144,6 +147,9 @@ jobs:
       - name: Run chdb/build/build_static_lib_mac_on_linux.sh
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 600
+        env:
+          # For the cctools clones in chdb/build/install_cctools.sh.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           source ~/.cargo/env
           bash ./chdb/build/build_static_lib_mac_on_linux.sh arm64

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -42,6 +42,17 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 600
     steps:
+      - name: Keep unattended-upgrades from killing the job
+        # The runner image runs unattended-upgrades with needrestart in automatic mode.
+        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
+        # actions.runner.*.service and the job dies with "The runner has received a
+        # shutdown signal". Turn the timers off for the rest of this instance's life
+        # and make needrestart only list what it would restart. An upgrade that is
+        # already running is left alone: interrupting dpkg corrupts the package database.
+        run: |
+          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
+          sudo mkdir -p /etc/needrestart/conf.d
+          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -290,6 +290,7 @@ jobs:
           brew install go lz4
           go version
       - uses: actions/checkout@v7
+        id: checkout
         with:
           fetch-depth: 0
       - name: Update version for release
@@ -692,7 +693,7 @@ jobs:
           pyenv shell --unset
         continue-on-error: false
       - name: Restore pyproject.toml (chdb-core-lite build mutates it in place)
-        if: always()
+        if: always() && steps.checkout.outcome == 'success'
         run: git checkout -- pyproject.toml
       - name: Check and upload core files if present
         if: always()

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -42,17 +42,6 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 600
     steps:
-      - name: Keep unattended-upgrades from killing the job
-        # The runner image runs unattended-upgrades with needrestart in automatic mode.
-        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
-        # actions.runner.*.service and the job dies with "The runner has received a
-        # shutdown signal". Turn the timers off for the rest of this instance's life
-        # and make needrestart only list what it would restart. An upgrade that is
-        # already running is left alone: interrupting dpkg corrupts the package database.
-        run: |
-          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
-          sudo mkdir -p /etc/needrestart/conf.d
-          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -84,8 +84,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update submodules
-        run: |
-          git submodule update --init --recursive --jobs 4
+        # Authenticated clones; see the script header.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/update-submodules.sh
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
@@ -213,8 +215,17 @@ jobs:
             echo "This is an x86_64 (Intel) machine"
           fi
       - name: Setup pyenv
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl https://pyenv.run | bash
+          # Clone pyenv itself with the job token. `curl https://pyenv.run | bash` clones
+          # pyenv plus four unused plugins anonymously, and anonymous clones get
+          # rate-limited on the self-hosted pool's shared egress IP
+          # ("could not read Username for 'https://github.com'").
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')" \
+            git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
 

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -42,6 +42,17 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 600
     steps:
+      - name: Keep unattended-upgrades from killing the job
+        # The runner image runs unattended-upgrades with needrestart in automatic mode.
+        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
+        # actions.runner.*.service and the job dies with "The runner has received a
+        # shutdown signal". Turn the timers off for the rest of this instance's life
+        # and make needrestart only list what it would restart. An upgrade that is
+        # already running is left alone: interrupting dpkg corrupts the package database.
+        run: |
+          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
+          sudo mkdir -p /etc/needrestart/conf.d
+          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -290,6 +290,7 @@ jobs:
           brew install go lz4
           go version
       - uses: actions/checkout@v7
+        id: checkout
         with:
           fetch-depth: 0
       - name: Update version for release
@@ -692,7 +693,7 @@ jobs:
           pyenv shell --unset
         continue-on-error: false
       - name: Restore pyproject.toml (chdb-core-lite build mutates it in place)
-        if: always()
+        if: always() && steps.checkout.outcome == 'success'
         run: git checkout -- pyproject.toml
       - name: Check and upload core files if present
         if: always()

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -132,6 +132,9 @@ jobs:
 
       - name: Run chdb/build_mac_on_linux.sh
         timeout-minutes: 600
+        env:
+          # For the cctools clones in chdb/build/install_cctools.sh.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           source ~/.cargo/env
           # Use Debug for crash analysis when DEBUG_MODE is enabled
@@ -144,6 +147,9 @@ jobs:
       - name: Run chdb/build/build_static_lib_mac_on_linux.sh
         if: env.EFFECTIVE_DEBUG_MODE != 'true'
         timeout-minutes: 600
+        env:
+          # For the cctools clones in chdb/build/install_cctools.sh.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           source ~/.cargo/env
           bash ./chdb/build/build_static_lib_mac_on_linux.sh x86_64

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -42,17 +42,6 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 600
     steps:
-      - name: Keep unattended-upgrades from killing the job
-        # The runner image runs unattended-upgrades with needrestart in automatic mode.
-        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
-        # actions.runner.*.service and the job dies with "The runner has received a
-        # shutdown signal". Turn the timers off for the rest of this instance's life
-        # and make needrestart only list what it would restart. An upgrade that is
-        # already running is left alone: interrupting dpkg corrupts the package database.
-        run: |
-          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
-          sudo mkdir -p /etc/needrestart/conf.d
-          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Install Python build dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,6 +63,27 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     timeout-minutes: 120
     steps:
+      - name: Clean up submodule state left by a cancelled job
+        # Runners are reused. A job cancelled mid-checkout leaves lock files and half-cloned
+        # repositories under .git/modules, and actions/checkout only resets the superproject
+        # ("Unable to create '.git/modules/.../index.lock': File exists", "Unable to find
+        # current revision in submodule path ..."). Same logic as
+        # .github/scripts/update-submodules.sh, inlined because it has to run before checkout.
+        run: |
+          [ -d .git/modules ] && [ -f .gitmodules ] || exit 0
+          find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
+          git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
+          while read -r key path; do
+            name=${key#submodule.}
+            name=${name%.path}
+            gitdir=".git/modules/$name"
+            [ -d "$gitdir" ] || continue
+            if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+              echo "Removing broken submodule clone: $path"
+              rm -rf "$path" "$gitdir"
+            fi
+          done
+
       - name: Checkout (with submodules)
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -77,13 +77,11 @@ jobs:
             name=${key#submodule.}
             name=${name%.path}
             gitdir=".git/modules/$name"
-            if [ -d "$gitdir" ]; then
-              git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1 && continue
-            elif [ ! -e "$path/.git" ]; then
-              continue
+            [ -d "$gitdir" ] || continue
+            if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+              echo "Removing broken submodule clone: $path"
+              rm -rf "$path" "$gitdir"
             fi
-            echo "Removing broken submodule clone: $path"
-            rm -rf "$path" "$gitdir"
           done
 
       - name: Checkout (with submodules)

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -88,11 +88,13 @@ jobs:
             name=${key#submodule.}
             name=${name%.path}
             gitdir=".git/modules/$name"
-            [ -d "$gitdir" ] || continue
-            if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
-              echo "Removing broken submodule clone: $path"
-              rm -rf "$path" "$gitdir"
+            if [ -d "$gitdir" ]; then
+              git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1 && continue
+            elif [ ! -e "$path/.git" ]; then
+              continue
             fi
+            echo "Removing broken submodule clone: $path"
+            rm -rf "$path" "$gitdir"
           done
 
       - name: Checkout (with submodules)

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,6 +63,17 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     timeout-minutes: 120
     steps:
+      - name: Keep unattended-upgrades from killing the job
+        # The runner image runs unattended-upgrades with needrestart in automatic mode.
+        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
+        # actions.runner.*.service and the job dies with "The runner has received a
+        # shutdown signal". Turn the timers off for the rest of this instance's life
+        # and make needrestart only list what it would restart. An upgrade that is
+        # already running is left alone: interrupting dpkg corrupts the package database.
+        run: |
+          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
+          sudo mkdir -p /etc/needrestart/conf.d
+          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Clean up submodule state left by a cancelled job
         # Runners are reused. A job cancelled mid-checkout leaves lock files and half-cloned
         # repositories under .git/modules, and actions/checkout only resets the superproject

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,17 +63,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     timeout-minutes: 120
     steps:
-      - name: Keep unattended-upgrades from killing the job
-        # The runner image runs unattended-upgrades with needrestart in automatic mode.
-        # In the daily apt-daily-upgrade window (06:00-07:00 UTC) that restarts
-        # actions.runner.*.service and the job dies with "The runner has received a
-        # shutdown signal". Turn the timers off for the rest of this instance's life
-        # and make needrestart only list what it would restart. An upgrade that is
-        # already running is left alone: interrupting dpkg corrupts the package database.
-        run: |
-          sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer || true
-          sudo mkdir -p /etc/needrestart/conf.d
-          echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-ci-no-restart.conf >/dev/null
       - name: Clean up submodule state left by a cancelled job
         # Runners are reused. A job cancelled mid-checkout leaves lock files and half-cloned
         # repositories under .git/modules, and actions/checkout only resets the superproject

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,27 +63,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     timeout-minutes: 120
     steps:
-      - name: Clean up submodule state left by a cancelled job
-        # Runners are reused. A job cancelled mid-checkout leaves lock files and half-cloned
-        # repositories under .git/modules, and actions/checkout only resets the superproject
-        # ("Unable to create '.git/modules/.../index.lock': File exists", "Unable to find
-        # current revision in submodule path ..."). Same logic as
-        # .github/scripts/update-submodules.sh, inlined because it has to run before checkout.
-        run: |
-          [ -d .git/modules ] && [ -f .gitmodules ] || exit 0
-          find .git/modules -type f -name '*.lock' -print -delete | sed 's/^/Removed stale lock: /'
-          git config --file .gitmodules --get-regexp '^submodule\..*\.path$' |
-          while read -r key path; do
-            name=${key#submodule.}
-            name=${name%.path}
-            gitdir=".git/modules/$name"
-            [ -d "$gitdir" ] || continue
-            if ! git --git-dir="$gitdir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
-              echo "Removing broken submodule clone: $path"
-              rm -rf "$path" "$gitdir"
-            fi
-          done
-
       - name: Checkout (with submodules)
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,10 +63,16 @@ jobs:
     runs-on: [self-hosted, linux, x64, ubuntu-latest]
     timeout-minutes: 120
     steps:
-      - name: Checkout (with submodules)
+      - name: Checkout
         uses: actions/checkout@v7
-        with:
-          submodules: recursive
+
+      - name: Update submodules
+        # Authenticated clones and recovery from state left by a cancelled job; see the
+        # script header. Depth 1 keeps the shallow submodules actions/checkout used here.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SUBMODULE_DEPTH: 1
+        run: .github/scripts/update-submodules.sh
 
       - name: Install build deps
         run: |

--- a/chdb/build/install_cctools.sh
+++ b/chdb/build/install_cctools.sh
@@ -2,6 +2,17 @@
 
 set -e
 
+# CI passes GITHUB_TOKEN so the clones below are authenticated: anonymous clones
+# from the shared runner egress address get rate-limited by GitHub (HTTP 401,
+# "could not read Username for 'https://github.com'"). Same header
+# actions/checkout uses; GIT_CONFIG_* is process-local and never written to disk.
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+    GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+    export GIT_CONFIG_VALUE_0
+fi
+
 # Parse arguments
 TARGET_ARCH="${1:-x86_64}"
 


### PR DESCRIPTION
Between 2026-08-24 and 2026-09-02, 43 of the last 200 workflow runs failed; 39 of those were infrastructure, not code. Every push to `main` in that window had at least one red workflow for infra reasons. Three failure modes account for almost all of it. This PR fixes the first and the third and documents the second, which needs a runner-image change.

### 1. Anonymous clones rejected by GitHub (22 jobs, all on 2026-09-02)

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

Hit `Setup pyenv` (`curl https://pyenv.run | bash`, five anonymous clones), `Update submodules` (`git submodule update`, ~140 anonymous clones; the token actions/checkout configures only covers the superproject) and, as the first run of this branch showed, the apple-libtapi / cctools-port clones in `chdb/build/install_cctools.sh`. Every runner in the pool shares one NAT egress address, and a push to `main` plus a PR push fans out into a dozen jobs cloning 4 submodules in parallel each, which is enough for GitHub to start answering unauthenticated requests with HTTP 401. In the same jobs the token-authenticated checkout succeeded every time.

**Fix:** send the job token the same way actions/checkout does (`http.https://github.com/.extraheader`), through `GIT_CONFIG_*`, which child git processes inherit and which is never written to disk. `git submodule update` moves to `.github/scripts/update-submodules.sh`; pyenv is cloned directly (the pyenv.run plugins were never used); `install_cctools.sh` honours `GITHUB_TOKEN`.

The header is only ever set for processes that do not touch the superproject over the network: git sends *both* headers when the same key comes from the persisted checkout credential and from the environment, and GitHub answers 400 (verified locally with `GIT_TRACE_CURL`).

### 2. Runner killed in the 06:00-07:00 UTC window (10 jobs in this period, 32 of 34 kills in the last 700 runs), finding only

```
##[error]The runner has received a shutdown signal.
```

That window is `apt-daily-upgrade.timer` (06:00 plus up to 60 minutes of random delay). Job logs show the runner image runs unattended-upgrades with needrestart in automatic mode, and needrestart lists `actions.runner.chdb-io.*.service` as a restart candidate. When the job's own `apt-get` triggers needrestart, the runner unit is deferred because needrestart runs inside it; the timer-driven upgrade runs outside it and restarts the runner. The dpkg-lock timeout on 2026-08-25 06:01-06:12 is the same upgrade holding the lock.

**Not fixed here.** An earlier commit disabled the apt timers from a workflow step; it was reverted because host configuration belongs to the runner image, not to a repository's workflow. The fix for the image owner: disable `apt-daily.timer` / `apt-daily-upgrade.timer` (or unattended-upgrades) and/or set needrestart to list mode with `actions.runner.*` in `override_rc`. Until then, jobs running across 06:00-07:00 UTC can still be killed.

### 3. Stale submodule state on reused runners (5 jobs, plus four failures across this branch's runs)

```
fatal: Unable to create '.../.git/modules/contrib/llvm-project/index.lock': File exists.
fatal: Unable to find current revision in submodule path 'contrib/google-cloud-cpp'
CMake Error at contrib/librdkafka-cmake/CMakeLists.txt:140 (add_library):
  Cannot find source file: .../contrib/librdkafka/src/cJSON.c
```

A job cancelled (superseded PR push) or killed mid-checkout leaves locks and half-cloned repositories under `.git/modules`; actions/checkout only cleans the superproject, and all workflows share one workspace per instance. This morning's 401-aborted updates left at least four instances in that state; the runs of this branch hit `google-cloud-cpp` (FT twice, wasm once) and the third error below (FT, macOS arm64 with `hive-metastore`).

The third error is subtler. `git submodule update` clones with `--no-checkout` and populates the working trees afterwards, and when one clone fails twice it aborts before *any* checkout. The successfully cloned submodules are left with HEAD at the remote tip and an empty working tree. 24 of the 139 submodules are pinned at that tip (librdkafka's `a0f91df2` is the tip of `ClickHouse/release-2.14.1`, hive-metastore's `809a77d4` the tip of `main`), so a plain update considers them up to date and the build fails much later. `git status` in the failed FT job listed exactly the five affected submodules as "modified content".

**Fix.** `update-submodules.sh` runs `git submodule update --init --recursive --force --jobs 4`: `--force` makes git run every checkout even when HEAD already matches, which repopulates the empty working trees (actions/checkout does the same). If the update fails, the workspace is known to be damaged and no other git process is running, so the script removes stale locks under `.git/modules`, deletes submodule clones without a usable repository and retries once. The wasm job now checks out without submodules and runs the same script; `SUBMODULE_DEPTH=1` keeps the depth-1 submodules actions/checkout gave it. On the runners: the fifth run's FT job landed on the instance with the broken `google-cloud-cpp` clone and its `Update submodules` recovered and passed.

### 4. Noise

`Restore pyproject.toml` is `if: always()` and runs before any checkout happened when `Setup pyenv` fails, so every pyenv failure showed up as two failed steps. Now conditioned on the checkout step having run.

### Not in this PR

- The wasm `parquet_seek` (mt) failure, `CANNOT_SCHEDULE_TASK: thread constructor failed: Resource temporarily unavailable`, is deterministic on `main` since 2026-09-01. That is a code/test regression, not infra.
- The runner image itself (unattended-upgrades / needrestart, see 2; baking Python and apt deps).
- `.gitmodules` still lists `contrib/spdlog`, which has no gitlink in the tree.

### Verification

- Auth path, local superproject with a GitHub submodule: bogus token fails the submodule clone with "Authentication failed" (the header reaches the clone subprocess), real token succeeds, no `extraheader` written to any config. On the runners: `Setup pyenv` and `Update submodules` passed on all six self-hosted jobs of the first run while anonymous clones in the same minutes were still being rejected.
- Recovery path, local superproject with two submodules: a healthy tree runs once with no warning; an empty `--no-checkout` working tree at the pinned commit is repopulated by the normal path; a planted `index.lock` (reproduces "File exists") and a gitdir with an unborn HEAD (reproduces "Unable to find current revision") are repaired by the single retry; `SUBMODULE_DEPTH=1` yields shallow clones.
- All workflow files parse as YAML.

Net change after the reverts: authenticated clones (submodules, pyenv, cctools), `--force` plus a cleanup-and-retry in the shared submodule script (now also used by the wasm job), and the `Restore pyproject.toml` guard. The unattended-upgrades mitigation was reverted.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden CI submodule updates with shared retry script and authenticated pyenv clone
> - Adds [.github/scripts/update-submodules.sh](https://github.com/chdb-io/chdb-core/pull/208/files#diff-68325c0b0267992a96bed0e9a45422f3cf998ae255f5a3916f51bad9e6a10d34), a shared script that runs recursive submodule updates with forced checkout and optional shallow depth; on first failure it removes stale `.git/modules` lock files and broken submodule clones, then retries once
> - Replaces inline `git submodule update` commands across all wheel build workflows (`build_linux_arm64_wheels-gh.yml`, `build_linux_x86_wheels.yml`, `build_ft_wheels.yml`, `build_macos_arm64_wheels.yml`, `build_macos_x86_wheels.yml`, `wasm.yml`) with the new script, passing `github.token` and `SUBMODULE_DEPTH`
> - Replaces the remote pyenv installer endpoint in every affected workflow with an authenticated depth-1 clone of the pyenv repository using a checkout-style GitHub authorization header
> - Adds `GITHUB_TOKEN` to the environment of the macOS cross-build and static-library scripts so downstream [install_cctools.sh](https://github.com/chdb-io/chdb-core/pull/208/files#diff-7b6749182aa56478e48b0b0815846a544f75c271bc696a73e2aa9537fdfa842c) clones can authenticate
> - Gates the `Restore pyproject.toml` step on successful checkout outcome so it no longer runs after a failed checkout
> - Behavioral Change: submodule update now forces checkout of recorded revisions and uses up to 4 parallel jobs; first-update failures trigger deletion of lock files under `.git/modules` and removal of clones with unverifiable `HEAD` or missing git directories before a single retry
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71de065.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->