### PR TITLE
Hand git the token the DataStore test script already asks curl for

### DIFF
--- a/chdb/test_chdb_datastore.sh
+++ b/chdb/test_chdb_datastore.sh
@@ -36,6 +36,18 @@ fi
 CORE_VERSION=$(${PYTHON} -c "import chdb; print(chdb.query('SELECT version()', 'CSV').bytes().decode().strip())" 2>/dev/null || echo "unknown")
 echo "chdb-core engine version: ${CORE_VERSION}"
 
+# curl below gets GITHUB_TOKEN explicitly, but git does not read it, so the
+# clone and the ls-remote fallback go out anonymous. On a shared runner egress
+# GitHub throttles those to 401, git then tries to prompt for a username, finds
+# no tty, and exits 128. GIT_CONFIG_* is the same channel actions/checkout uses:
+# environment only, never written to disk, inherited by every child process.
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+    GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+    export GIT_CONFIG_VALUE_0
+fi
+
 resolve_latest_chdb_tag() {
     local i auth=() body tag
     [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")


### PR DESCRIPTION
`chdb/test_chdb_datastore.sh` authenticates its GitHub API call and falls back
to `git ls-remote` when the API rate-limits, but neither the fallback nor the
clone that follows carries a credential. git does not read `GITHUB_TOKEN`, so
both go out anonymous; GitHub throttles anonymous requests from the shared
runner egress to 401, git then tries to prompt for a username, finds no tty,
and exits 128.

Reproduced on both Linux runners during the v26.7.2-rc.2 rebuild, identical
output on each:

```
Cloning chdb-io/chdb@v4.3.0 into /tmp/chdb-tests-jRw0DM/chdb...
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
##[error]Process completed with exit code 128
```

Same class as the ADBC step in #209, same fix. `GIT_CONFIG_*` carries the
header through the environment, is never written to disk, and is inherited by
every child process — what actions/checkout already does for the superproject.

Fixing the script rather than each workflow covers all eight call sites across
the four wheel workflows at once, and leaves local runs untouched: with no
token in the environment the block does not fire.

Verified locally: `bash -n` and bash 3.2 `-n` clean, shellcheck clean, no-token
path leaves `GIT_CONFIG_COUNT` unset, token path decodes to
`x-access-token:<token>`, `git config --get` reads it back, and the exact
clone command that failed in CI succeeds under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `GITHUB_TOKEN` to Git in `test_chdb_datastore.sh`
> Adds conditional Git configuration that exports an in-memory HTTP extra header with a base64-encoded `x-access-token` credential when `GITHUB_TOKEN` is set. Child Git processes inherit the header, so GitHub clone and ls-remote operations run authenticated. Behavior is unchanged when `GITHUB_TOKEN` is not set.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4b61769. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->