### PR TITLE
Authenticate the clones the ADBC validation step makes

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -338,10 +338,29 @@ jobs:
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.
       - name: ADBC validation suites
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eo pipefail
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+
+          # Three anonymous clones live under this step and none of them is ours
+          # to pass a token to directly: FetchContent clones apache/arrow-adbc,
+          # that clone updates its own apache/arrow-testing submodule, and pip
+          # installs a git+https requirement. Anonymous clones from the shared
+          # runner egress address get answered with HTTP 401
+          # ("could not read Username for 'https://github.com'"). Same header
+          # actions/checkout uses; GIT_CONFIG_* is inherited by every child
+          # process and never written to disk. Nothing here talks to the
+          # superproject, so the header cannot collide with the credential
+          # actions/checkout persists there.
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+            export GIT_CONFIG_VALUE_0
+          fi
 
           BUILD_DIR="$RUNNER_TEMP/adbc-validation"
           VENV="$RUNNER_TEMP/adbc-validation-venv"

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -323,10 +323,29 @@ jobs:
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.
       - name: ADBC validation suites
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eo pipefail
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+
+          # Three anonymous clones live under this step and none of them is ours
+          # to pass a token to directly: FetchContent clones apache/arrow-adbc,
+          # that clone updates its own apache/arrow-testing submodule, and pip
+          # installs a git+https requirement. Anonymous clones from the shared
+          # runner egress address get answered with HTTP 401
+          # ("could not read Username for 'https://github.com'"). Same header
+          # actions/checkout uses; GIT_CONFIG_* is inherited by every child
+          # process and never written to disk. Nothing here talks to the
+          # superproject, so the header cannot collide with the credential
+          # actions/checkout persists there.
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+            export GIT_CONFIG_VALUE_0
+          fi
 
           BUILD_DIR="$RUNNER_TEMP/adbc-validation"
           VENV="$RUNNER_TEMP/adbc-validation-venv"

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -374,10 +374,29 @@ jobs:
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.
       - name: ADBC validation suites
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eo pipefail
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+
+          # Three anonymous clones live under this step and none of them is ours
+          # to pass a token to directly: FetchContent clones apache/arrow-adbc,
+          # that clone updates its own apache/arrow-testing submodule, and pip
+          # installs a git+https requirement. Anonymous clones from the shared
+          # runner egress address get answered with HTTP 401
+          # ("could not read Username for 'https://github.com'"). Same header
+          # actions/checkout uses; GIT_CONFIG_* is inherited by every child
+          # process and never written to disk. Nothing here talks to the
+          # superproject, so the header cannot collide with the credential
+          # actions/checkout persists there.
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+            export GIT_CONFIG_VALUE_0
+          fi
 
           BUILD_DIR="$RUNNER_TEMP/adbc-validation"
           VENV="$RUNNER_TEMP/adbc-validation-venv"

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -375,10 +375,29 @@ jobs:
       # here rather than after the wheel tests so an unrelated failure there
       # does not withhold the result.
       - name: ADBC validation suites
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eo pipefail
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
+
+          # Three anonymous clones live under this step and none of them is ours
+          # to pass a token to directly: FetchContent clones apache/arrow-adbc,
+          # that clone updates its own apache/arrow-testing submodule, and pip
+          # installs a git+https requirement. Anonymous clones from the shared
+          # runner egress address get answered with HTTP 401
+          # ("could not read Username for 'https://github.com'"). Same header
+          # actions/checkout uses; GIT_CONFIG_* is inherited by every child
+          # process and never written to disk. Nothing here talks to the
+          # superproject, so the header cannot collide with the credential
+          # actions/checkout persists there.
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+            export GIT_CONFIG_VALUE_0
+          fi
 
           BUILD_DIR="$RUNNER_TEMP/adbc-validation"
           VENV="$RUNNER_TEMP/adbc-validation-venv"

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -12,11 +12,11 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
-#define CHDB_VERSION "26.7.0"
+#define CHDB_VERSION "26.7.2"
 
 /**
  * Returns the version of the linked chDB library.
- * @return Null-terminated version string, e.g. "26.7.0"
+ * @return Null-terminated version string, e.g. "26.7.2"
  */
 CHDB_EXPORT const char * chdb_version(void);
 


### PR DESCRIPTION
#208 took the job token to the clones it could name — pyenv, the submodules, the cctools sources. `ADBC validation suites` has three more, and none of them is a clone this repository writes:

| clone | who runs it |
| --- | --- |
| `apache/arrow-adbc` | CMake `FetchContent_MakeAvailable` |
| `apache/arrow-testing` | that clone's own `git submodule update` |
| `adbc-drivers/validation` | `pip install` of a `git+https` requirement |

All three go out anonymously from the pool's shared egress address, so they draw the same 401 #208 describes:

```
Cloning into '.../arrow_adbc-src/testing'...
fatal: could not read Username for 'https://github.com': No such device or address
Failed to clone 'testing' a second time, aborting
CMake Error: Failed to update submodules in '.../arrow_adbc-src'
```

That is [v26.7.2-rc.2's Linux arm64 job](https://github.com/chdb-io/chdb-core/actions/runs/33688359132/job/100441092760), three hours in, after everything the release needed had already been built. The release published with only the macOS arm64 artifacts. A day earlier the same step failed on the pip requirement instead — which clone loses the race varies, so the fix covers the step rather than the clone.

## Fix

`GIT_CONFIG_*` set once at the top of the step. cmake, git and pip inherit it however deep the process tree goes, and it is never written to disk — the same mechanism and the same header #208 uses.

Nothing in this step touches the superproject, so the header cannot meet the credential `actions/checkout` persists there, which is the 400 #208 warns about. Guarded on `GITHUB_TOKEN` being set, so a context without one still runs the suite the way it does today.

## Also

`CHDB_VERSION` in the public header still said `26.7.0` while the tree is at `26.7.2.1`. A release build overwrites it from the tag, so this is the value a build with no tag reports. `check-abi-version.sh` only holds the major line, so nothing was going to catch the drift — the value it guards against is what this header sat at before, `26.5.1-rc.3`, two ClickHouse lines behind the engine around it.

## Verification

Structural, since the failure only reproduces on the shared runners: all four workflows parse, the ADBC step keeps its cmake/pip/pytest body, gains `env.GITHUB_TOKEN` and the header, and skips the header when no token is set. `check-abi-version.sh` passes with the new value.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass workflow token to ADBC validation step clones in wheel build workflows
> - Adds the workflow token to the ADBC validation step environment across all four Linux and macOS wheel build workflows so nested `FetchContent` clones, submodule updates, and pip Git requirements authenticate against GitHub
> - Configures Git's process-level `http.extraheader` with a base64-encoded token, letting child processes inherit auth without writing credentials to disk
> - Bumps declared chDB version from 26.7.0 to 26.7.2 in [chdb.h](https://github.com/chdb-io/chdb-core/pull/209/files#diff-94d5015823266e6cde1cc053a7e93ba90cd8905d1f880c64c2b342cb89fc8bde) and updates the version example in the `chdb_version` docs
> - Risk: the Git extraheader config is conditional on the token being present; if the token env var is unset, validation clones may fail auth as before
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3307ec7. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->