### PR TITLE
Remove the dead ownership probe from operator delete

### DIFF
--- a/programs/local/PandasAnalyzer.cpp
+++ b/programs/local/PandasAnalyzer.cpp
@@ -8,9 +8,6 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeFactory.h>
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
 
 namespace DB
 {
@@ -127,9 +124,6 @@ PandasAnalyzer::PandasAnalyzer(const DB::Settings & settings)
 }
 
 bool PandasAnalyzer::Analyze(py::object column) {
-#if USE_JEMALLOC
-	::Memory::MemoryCheckScope memory_check_scope;
-#endif
 	if (sample_size == 0)
 		return false;
 

--- a/programs/local/PandasDataFrame.cpp
+++ b/programs/local/PandasDataFrame.cpp
@@ -16,9 +16,6 @@
 #include <DataTypes/DataTypeObject.h>
 #include <DataTypes/DataTypeString.h>
 #include <Interpreters/Context.h>
-#if USE_JEMALLOC
-#    include <Common/memory.h>
-#endif
 
 namespace DB
 {
@@ -175,9 +172,6 @@ static DataTypePtr inferDataTypeFromPandasColumn(
 
 ColumnsDescription PandasDataFrame::getActualTableStructure(DataSourceWrapper & wrapper, ContextPtr & context)
 {
-#if USE_JEMALLOC
-    ::Memory::MemoryCheckScope memory_check_scope;
-#endif
     chassert(py::gil_check());
     NamesAndTypesList names_and_types;
 
@@ -208,9 +202,6 @@ ColumnsDescription PandasDataFrame::getActualTableStructure(DataSourceWrapper & 
 
 bool PandasDataFrame::isPandasDataframe(const py::object & object)
 {
-#if USE_JEMALLOC
-    ::Memory::MemoryCheckScope memory_check_scope;
-#endif
     chassert(py::gil_check());
 
     if (!ModuleIsLoaded<PandasCacheItem>())

--- a/programs/local/PandasScan.cpp
+++ b/programs/local/PandasScan.cpp
@@ -22,9 +22,6 @@
 #include <IO/WriteHelpers.h>
 #include <base/defines.h>
 #include <Common/assert_cast.h>
-#if USE_JEMALLOC
-#    include <Common/memory.h>
-#endif
 
 namespace DB
 {
@@ -270,9 +267,6 @@ void PandasScan::innerScanObject(
     case TypeIndex::Object:
         {
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
             auto & nullable_column = typeid_cast<ColumnNullable &>(*column);
             auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
             auto & null_map = nullable_column.getNullMapData();
@@ -301,9 +295,6 @@ void PandasScan::innerScanObject(
             /// a Nullable string column (the only case that reaches here) corrupts
             /// the interpreter state and deadlocks.
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
             auto & nullable_col = assert_cast<ColumnNullable &>(*column);
             auto data_column = nullable_col.getNestedColumnPtr()->assumeMutable();
             auto & null_map = nullable_col.getNullMapData();
@@ -353,9 +344,6 @@ void PandasScan::innerScanObject(
     case TypeIndex::Float64:
         {
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
             auto & nullable_column = typeid_cast<ColumnNullable &>(*column);
             auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
             auto & null_map = nullable_column.getNullMapData();
@@ -404,9 +392,6 @@ void PandasScan::innerScanObject(
     case TypeIndex::Int64:
         {
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
             for (size_t i = cursor; i < cursor + count; ++i)
             {
                 auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
@@ -417,9 +402,6 @@ void PandasScan::innerScanObject(
     case TypeIndex::Int32:
         {
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
             for (size_t i = cursor; i < cursor + count; ++i)
             {
                 auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
@@ -430,9 +412,6 @@ void PandasScan::innerScanObject(
     case TypeIndex::UInt64:
         {
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
             for (size_t i = cursor; i < cursor + count; ++i)
             {
                 auto * obj_ptr = *reinterpret_cast<PyObject * const *>(base_ptr + i * stride);
@@ -443,10 +422,6 @@ void PandasScan::innerScanObject(
     case TypeIndex::UInt8:
         {
             py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-            ::Memory::MemoryCheckScope memory_check_scope;
-#endif
-
             auto & nullable_column = typeid_cast<ColumnNullable &>(*column);
             auto data_column = nullable_column.getNestedColumnPtr()->assumeMutable();
             auto & null_map = nullable_column.getNullMapData();

--- a/programs/local/PyArrowStreamFactory.cpp
+++ b/programs/local/PyArrowStreamFactory.cpp
@@ -9,10 +9,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/gil.h>
 
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
-
 namespace DB
 {
 
@@ -50,9 +46,6 @@ std::unique_ptr<ArrowArrayStreamWrapper> PyArrowStreamFactory::createFromPyObjec
     }
     catch (const py::error_already_set & e)
     {
-#if USE_JEMALLOC
-        ::Memory::MemoryCheckScope memory_check_scope;
-#endif
         throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED,
                         "Failed to convert PyArrow object to arrow array stream: {}", e.what());
     }

--- a/programs/local/PythonArrowStream.cpp
+++ b/programs/local/PythonArrowStream.cpp
@@ -14,10 +14,6 @@
 #include <arrow/record_batch.h>
 #include <pybind11/gil.h>
 
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
-
 namespace DB
 {
 
@@ -67,9 +63,6 @@ std::unique_ptr<ArrowArrayStreamWrapper> importArrowCStream(const py::object & o
     }
     catch (const py::error_already_set & e)
     {
-#if USE_JEMALLOC
-        ::Memory::MemoryCheckScope memory_check_scope;
-#endif
         throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED,
             "Failed to import Arrow stream from Python object via __arrow_c_stream__: {}", e.what());
     }

--- a/programs/local/PythonConversion.cpp
+++ b/programs/local/PythonConversion.cpp
@@ -10,9 +10,6 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
-#if USE_JEMALLOC
-#    include <Common/memory.h>
-#endif
 
 namespace DB
 {
@@ -241,9 +238,6 @@ bool isMemoryView(const py::handle & obj)
 
 static void writeMemoryView(const py::handle & obj, rapidjson::Value & json_value, rapidjson::Document::AllocatorType & allocator)
 {
-#if USE_JEMALLOC
-    Memory::MemoryCheckScope memory_check_scope; 
-#endif
     try {
         /// Try to get buffer info using pybind11's buffer interface
         py::buffer_info buf_info = py::cast<py::buffer>(obj).request();

--- a/programs/local/PythonImportCache.cpp
+++ b/programs/local/PythonImportCache.cpp
@@ -4,10 +4,6 @@
 #include <Common/Exception.h>
 #include <stack>
 
-#if USE_JEMALLOC
-#    include <Common/memory.h>
-#endif
-
 namespace DB
 {
 
@@ -66,9 +62,6 @@ py::handle PythonImportCacheItem::AddCache(PythonImportCache & cache, py::object
 
 void PythonImportCacheItem::LoadModule(PythonImportCache & cache)
 {
-#if USE_JEMALLOC
-	::Memory::MemoryCheckScope memory_check_scope;
-#endif
 	try
 	{
 		py::gil_assert();
@@ -79,9 +72,6 @@ void PythonImportCacheItem::LoadModule(PythonImportCache & cache)
 	{
 		if (IsRequired())
 		{
-#if USE_JEMALLOC
-			::Memory::MemoryCheckScope memory_check_scope;
-#endif
 			throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR,
 			    				"Required module {} failed to import, due to the following Python exception:\n {}", name, e.what());
 		}
@@ -92,9 +82,6 @@ void PythonImportCacheItem::LoadModule(PythonImportCache & cache)
 
 void PythonImportCacheItem::LoadAttribute(PythonImportCache & cache, py::handle source)
 {
-#if USE_JEMALLOC
-	::Memory::MemoryCheckScope memory_check_scope;
-#endif
 	if (py::hasattr(source, name.c_str()))
 		object = AddCache(cache, std::move(source.attr(name.c_str())));
 	else
@@ -167,9 +154,6 @@ PythonImportCache::~PythonImportCache()
 	try
 	{
 		py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-		::Memory::MemoryCheckScope memory_check_scope;
-#endif
 		owned_objects.clear();
 	}
 	catch (...)

--- a/programs/local/PythonReader.cpp
+++ b/programs/local/PythonReader.cpp
@@ -1,8 +1,5 @@
 #include "PythonReader.h"
 #include "StoragePython.h"
-#if USE_JEMALLOC
-#    include <Common/memory.h>
-#endif
 
 namespace DB
 {
@@ -20,9 +17,6 @@ namespace CHDB {
 
 ColumnsDescription PythonReader::getActualTableStructure(const py::object & object, ContextPtr & context)
 {
-#if USE_JEMALLOC
-    Memory::MemoryCheckScope memory_check_scope;  // Enable memory checking for Python calls
-#endif
     std::vector<std::pair<std::string, std::string>> schema;
 
     schema = object.attr("get_schema")().cast<std::vector<std::pair<std::string, std::string>>>();

--- a/programs/local/PythonScalarUDF.cpp
+++ b/programs/local/PythonScalarUDF.cpp
@@ -18,11 +18,6 @@
 #include <Common/Exception.h>
 #include <IO/readIntText.h>
 
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
-
-
 namespace DB
 {
 namespace ErrorCodes
@@ -406,9 +401,6 @@ void PythonScalarUDF::initSignature(const py::list & arg_types_hint)
     }
     catch (py::error_already_set & e)
     {
-#if USE_JEMALLOC
-        ::Memory::MemoryCheckScope memory_check_scope;
-#endif
         throw DB::Exception(
             DB::ErrorCodes::BAD_ARGUMENTS,
             "Python UDF '{}': failed to inspect function signature: {}",
@@ -1116,9 +1108,6 @@ DB::ColumnPtr PythonScalarUDF::executeImpl(
             py::error_already_set e;
             if (exception_handling == ExceptionHandling::PROPAGATE)
             {
-#if USE_JEMALLOC
-                ::Memory::MemoryCheckScope memory_check_scope;
-#endif
                 throw DB::Exception(
                     DB::ErrorCodes::PY_EXCEPTION_OCCURED,
                     "Python UDF '{}' raised an exception at row {}: {}",

--- a/programs/local/PythonSource.cpp
+++ b/programs/local/PythonSource.cpp
@@ -46,9 +46,6 @@
 #include <base/scope_guard.h>
 #include <base/types.h>
 #include <Common/typeid_cast.h>
-#if USE_JEMALLOC
-#    include <Common/memory.h>
-#endif
 
 using namespace CHDB;
 
@@ -102,9 +99,6 @@ template <typename T>
 void PythonSource::insert_from_list(const py::list & obj, const MutableColumnPtr & column)
 {
     py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-    ::Memory::MemoryCheckScope memory_check_scope;
-#endif
     for (auto && item : obj)
     {
         if constexpr (std::is_same_v<T, UInt8>)

--- a/programs/local/PythonUtils.cpp
+++ b/programs/local/PythonUtils.cpp
@@ -11,10 +11,6 @@
 #include <Columns/ColumnString.h>
 #include <Common/logger_useful.h>
 
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
-
 namespace DB
 {
 
@@ -287,9 +283,6 @@ void insertObjToStringColumn(PyObject * obj, ColumnString * string_column)
             type_name = "unknown";
         }
 
-#if USE_JEMALLOC
-        ::Memory::MemoryCheckScope memory_check_scope;
-#endif
         throw Exception(ErrorCodes::BAD_TYPE_OF_FIELD, "Error converting Python object {} to string: {}", type_name, e.what());
     }
 }

--- a/programs/local/StoragePython.cpp
+++ b/programs/local/StoragePython.cpp
@@ -39,9 +39,6 @@
 #include <Poco/Logger.h>
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
 
 using namespace CHDB;
 
@@ -658,9 +655,6 @@ void StoragePython::prepareColumnCache(
     const ContextPtr & context_)
 {
     py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-    ::Memory::MemoryCheckScope memory_check_scope;
-#endif
 
     auto & data_source = data_source_wrapper->getDataSource();
 

--- a/programs/local/TableFunctionPython.cpp
+++ b/programs/local/TableFunctionPython.cpp
@@ -25,10 +25,6 @@
 #include <Common/FunctionDocumentation.h>
 #include <Common/logger_useful.h>
 
-#if USE_JEMALLOC
-#include <Common/memory.h>
-#endif
-
 namespace py = pybind11;
 
 using namespace CHDB;
@@ -99,9 +95,6 @@ void TableFunctionPython::parseArguments(const ASTPtr & ast_function, ContextPtr
     }
     catch (py::error_already_set & e)
     {
-#if USE_JEMALLOC
-        ::Memory::MemoryCheckScope memory_check_scope;
-#endif
         throw Exception(ErrorCodes::PY_EXCEPTION_OCCURED, "Python exception occurred: {}", e.what());
     }
 }
@@ -132,9 +125,6 @@ StoragePtr TableFunctionPython::executeImpl(
 ColumnsDescription TableFunctionPython::getActualTableStructure(ContextPtr context, bool /*is_insert_query*/) const
 {
     py::gil_scoped_acquire acquire;
-#if USE_JEMALLOC
-    Memory::MemoryCheckScope memory_check_scope;
-#endif
 
     if (!data_source_wrapper)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Python data source not initialized");

--- a/src/Common/AllocationInterceptors.cpp
+++ b/src/Common/AllocationInterceptors.cpp
@@ -165,69 +165,6 @@ void * operator new[](std::size_t size, std::align_val_t align, const std::nothr
     return ptr;
 }
 
-#if USE_JEMALLOC
-
-extern "C" void __real_free(void * ptr);
-
-inline ALWAYS_INLINE bool isJemallocMemory(void * ptr)
-{
-    int arena_ind = je_mallctl("arenas.lookup", nullptr, nullptr, &ptr, sizeof(ptr));
-    return arena_ind == 0; // arena_ind == 0 means jemalloc memory
-}
-
-/// Safely handle memory that may not have been allocated by jemalloc.
-///
-/// This function addresses a critical memory management issue in libpybind11nonlimitedapi_chdb.so:
-/// - The 'new' operator inside the library may not be overridden by chdb's custom allocator
-/// - However, the 'delete' operator is overridden by chdb's custom implementation
-/// - This mismatch can cause crashes when trying to free memory that wasn't allocated by jemalloc
-///
-/// To prevent crashes, this function checks if the memory pointer was allocated by jemalloc
-/// before attempting to free it. If the memory was allocated by a different allocator,
-/// it uses the system's default free() function instead.
-///
-/// Note: We don't update memory tracking for non-jemalloc memory since it was likely
-/// never tracked by our system in the first place.
-inline ALWAYS_INLINE bool tryFreeNonJemallocMemory(void * ptr)
-{
-    if (unlikely(ptr == nullptr))
-        return true;
-
-    int arena_ind = je_mallctl("arenas.lookup", nullptr, nullptr, &ptr, sizeof(ptr));
-    if (unlikely(arena_ind != 0))
-    {
-        __real_free(ptr);
-        return true;
-    }
-
-    return false; // Not handled - should continue with jemalloc path
-}
-
-namespace Memory
-{
-thread_local bool disable_memory_check{false};
-}
-
-inline ALWAYS_INLINE bool tryFreeNonJemallocMemoryConditional(void * ptr)
-{
-    if (unlikely(ptr == nullptr))
-        return true;
-
-    if (likely(Memory::disable_memory_check))
-        return false;
-
-    int arena_ind = je_mallctl("arenas.lookup", nullptr, nullptr, &ptr, sizeof(ptr));
-    if (unlikely(arena_ind != 0))
-    {
-        __real_free(ptr);
-        return true;
-    }
-
-    return false; // Not handled - should continue with jemalloc path
-}
-
-#endif
-
 /// delete
 
 /// C++17 std 21.6.2.1 (11)
@@ -241,10 +178,6 @@ inline ALWAYS_INLINE bool tryFreeNonJemallocMemoryConditional(void * ptr)
 
 void operator delete(void * ptr) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace);
     trace.onFree(ptr, actual_size);
@@ -253,10 +186,6 @@ void operator delete(void * ptr) noexcept
 
 void operator delete(void * ptr, std::align_val_t align) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace, 0, align);
     trace.onFree(ptr, actual_size);
@@ -265,10 +194,6 @@ void operator delete(void * ptr, std::align_val_t align) noexcept
 
 void operator delete[](void * ptr) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace);
     trace.onFree(ptr, actual_size);
@@ -277,10 +202,6 @@ void operator delete[](void * ptr) noexcept
 
 void operator delete[](void * ptr, std::align_val_t align) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace, 0, align);
     trace.onFree(ptr, actual_size);
@@ -289,10 +210,6 @@ void operator delete[](void * ptr, std::align_val_t align) noexcept
 
 void operator delete(void * ptr, std::size_t size) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace, size);
     trace.onFree(ptr, actual_size);
@@ -301,10 +218,6 @@ void operator delete(void * ptr, std::size_t size) noexcept
 
 void operator delete(void * ptr, std::size_t size, std::align_val_t align) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace, size, align);
     trace.onFree(ptr, actual_size);
@@ -313,10 +226,6 @@ void operator delete(void * ptr, std::size_t size, std::align_val_t align) noexc
 
 void operator delete[](void * ptr, std::size_t size) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace, size);
     trace.onFree(ptr, actual_size);
@@ -325,10 +234,6 @@ void operator delete[](void * ptr, std::size_t size) noexcept
 
 void operator delete[](void * ptr, std::size_t size, std::align_val_t align) noexcept
 {
-#if USE_JEMALLOC
-    if (tryFreeNonJemallocMemoryConditional(ptr))
-        return;
-#endif
     AllocationTrace trace;
     std::size_t actual_size = Memory::untrackMemory(ptr, trace, size, align);
     trace.onFree(ptr, actual_size);

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -129,10 +129,6 @@ ThreadStatus::ThreadStatus()
 
     current_thread = this;
 
-#if USE_JEMALLOC
-    Memory::disable_memory_check = true;
-#endif
-
     /// NOTE: It is important not to do any non-trivial actions (like updating ProfileEvents or logging) before ThreadStatus is created
     /// Otherwise it could lead to SIGSEGV due to current_thread dereferencing
 
@@ -309,10 +305,6 @@ ThreadStatus::~ThreadStatus()
 
     /// Flush untracked_memory **right before** switching the current_thread to avoid losing untracked_memory in deleter (detachFromGroup)
     flushUntrackedMemory();
-
-#if USE_JEMALLOC
-    Memory::disable_memory_check = false;
-#endif
 
     /// Only change current_thread if it's currently being used by this ThreadStatus
     /// For example, PushingToViews chain creates and deletes ThreadStatus instances while running in the main query thread

--- a/src/Common/malloc.cpp
+++ b/src/Common/malloc.cpp
@@ -51,7 +51,10 @@ void free(void * ptr)
     /// which bypasses our malloc override, returning pointers not known to jemalloc.
     /// je_vsallocx() safely returns 0 for such foreign pointers (uses rtree dependent=false),
     /// whereas je_sallocx / je_free crash in jemalloc's rtree lookup.
-    if (unlikely(je_vsallocx(ptr, 0) == 0))
+    /// For jemalloc-owned pointers it returns the usable size, the same value je_sallocx()
+    /// would return, so it doubles as the size lookup for memory tracking.
+    size_t actual_size = je_vsallocx(ptr, 0);
+    if (unlikely(actual_size == 0))
     {
         static void (* libc_free_ptr)(void *) =
             reinterpret_cast<void (*)(void *)>(dlsym(RTLD_NEXT, "free"));
@@ -60,8 +63,7 @@ void free(void * ptr)
         return;
     }
 
-    AllocationTrace trace;
-    size_t actual_size = Memory::untrackMemory(ptr, trace);
+    AllocationTrace trace = CurrentMemoryTracker::free(actual_size);
     trace.onFree(ptr, actual_size);
     je_free(ptr);
 }

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -27,28 +27,6 @@ void memoryGuardRemove(void *addr, size_t len);
 
 namespace Memory
 {
-#if USE_JEMALLOC
-extern thread_local bool disable_memory_check;
-
-class MemoryCheckScope
-{
-public:
-    MemoryCheckScope() noexcept
-        : old_value(disable_memory_check)
-    {
-        disable_memory_check = false;
-    }
-
-    ~MemoryCheckScope() noexcept { disable_memory_check = old_value; }
-
-    MemoryCheckScope(const MemoryCheckScope &) = delete;
-    MemoryCheckScope & operator=(const MemoryCheckScope &) = delete;
-
-private:
-    bool old_value;
-};
-#endif
-
 inline ALWAYS_INLINE size_t alignToSizeT(std::align_val_t align) noexcept
 {
     return static_cast<size_t>(align);


### PR DESCRIPTION
`tryFreeNonJemallocMemoryConditional()` probed every `operator delete` with `je_mallctl("arenas.lookup")` whenever the thread had no `ThreadStatus`, and inside every `MemoryCheckScope`. That call parses the ctl name and takes jemalloc's single global `ctl_mtx`: 123 ns per delete single-threaded, 13 µs per delete with 16 threads contending — the same convoy #183 removed from `Allocator::freeImpl`. It fires ~105K times per trivial `chdb.query()` process on the Python thread, and ~19 times per row when parallel workers scan object-dtype pandas columns (ctl_mtx contention was ~30% of cycles there).

The probe has been inert for a while:

- Since the 26.3 upgrade `__real_free` is `#define`d to `je_free`, so the "foreign pointer" branch handed the pointer to jemalloc anyway (checked on the preprocessed TU and in the built binary). It could not rescue a glibc pointer; it only added a lock.
- The mismatch it was written for — the pybind11 shim's `operator new` resolving to glibc while `delete` ran inside chdb — is fixed by the RTLD_DEEPBIND preload and the exported `operator new/delete` (7366309eaea): shim and stubs now bind to chdb's jemalloc new/delete.

This removes the probe, `Memory::disable_memory_check` and all `MemoryCheckScope` uses.

The `je_vsallocx` probe in `free()` stays. glibc-owned pointers do reach it on query threads: libc++ `std::filesystem::canonical` frees `realpath(NULL)` / `getcwd(NULL)` buffers via `::free` from `file()`, the first query's workload-storage init, `CREATE TABLE`, stack-trace symbolization, plus `strdup` results in libpq/libarchive/krb5. It is lock-free and off the hot path (`Allocator` and `operator delete` call `je_free` directly; a 30M-row GROUP BY makes one `free()` call). `free()` now reuses the size `je_vsallocx()` returns instead of a second `je_sallocx()` lookup.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead jemalloc foreign-pointer ownership probe from `operator delete`
> - Deletes the jemalloc foreign-pointer detection helpers, conditional free path, and thread-local memory-check state from [AllocationInterceptors.cpp](https://github.com/chdb-io/chdb-core/pull/211/files#diff-8603c500d1b5463aeb296715fd52088d2aae1b9ccc4e9f5a8c5742e78ab6c131) and [memory.h](https://github.com/chdb-io/chdb-core/pull/211/files#diff-922754d0afc5f43e1eaf2f57d5fbfeea0ec70179bb570786de372b2821b25656). All `operator delete`/`operator delete[]` overloads now go directly through memory untracking and the custom delete implementation.
> - Updates `global free()` in [malloc.cpp](https://github.com/chdb-io/chdb-core/pull/211/files#diff-22d63e2637cd7dbfb7c86e06a2bd27296e3b58bef7bd28a1ca23520e2f30a5c5) to use jemalloc's usable allocation size both to identify jemalloc-owned memory and to decrement the current memory tracker before releasing. Foreign pointers still forward to libc `free()`.
> - Removes the jemalloc-only memory-check suppression flag init/restore from [ThreadStatus.cpp](https://github.com/chdb-io/chdb-core/pull/211/files#diff-d2f357fc211784db94abd9ed647c1b66e10d18eee8b828f4a2310f74cbd1e5c6).
> - Strips the jemalloc memory header and memory-check scopes from all Python integration files under `programs/local/` (pandas, arrow stream, UDF, import cache, conversion, etc.).
> - Risk: `operator delete` overloads no longer route pointers detected as non-jemalloc memory to the real libc `free`; any callers relying on the foreign-pointer dispatch path must use `global free()` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56b32a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->