### PR TITLE
Cancel an active streaming read before a query on the same connection

### DIFF
--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -382,6 +382,19 @@ CHDB::QueryResultPtr ChdbClient::executeMaterializedQuery(
     try
     {
         DB::ThreadStatus thread_status;
+
+        /// A materialized query rebuilds this connection's LocalQueryState. An
+        /// un-drained streaming read left active on the connection would then
+        /// keep a ClientBase-side streaming context that outlives the engine
+        /// state it points at, so cancelling it later (e.g. from cleanup() at
+        /// connection close) dereferences a disengaged LocalQueryState and
+        /// aborts. Retire the stream now, while its state is still valid; this
+        /// also clears the process-global output buffer the abandoned stream
+        /// would otherwise leave dirty. Mirrors executeStreamingInit abandoning
+        /// an unfinished stream before starting a new one.
+        if (streaming_query_context && streaming_query_context->streaming_result)
+            cancelStreamingQueryWithoutLock(streaming_query_context->streaming_result);
+
         if (!parseQueryTextWithOutputFormat(query_str, format_str))
         {
 #if USE_PYTHON

--- a/tests/test_stream_then_query.py
+++ b/tests/test_stream_then_query.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import unittest
+
+import chdb
+
+
+# Child program: open a streaming read, consume one chunk, then run an ordinary
+# query on the same connection and exit WITHOUT draining or cancelling the
+# stream. Before the fix, the interleaved query rebuilt the connection's query
+# state out from under the still-active streaming context, so the cleanup at
+# interpreter exit cancelled the stream against a released state, tripped a
+# libc++ hardening assertion, and hung in the crash handler.
+_CHILD = """
+import chdb
+conn = chdb.connect(":memory:")
+stream = conn.send_query("SELECT number FROM numbers(3000000)", "CSV")
+assert stream.fetch() is not None
+assert conn.query("SELECT 42 AS x", "CSV").bytes() == b"42\\n"
+print("CHILD_DONE", flush=True)
+"""
+
+
+class TestStreamThenQuery(unittest.TestCase):
+    def test_query_interleaved_with_active_stream_returns_correct_data(self):
+        conn = chdb.connect(":memory:")
+        try:
+            stream = conn.send_query("SELECT number FROM numbers(3000000)", "CSV")
+            self.assertIsNotNone(stream.fetch())
+
+            # A materialized query on the same connection must run correctly,
+            # not return the abandoned stream's dirty/empty output buffer.
+            self.assertEqual(conn.query("SELECT 42 AS x", "CSV").bytes(), b"42\n")
+            self.assertEqual(
+                conn.query("SELECT count() FROM numbers(10)", "CSV").bytes(), b"10\n"
+            )
+
+            # The abandoned stream has been retired: fetching again reports it
+            # cleanly instead of crashing.
+            with self.assertRaises(RuntimeError):
+                stream.fetch()
+        finally:
+            conn.close()
+
+    def test_process_exits_cleanly_with_undrained_stream_and_interleaved_query(self):
+        # Runs the sequence in a child that never drains or cancels the stream
+        # and relies on interpreter-exit cleanup. Before the fix this hung in
+        # the crash handler; assert it exits promptly and cleanly.
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", _CHILD],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail(
+                "process hung at exit with an undrained stream and an "
+                "interleaved query on the same connection"
+            )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("CHILD_DONE", proc.stdout)
+        self.assertNotIn("Hardening assertion", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #214.

An un-drained `send_query` stream followed by an ordinary query on the **same** connection hung the process at exit with a libc++ hardening assertion (`optional operator-> called on a disengaged value`), and made that interleaved query return an empty result.

The materialized query rebuilds the connection's `LocalConnection` query state, but the stream's `ClientBase`-side streaming context stays set and now outlives the engine state it points at. Cancelling it at connection close then dereferences a disengaged `std::optional<LocalQueryState>` and aborts; the `SIGABRT` is caught by chDB's crash handler, which waits ~5 minutes.

`executeMaterializedQuery` now retires an active streaming read up front, while its state is still valid, mirroring how `executeStreamingInit` abandons an unfinished stream before starting a new one. This also clears the process-global output buffer the abandoned stream left dirty, so the interleaved query returns correct data.

### Test

`tests/test_stream_then_query.py` (CSV-only, no pandas/pyarrow): asserts the interleaved query returns real data and that a child process running the sequence and relying on exit-time cleanup exits cleanly within a timeout. Verified failing before the change and passing after; the existing streaming suites still pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel active streaming query before running materialized query on same connection
> - `executeMaterializedQuery` now calls `cancelStreamingQueryWithoutLock` to retire any active streaming result while the connection mutex is held, before parsing the materialized query. This clears the old stream's output-buffer state so the new query can proceed.
> - Adds integration tests in [test_stream_then_query.py](https://github.com/chdb-io/chdb-core/pull/215/files#diff-3faa2bc3d038a1f855079f8961de96c1e7237cb28049e479cf22b1623d786821) that consume one chunk of a large stream, then run materialized CSV queries on the same connection. Later fetches from the retired stream raise `RuntimeError`.
> - Adds a subprocess regression test verifying clean exit (zero status, completion marker, no crash assertions) when a child process leaves a stream undrained but runs an interleaved query.
> - Risk: a materialized query on a connection with an active stream now silently retires that stream; any subsequent fetch on the old stream raises `RuntimeError` instead of returning data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d799f2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->