### PR TITLE
Publish release checksums and stop overriding libc's posix_spawn

### DIFF
--- a/.github/scripts/publish-release-checksums.sh
+++ b/.github/scripts/publish-release-checksums.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# Publish one SHA256SUMS for a release (chdb-io/chdb-core#217).
+#
+# A release asset carries no checksum a consumer can fetch, so everything downstream can
+# only verify that the URL answered. chdb-rust pins an engine version and fetches
+# <platform>-libchdb[-static].tar.gz from that release during `cargo build`; the pin names
+# one release but does not make the build reproducible, because nothing checks the bytes are
+# the ones the release was cut with. A replaced or truncated asset produces a build that
+# looks fine. chdb-go, packagers and anyone scripting an install are in the same position.
+#
+# The file this writes is `sha256sum -c` / `shasum -a 256 -c` format - `<hex>  <name>`, one
+# line per asset, sorted by name - so a consumer verifies with the tool it already has, from
+# a plain download URL, with no API call and no token.
+#
+# The digests come from GitHub's own per-asset `digest` field, which it computes over the
+# stored bytes at upload time. Restating them as a file is the point: the field is only
+# reachable one asset at a time through the API, which is not something a `cargo build`
+# script or an install one-liner is going to do. Assets predating that field - or carrying a
+# digest in some algorithm other than sha256 - are downloaded and hashed here instead, one
+# at a time and deleted straight after, because the four platforms together are around nine
+# gigabytes and a hosted runner has about fourteen free.
+#
+# A fallback download is checked against the size the API reports before it is hashed. A
+# truncated download would otherwise be published as an authoritative checksum for a
+# complete file, which is worse than publishing nothing.
+#
+# Assets that are still uploading are fatal, not skipped. Skipping would quietly produce a
+# SHA256SUMS that is missing a line, and a consumer cannot tell that from an asset that was
+# never meant to be covered.
+#
+# Safe to run repeatedly: each run rewrites the file from whatever the release holds at that
+# moment, and the run after the last upload is the one that is complete.
+#
+# Usage: publish-release-checksums.sh <tag> [--dry-run]
+#   GH_TOKEN  needs contents:write unless --dry-run
+#   GH_REPO   defaults to the repository gh infers from the checkout
+
+set -euo pipefail
+
+TAG=${1:-}
+DRY_RUN=${2:-}
+
+if [ -z "${TAG}" ]; then
+    echo "Usage: $0 <tag> [--dry-run]" >&2
+    exit 2
+fi
+if [ -n "${DRY_RUN}" ] && [ "${DRY_RUN}" != "--dry-run" ]; then
+    echo "Error: unknown argument '${DRY_RUN}' (expected --dry-run)" >&2
+    exit 2
+fi
+
+CHECKSUM_FILE=SHA256SUMS
+
+# Coreutils on Linux, the BSD spelling on macOS. Resolved once so the failure is "no sha256
+# tool" rather than a confusing error from inside the loop.
+if command -v sha256sum > /dev/null 2>&1; then
+    sha256_of () { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum > /dev/null 2>&1; then
+    sha256_of () { shasum -a 256 "$1" | cut -d' ' -f1; }
+else
+    echo "Error: neither sha256sum nor shasum is available" >&2
+    exit 1
+fi
+
+# stat's spelling differs the same way.
+if stat -c %s . > /dev/null 2>&1; then
+    size_of () { stat -c %s "$1"; }
+else
+    size_of () { stat -f %z "$1"; }
+fi
+
+is_sha256 () { printf '%s' "$1" | grep -Eq '^[0-9a-f]{64}$'; }
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+echo "Release checksums for ${TAG}"
+
+# Tab separated so a name with spaces still parses. SHA256SUMS itself is excluded because it
+# is the output, and including it would make the file describe its own previous revision.
+# apiUrl carries the numeric asset id the REST download endpoint wants; the `id` field is
+# the GraphQL node id, which that endpoint does not accept.
+if ! gh release view "${TAG}" --json assets \
+        --jq '.assets[]
+              | select(.name != "'"${CHECKSUM_FILE}"'")
+              | [.name, .size, .state, (.apiUrl | split("/") | last), (.digest // "")]
+              | @tsv' \
+        > "${WORK_DIR}/assets.tsv"; then
+    echo "Error: no release ${TAG}, or its assets could not be listed" >&2
+    exit 1
+fi
+sort "${WORK_DIR}/assets.tsv" -o "${WORK_DIR}/assets.tsv"
+
+asset_count=$(wc -l < "${WORK_DIR}/assets.tsv" | tr -d ' ')
+if [ "${asset_count}" -eq 0 ]; then
+    echo "Error: ${TAG} has no assets besides ${CHECKSUM_FILE}; refusing to publish an empty file" >&2
+    exit 1
+fi
+echo "  ${asset_count} asset(s)"
+echo
+
+: > "${WORK_DIR}/${CHECKSUM_FILE}"
+while IFS=$'\t' read -r name size state asset_id reported; do
+    if [ "${state}" != "uploaded" ]; then
+        echo "Error: ${name} is in state '${state}', not 'uploaded'; its bytes are not final yet" >&2
+        exit 1
+    fi
+
+    digest=""
+    note=""
+
+    # GitHub's own digest, when it has one and it is sha256.
+    case "${reported}" in
+        sha256:*)
+            candidate=${reported#sha256:}
+            if is_sha256 "${candidate}"; then
+                digest=${candidate}
+                note="from the release"
+            else
+                echo "  ${name}: the release reports a malformed sha256, hashing it instead"
+            fi
+            ;;
+        "") ;;
+        *) echo "  ${name}: the release reports ${reported%%:*}, not sha256, hashing it instead" ;;
+    esac
+
+    if [ -z "${digest}" ]; then
+        # By asset id rather than `gh release download --pattern`: the pattern is a glob, and
+        # an asset name is not one. `gh api` follows the redirect to the storage backend and
+        # streams the body, so nothing is held in memory.
+        target="${WORK_DIR}/asset.bin"
+        rm -f "${target}"
+        if ! gh api -H "Accept: application/octet-stream" \
+                "repos/{owner}/{repo}/releases/assets/${asset_id}" \
+                > "${target}" < /dev/null; then
+            echo "Error: could not download ${name}" >&2
+            exit 1
+        fi
+
+        downloaded=$(size_of "${target}")
+        if [ "${downloaded}" != "${size}" ]; then
+            echo "Error: ${name} downloaded as ${downloaded} bytes, the release says ${size}" >&2
+            exit 1
+        fi
+
+        digest=$(sha256_of "${target}")
+        rm -f "${target}"
+        note="hashed here"
+    fi
+
+    printf '%s  %s\n' "${digest}" "${name}" >> "${WORK_DIR}/${CHECKSUM_FILE}"
+    printf '  %s  %s (%s)\n' "${digest}" "${name}" "${note}"
+done < "${WORK_DIR}/assets.tsv"
+
+lines=$(wc -l < "${WORK_DIR}/${CHECKSUM_FILE}" | tr -d ' ')
+if [ "${lines}" -ne "${asset_count}" ]; then
+    echo "Error: wrote ${lines} lines for ${asset_count} assets" >&2
+    exit 1
+fi
+
+echo
+if [ "${DRY_RUN}" = "--dry-run" ]; then
+    echo "--dry-run: not uploading. ${CHECKSUM_FILE} would be:"
+    sed 's/^/  /' "${WORK_DIR}/${CHECKSUM_FILE}"
+    exit 0
+fi
+
+gh release upload "${TAG}" "${WORK_DIR}/${CHECKSUM_FILE}" --clobber
+echo "Uploaded ${CHECKSUM_FILE} (${lines} entries) to ${TAG}"

--- a/.github/workflows/publish_checksums.yml
+++ b/.github/workflows/publish_checksums.yml
@@ -1,0 +1,76 @@
+# Attach one SHA256SUMS to every release (chdb-io/chdb-core#217).
+#
+# The four platform builds each upload their own assets, hours apart, from four runners that
+# never see each other's output. No one of them can write a file describing the release as a
+# whole, so this runs after each of them finishes and rewrites SHA256SUMS from whatever the
+# release holds at that moment. The run that follows the last upload is the complete one;
+# the earlier ones are partial and are replaced. That is the deliberate trade - a partial
+# file for a few hours beats no file at all, and beats hard-coding which builds a release is
+# supposed to contain, which changes with DEBUG_MODE, with re-runs and with the platform set.
+#
+# cancel-in-progress is off. Cancelling would leave the last-finishing build's assets out of
+# the file that ends up published, which is exactly the case this exists to cover.
+#
+# workflow_run also fires for pushes and pull requests, where there is no release to attach
+# anything to; the tag shape and then the release lookup filter those out quietly. Anything
+# else - a missing asset digest, an asset still uploading - is a hard failure, because a
+# SHA256SUMS that is quietly missing a line is worse than one that was never written.
+
+name: Publish release checksums
+
+on:
+  workflow_run:
+    workflows:
+      - Build & Test Linux x86_64
+      - Build & Test Linux arm64
+      - Build & Test macOS x86_64
+      - Build & Test macOS arm64
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Release tag to (re)publish SHA256SUMS for'
+        required: true
+
+concurrency:
+  group: publish-checksums-${{ inputs.TAG_NAME || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    # A build triggered by `release: published` records the tag as its head_branch. A build
+    # from a push or a pull request records a branch name, and only a branch deliberately
+    # named like a tag gets past this - the release lookup below is what stops that one.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ inputs.TAG_NAME || github.event.workflow_run.head_branch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Is there a release for this tag?
+        id: release
+        run: |
+          if gh release view "${TAG}" --json tagName > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            # Asking for a tag by hand and getting nothing is a mistake worth reporting.
+            # Arriving here from a branch build is not.
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "Error: no release ${TAG}" >&2
+              exit 1
+            fi
+            echo "No release ${TAG}; nothing to checksum."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish SHA256SUMS
+        if: steps.release.outputs.exists == 'true'
+        run: .github/scripts/publish-release-checksums.sh "${TAG}"

--- a/README-zh.md
+++ b/README-zh.md
@@ -109,7 +109,7 @@ curl -sSLO ${BASE}/linux-x86_64-libchdb.tar.gz
 curl -sSLO ${BASE}/SHA256SUMS
 
 # 加 --ignore-missing，只校验实际下载的文件，而不是 release 的全部产物
-sha256sum -c --ignore-missing SHA256SUMS   # macOS 上用 shasum -a 256 -c
+sha256sum -c --ignore-missing SHA256SUMS   # macOS 上用 shasum -a 256 -c --ignore-missing
 ```
 
 ---

--- a/README-zh.md
+++ b/README-zh.md
@@ -95,6 +95,23 @@
 pip install chdb-core
 ```
 
+### 校验下载的发布产物
+
+语言绑定和打包者会直接从 release 下载 C 库，即 `<platform>-libchdb.tar.gz`（动态库）或
+`<platform>-libchdb-static.tar.gz`（静态库）。每个 release 都附带一个覆盖全部产物的
+`SHA256SUMS`，因此下载结果可以校验，而不必假定其正确：
+
+```bash
+TAG=v26.7.2-rc.2
+BASE=https://github.com/chdb-io/chdb-core/releases/download/${TAG}
+
+curl -sSLO ${BASE}/linux-x86_64-libchdb.tar.gz
+curl -sSLO ${BASE}/SHA256SUMS
+
+# 加 --ignore-missing，只校验实际下载的文件，而不是 release 的全部产物
+sha256sum -c --ignore-missing SHA256SUMS   # macOS 上用 shasum -a 256 -c
+```
+
 ---
 
 ## 快速开始

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ Currently, chdb-core supports Python 3.9+ on macOS and Linux (x86_64 and ARM64).
 pip install chdb-core
 ```
 
+### Verifying a release download
+
+Language bindings and packagers fetch the C library straight from a release, as
+`<platform>-libchdb.tar.gz` (shared) or `<platform>-libchdb-static.tar.gz` (static). Every
+release also carries a `SHA256SUMS` covering all of its assets, so a download can be checked
+rather than assumed:
+
+```bash
+TAG=v26.7.2-rc.2
+BASE=https://github.com/chdb-io/chdb-core/releases/download/${TAG}
+
+curl -sSLO ${BASE}/linux-x86_64-libchdb.tar.gz
+curl -sSLO ${BASE}/SHA256SUMS
+
+# --ignore-missing so it checks the files you actually downloaded, not all of the release
+sha256sum -c --ignore-missing SHA256SUMS   # shasum -a 256 -c on macOS
+```
+
 ---
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ curl -sSLO ${BASE}/linux-x86_64-libchdb.tar.gz
 curl -sSLO ${BASE}/SHA256SUMS
 
 # --ignore-missing so it checks the files you actually downloaded, not all of the release
-sha256sum -c --ignore-missing SHA256SUMS   # shasum -a 256 -c on macOS
+sha256sum -c --ignore-missing SHA256SUMS   # shasum -a 256 -c --ignore-missing on macOS
 ```
 
 ---

--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -16,15 +16,30 @@ if (GLIBC_COMPATIBILITY)
         message (FATAL_ERROR "glibc_compatibility can only be used on x86_64 or aarch64.")
     endif ()
 
-    # chdb: glibc's posix_spawn, not this directory's. The in-tree one is a partial
-    # reimplementation that drops file actions (musl/posix_spawn.c explains why it cannot
-    # walk them), which is harmless inside the binary and not harmless in libchdb.a: the
-    # archive's strong definition displaces libc's for whatever program links it, so a
-    # consumer's dup2/chdir/close requests vanish with no error returned. Removing the
-    # source and defining the guard macro is one decision in two halves - the family is
-    # split across musl/posix_spawn.c (posix_spawn) and glibc-compatibility.c (posix_spawnp,
-    # posix_spawn_file_actions_*). See chdb-io/chdb-core#216 and the comment at the guard.
-    list (REMOVE_ITEM glibc_compatibility_sources musl/posix_spawn.c)
+    # chdb, static-library build only: glibc's posix_spawn, not this directory's. The
+    # in-tree one is a partial reimplementation that drops file actions
+    # (musl/posix_spawn.c explains why it cannot walk them). That is harmless inside a
+    # binary or a shared library - the two callers in this tree pass no file actions, and
+    # chdb/libchdb_export.map makes the symbol local in libchdb.so. It is not harmless in
+    # libchdb.a, which is handed to a linker chdb does not control: the archive's strong
+    # definition displaces libc's for whatever program links it, so a consumer's
+    # dup2/chdir/close requests vanish with no error returned (chdb-io/chdb-core#216).
+    #
+    # Scoped rather than unconditional, because the shared build does need these. Nothing
+    # in chdb's own sources calls posix_spawn_file_actions_add{,f}chdir_np, but the Rust
+    # crates the wheel links (ENABLE_RUST=1) do, and glibc versions those at 2.29 - above
+    # the 2.17 floor manylinux2014 allows. Dropping them everywhere pushed the wheel to
+    # GLIBC_2.29 and auditwheel refused to repair it. The static build sets ENABLE_RUST=0
+    # and references nothing above posix_spawn's own 2.15, so it can do without them.
+    #
+    # One decision in two halves, because the family is split across musl/posix_spawn.c
+    # (posix_spawn) and glibc-compatibility.c (posix_spawnp, posix_spawn_file_actions_*).
+    # Never take one half alone: chdb's posix_spawn_file_actions_* build a musl fdop list
+    # in a field glibc's posix_spawn reads as a counted __spawn_action array, so mixing
+    # the two walks garbage instead of merely ignoring it.
+    if (CHDB_STATIC_LIBRARY_BUILD)
+        list (REMOVE_ITEM glibc_compatibility_sources musl/posix_spawn.c)
+    endif ()
 
     if (SANITIZE STREQUAL thread AND ARCH_AMD64)
         # Disable TSAN instrumentation that conflicts with re-exec due to high ASLR entropy using getauxval
@@ -47,7 +62,9 @@ if (GLIBC_COMPATIBILITY)
 
     target_include_directories(glibc-compatibility PRIVATE libcxxabi ${musl_arch_include_dir})
 
-    target_compile_definitions(glibc-compatibility PRIVATE CHDB_NO_POSIX_SPAWN_COMPAT)
+    if (CHDB_STATIC_LIBRARY_BUILD)
+        target_compile_definitions(glibc-compatibility PRIVATE CHDB_NO_POSIX_SPAWN_COMPAT)
+    endif ()
 
     if (ENABLE_OPENSSL_DYNAMIC)
         target_compile_options(glibc-compatibility PRIVATE -fPIC)

--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -16,6 +16,16 @@ if (GLIBC_COMPATIBILITY)
         message (FATAL_ERROR "glibc_compatibility can only be used on x86_64 or aarch64.")
     endif ()
 
+    # chdb: glibc's posix_spawn, not this directory's. The in-tree one is a partial
+    # reimplementation that drops file actions (musl/posix_spawn.c explains why it cannot
+    # walk them), which is harmless inside the binary and not harmless in libchdb.a: the
+    # archive's strong definition displaces libc's for whatever program links it, so a
+    # consumer's dup2/chdir/close requests vanish with no error returned. Removing the
+    # source and defining the guard macro is one decision in two halves - the family is
+    # split across musl/posix_spawn.c (posix_spawn) and glibc-compatibility.c (posix_spawnp,
+    # posix_spawn_file_actions_*). See chdb-io/chdb-core#216 and the comment at the guard.
+    list (REMOVE_ITEM glibc_compatibility_sources musl/posix_spawn.c)
+
     if (SANITIZE STREQUAL thread AND ARCH_AMD64)
         # Disable TSAN instrumentation that conflicts with re-exec due to high ASLR entropy using getauxval
         # See longer comment in __auxv_init_procfs
@@ -36,6 +46,8 @@ if (GLIBC_COMPATIBILITY)
     target_no_warning(glibc-compatibility builtin-requires-header)
 
     target_include_directories(glibc-compatibility PRIVATE libcxxabi ${musl_arch_include_dir})
+
+    target_compile_definitions(glibc-compatibility PRIVATE CHDB_NO_POSIX_SPAWN_COMPAT)
 
     if (ENABLE_OPENSSL_DYNAMIC)
         target_compile_options(glibc-compatibility PRIVATE -fPIC)

--- a/base/glibc-compatibility/glibc-compatibility.c
+++ b/base/glibc-compatibility/glibc-compatibility.c
@@ -319,24 +319,26 @@ int __execvpe(const char *file, char *const argv[], char *const envp[])
 }
 
 
-/// The posix_spawn family below is compiled out of chdb (CHDB_NO_POSIX_SPAWN_COMPAT,
-/// set in this directory's CMakeLists.txt together with the removal of
-/// musl/posix_spawn.c) and glibc's own implementation is used instead.
+/// In the static-library build the posix_spawn family below is compiled out
+/// (CHDB_NO_POSIX_SPAWN_COMPAT, set in this directory's CMakeLists.txt together with the
+/// removal of musl/posix_spawn.c) and glibc's own implementation is used instead. That
+/// CMakeLists.txt comment carries the full reasoning, including why the scope stops there;
+/// what follows is the part a reader of this code needs.
 ///
-/// These are not drop-in replacements, they are a partial reimplementation whose
+/// These are not drop-in replacements. They are a partial reimplementation whose
 /// posix_spawn ignores file actions on purpose - see the comment at the top of
-/// musl/posix_spawn.c. Inside the ClickHouse binary that is invisible: the two callers
-/// in this tree (src/Common/OOMCanary, src/Client/JWTProvider) pass no file actions.
-/// libchdb.a is handed to a linker chdb does not control, and there a strong definition
-/// of posix_spawn in the archive silently displaces libc's for the whole program. Rust's
-/// std::process::Command spawns that way, so every redirection, current_dir and closed fd
-/// a consumer asked for was dropped without an error - chdb-io/chdb-core#216.
+/// musl/posix_spawn.c. Inside the ClickHouse binary that is invisible: the two callers in
+/// this tree (src/Common/OOMCanary, src/Client/JWTProvider) pass no file actions, and
+/// chdb/libchdb_export.map keeps the symbol local in libchdb.so. libchdb.a has no link
+/// step to gate, so there a strong definition in the archive silently displaces libc's for
+/// the whole program. Rust's std::process::Command spawns that way, so every redirection,
+/// current_dir and closed fd a consumer asked for was dropped without an error -
+/// chdb-io/chdb-core#216.
 ///
-/// Nothing here is needed for the old-glibc guarantee that the rest of this file exists
-/// for: posix_spawn, posix_spawnp and posix_spawn_file_actions_* have been in glibc since
-/// 2.15 or earlier, well under the 2.17 floor the manylinux2014 wheels target, and the two
-/// members that do need a newer glibc (posix_spawn_file_actions_add{,f}chdir_np, 2.29) are
-/// referenced nowhere in this tree.
+/// Treat the family as indivisible. These posix_spawn_file_actions_* build a musl fdop
+/// list in the field glibc's posix_spawn reads as a counted __spawn_action array, so
+/// keeping half and dropping half makes a caller walk garbage rather than merely lose its
+/// file actions.
 #ifndef CHDB_NO_POSIX_SPAWN_COMPAT
 
 #include "spawn.h"

--- a/base/glibc-compatibility/glibc-compatibility.c
+++ b/base/glibc-compatibility/glibc-compatibility.c
@@ -319,6 +319,26 @@ int __execvpe(const char *file, char *const argv[], char *const envp[])
 }
 
 
+/// The posix_spawn family below is compiled out of chdb (CHDB_NO_POSIX_SPAWN_COMPAT,
+/// set in this directory's CMakeLists.txt together with the removal of
+/// musl/posix_spawn.c) and glibc's own implementation is used instead.
+///
+/// These are not drop-in replacements, they are a partial reimplementation whose
+/// posix_spawn ignores file actions on purpose - see the comment at the top of
+/// musl/posix_spawn.c. Inside the ClickHouse binary that is invisible: the two callers
+/// in this tree (src/Common/OOMCanary, src/Client/JWTProvider) pass no file actions.
+/// libchdb.a is handed to a linker chdb does not control, and there a strong definition
+/// of posix_spawn in the archive silently displaces libc's for the whole program. Rust's
+/// std::process::Command spawns that way, so every redirection, current_dir and closed fd
+/// a consumer asked for was dropped without an error - chdb-io/chdb-core#216.
+///
+/// Nothing here is needed for the old-glibc guarantee that the rest of this file exists
+/// for: posix_spawn, posix_spawnp and posix_spawn_file_actions_* have been in glibc since
+/// 2.15 or earlier, well under the 2.17 floor the manylinux2014 wheels target, and the two
+/// members that do need a newer glibc (posix_spawn_file_actions_add{,f}chdir_np, 2.29) are
+/// referenced nowhere in this tree.
+#ifndef CHDB_NO_POSIX_SPAWN_COMPAT
+
 #include "spawn.h"
 
 int posix_spawnp(pid_t *restrict res, const char *restrict file,
@@ -426,6 +446,8 @@ int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *fa) {
 	}
 	return 0;
 }
+
+#endif /* CHDB_NO_POSIX_SPAWN_COMPAT */
 
 /// gettid was added in glibc 2.30. Use the raw syscall for compatibility with older systems.
 /// Rust's standard library (since ~nightly-2026) references gettid as a weak symbol;

--- a/chdb/build/check_static_lib_hermetic.sh
+++ b/chdb/build/check_static_lib_hermetic.sh
@@ -11,9 +11,12 @@
 #   Gate 3a the two checked-in export allow-lists describe the same C API contract
 #   Gate 3b every symbol in that contract is still reachable from libchdb.a
 #   Gate 4  the linked probe connects and runs a query
+#   Gate 5  the archive does not override libc's posix_spawn
 #
-# The five gates are the same on both platforms; only the tools and the condition that
-# exposes the hazard differ.
+# Gates 1 to 4 are the same on both platforms; only the tools and the condition that
+# exposes the hazard differ. Gate 5 has nothing to find on macOS - base/glibc-compatibility
+# is a Linux-only target - but its behavioural half is a real check there too, and it is
+# the half that keeps working if the archive is ever assembled a different way.
 #
 #   Mach-O  weak definitions that stay external land in the export trie and dyld may bind
 #           them to the system libc++/libc++abi. Exposed by a deployment target of 12.0 or
@@ -247,9 +250,10 @@ fi
 echo
 
 # --- Build the probe --------------------------------------------------------------------
-echo "== Building probe (${EXPOSURE}) =="
+echo "== Building probes (${EXPOSURE}) =="
 cp "${CHDB_H}" "${WORK_DIR}/chdb.h"
 cp "${MY_DIR}/static-probe/chdb_static_probe.c" "${WORK_DIR}/"
+cp "${MY_DIR}/static-probe/posix_spawn_probe.c" "${WORK_DIR}/"
 # Symlinked, not copied: the archive is around a gigabyte.
 ln -s "${LIBCHDB_A}" "${WORK_DIR}/libchdb.a"
 
@@ -334,20 +338,76 @@ echo
 
 # --- Gate 4: runtime smoke test ---------------------------------------------------------
 # The whole point of the exercise: the historical bug built cleanly and hung at run time.
-echo "== Gate 4: probe connects and runs a query =="
-# A watchdog, not a nicety: the failure this gate exists for is a hang, and macOS has no
+#
+# A watchdog, not a nicety: one failure these gates exist for is a hang, and macOS has no
 # coreutils `timeout`.
-(cd "${WORK_DIR}" && ./chdb_static_probe) &
-probe_pid=$!
-( sleep "${PROBE_TIMEOUT}"; kill -9 "${probe_pid}" 2>/dev/null ) &
-watchdog_pid=$!
-disown "${watchdog_pid}" 2>/dev/null || true
-if wait "${probe_pid}"; then
+run_probe () {
+    local probe=$1 probe_pid watchdog_pid rc=0
+    (cd "${WORK_DIR}" && "./${probe}") &
+    probe_pid=$!
+    ( sleep "${PROBE_TIMEOUT}"; kill -9 "${probe_pid}" 2>/dev/null ) &
+    watchdog_pid=$!
+    disown "${watchdog_pid}" 2>/dev/null || true
+    wait "${probe_pid}" || rc=$?
+    kill "${watchdog_pid}" 2>/dev/null || true
+    return "${rc}"
+}
+
+echo "== Gate 4: probe connects and runs a query =="
+if run_probe chdb_static_probe; then
     echo "PASS"
 else
     fail "probe did not complete successfully (killed after ${PROBE_TIMEOUT}s if it hung)"
 fi
-kill "${watchdog_pid}" 2>/dev/null || true
+echo
+
+# --- Gate 5: posix_spawn stays libc's ---------------------------------------------------
+# base/glibc-compatibility ships a partial posix_spawn that ignores file actions and reports
+# success anyway. Inside the ClickHouse binary that is invisible; in an archive handed to a
+# linker chdb does not control it displaces libc's definition for the whole program, and a
+# consumer's dup2/chdir/close requests disappear without an error - chdb-io/chdb-core#216.
+#
+# Two halves, because either one alone can be satisfied for the wrong reason. The symbol
+# half says the archive defines nothing in the family; the behavioural half links a second
+# probe against the archive and checks that the posix_spawn it actually reaches honours a
+# dup2 file action, which is the property a consumer depends on however the archive is built.
+echo "== Gate 5: the archive does not override libc's posix_spawn =="
+if ! nm -g --defined-only "${LIBCHDB_A}" > "${WORK_DIR}/archive_defined_raw.txt" 2>/dev/null; then
+    fail "nm could not read the archive; the symbol half of gate 5 was not evaluated"
+elif [ ! -s "${WORK_DIR}/archive_defined_raw.txt" ]; then
+    fail "nm read no defined symbol out of the archive - the symbol half would pass vacuously"
+else
+    # A definition line is `<addr> <type> <name>`, or `<type> <name>` where nm has no
+    # address to print; keying on the one-letter type field takes both and leaves out the
+    # archive member banners and blank lines. The Mach-O underscore is stripped so the
+    # match below is one pattern rather than two.
+    awk 'NF >= 2 && $(NF - 1) ~ /^[A-Za-z]$/ { n = $NF; sub(/^_/, "", n); print n }' \
+        "${WORK_DIR}/archive_defined_raw.txt" \
+        | sort -u > "${WORK_DIR}/archive_defined.txt"
+    grep_optional -E '^posix_spawn' "${WORK_DIR}/archive_defined.txt" \
+        > "${WORK_DIR}/spawn_defined.txt"
+    spawn_defined=$(wc -l < "${WORK_DIR}/spawn_defined.txt" | tr -d ' ')
+    echo "  archive definitions: $(wc -l < "${WORK_DIR}/archive_defined.txt" | tr -d ' '), in the posix_spawn family: ${spawn_defined}"
+    if [ "${spawn_defined}" -eq 0 ]; then
+        echo "PASS (symbols)"
+    else
+        sed 's/^/    /' "${WORK_DIR}/spawn_defined.txt"
+        fail "${spawn_defined} posix_spawn symbols are defined by the archive"
+    fi
+fi
+
+if (cd "${WORK_DIR}" && clang posix_spawn_probe.c -o posix_spawn_probe \
+            -L. -lchdb "${platform_flags[@]}" \
+        > "${WORK_DIR}/spawn_link.log" 2>&1); then
+    if run_probe posix_spawn_probe; then
+        echo "PASS (behaviour)"
+    else
+        fail "the posix_spawn reached through the archive dropped its file actions"
+    fi
+else
+    sed 's/^/    /' "${WORK_DIR}/spawn_link.log" | tail -40
+    fail "could not link the posix_spawn probe against the archive"
+fi
 echo
 
 if [ "${failures}" -ne 0 ]; then

--- a/chdb/build/static-probe/posix_spawn_probe.c
+++ b/chdb/build/static-probe/posix_spawn_probe.c
@@ -1,0 +1,127 @@
+/* Runtime half of gate 5: linking libchdb.a must not change what posix_spawn does
+ * (chdb-io/chdb-core#216).
+ *
+ * The archive used to carry base/glibc-compatibility's posix_spawn, a partial
+ * reimplementation that ignores file actions and reports success anyway. A strong
+ * definition in an archive displaces libc's for the whole program, so every consumer that
+ * spawns with a redirection lost it silently - Rust's std::process::Command spawns that
+ * way, and ten chdb-rust tests printed their answers into the CI log while the parent read
+ * an empty pipe.
+ *
+ * That is what this reproduces: spawn `echo` with its stdout dup2'd onto a pipe and read
+ * the word back. The symbol half of the gate checks the archive defines no posix_spawn;
+ * this half checks the one that gets called behaves like libc's, which is the property that
+ * actually matters and the only one that survives a change in how the archive is assembled.
+ *
+ * The pipe is O_CLOEXEC so a stub that drops the file actions fails as a short read rather
+ * than as a hang: the child then inherits the parent's stdout, both of its pipe descriptors
+ * close at exec, and the parent sees EOF. alarm() covers the rest.
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char ** environ;
+
+#define WORD "chdb-spawn-ok"
+#define PROBE_TIMEOUT_SECONDS 30
+
+int main(void)
+{
+    int fds[2];
+    if (pipe(fds) != 0)
+    {
+        fprintf(stderr, "spawn probe: pipe failed: %s\n", strerror(errno));
+        return 1;
+    }
+    /* Set after the fact rather than with pipe2(): pipe2 is one of the calls
+       base/glibc-compatibility also replaces, and the probe should not depend on it. */
+    for (int i = 0; i < 2; ++i)
+    {
+        if (fcntl(fds[i], F_SETFD, FD_CLOEXEC) != 0)
+        {
+            fprintf(stderr, "spawn probe: FD_CLOEXEC failed: %s\n", strerror(errno));
+            return 1;
+        }
+    }
+
+    posix_spawn_file_actions_t actions;
+    int rc = posix_spawn_file_actions_init(&actions);
+    if (rc != 0)
+    {
+        fprintf(stderr, "spawn probe: file_actions_init failed: %s\n", strerror(rc));
+        return 1;
+    }
+    /* dup2 clears FD_CLOEXEC on the new descriptor, so the child's stdout survives exec
+       while the two originals do not. */
+    rc = posix_spawn_file_actions_adddup2(&actions, fds[1], STDOUT_FILENO);
+    if (rc == 0)
+        rc = posix_spawn_file_actions_addclose(&actions, fds[0]);
+    if (rc == 0)
+        rc = posix_spawn_file_actions_addclose(&actions, fds[1]);
+    if (rc != 0)
+    {
+        fprintf(stderr, "spawn probe: adding a file action failed: %s\n", strerror(rc));
+        return 1;
+    }
+
+    char * const argv[] = {(char *)"echo", (char *)WORD, NULL};
+    pid_t pid = -1;
+    rc = posix_spawnp(&pid, "echo", &actions, NULL, argv, environ);
+    posix_spawn_file_actions_destroy(&actions);
+    if (rc != 0)
+    {
+        fprintf(stderr, "spawn probe: posix_spawnp failed: %s\n", strerror(rc));
+        return 1;
+    }
+    close(fds[1]);
+
+    alarm(PROBE_TIMEOUT_SECONDS);
+
+    char buffer[64] = {0};
+    size_t filled = 0;
+    for (;;)
+    {
+        ssize_t n = read(fds[0], buffer + filled, sizeof(buffer) - 1 - filled);
+        if (n < 0 && errno == EINTR)
+            continue;
+        if (n <= 0)
+            break;
+        filled += (size_t)n;
+        if (filled == sizeof(buffer) - 1)
+            break;
+    }
+    close(fds[0]);
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+        ;
+    alarm(0);
+
+    if (strncmp(buffer, WORD, strlen(WORD)) != 0)
+    {
+        fprintf(stderr,
+                "spawn probe: expected \"%s\" on the pipe, read %zu byte(s): \"%s\"\n",
+                WORD, filled, buffer);
+        fprintf(stderr,
+                "spawn probe: the posix_spawn that ran ignored its file actions, so the "
+                "archive is still overriding libc's - see chdb-io/chdb-core#216\n");
+        return 1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+    {
+        fprintf(stderr, "spawn probe: child did not exit cleanly (status %d)\n", status);
+        return 1;
+    }
+
+    printf("spawn probe: file actions honoured, read \"%s\" from the pipe\n", WORD);
+    return 0;
+}


### PR DESCRIPTION
Closes #216, closes #217.

## Stop `libchdb.a` from overriding libc's `posix_spawn` (#216)

`base/glibc-compatibility` replaces `posix_spawn`, `posix_spawnp` and the
`posix_spawn_file_actions_*` family with a partial reimplementation whose `posix_spawn`
ignores file actions on purpose and returns no error. The comment at the top of
`musl/posix_spawn.c` says why it cannot walk them: callers are compiled against glibc's
`<spawn.h>`, whose `posix_spawn_file_actions_t::__actions` is an array of
`struct __spawn_action`, not musl's linked list of `struct fdop`.

Inside the ClickHouse binary that is invisible — the two callers in this tree
(`src/Common/OOMCanary`, `src/Client/JWTProvider`) pass no file actions. `libchdb.a` is
handed to a linker chdb does not control, and there the archive's strong definition
displaces libc's for the whole program. Rust's `std::process::Command` spawns that way, so
every redirection, `current_dir` and closed fd a consumer asked for is dropped silently.

`libchdb.so` was never exposed: `chdb/libchdb_export.map` makes everything outside the
`chdb_*` API local. #199 gave the archive the same protection for libc++, libc++abi and
libunwind, but **visibility is the wrong tool here** — a hidden symbol is still a global
definition, and the linker will still pull it out of an archive to satisfy an undefined
reference from another object. Extending `hide_bundled_runtime()` to `glibc-compatibility`
would not have changed the outcome.

So in the **static-library build** the family is dropped and glibc's is used instead. The
shared build keeps it — the first attempt dropped it everywhere and CI rejected that:

```
Package requires GLIBC_2.29, incompatible with policy manylinux_2_17_x86_64
auditwheel: error: cannot repair ... to "manylinux2014_x86_64" ABI because of the
presence of too-recent versioned symbols
```

| symbol | glibc version | needed by the shared build | needed by the archive |
|---|---|---|---|
| `posix_spawn`, `posix_spawnp` | 2.15 | called, no file actions | called, no file actions |
| `posix_spawn_file_actions_{init,destroy,addclose,adddup2,addopen}` | 2.2 | — | — |
| `posix_spawn_file_actions_add{,f}chdir_np` | **2.29** | **yes — Rust std** | no (`ENABLE_RUST=0`) |

2.15 is under the manylinux2014 floor; 2.29 is not. My first pass claimed the 2.29 pair was
referenced nowhere in this tree — true of chdb's own sources, false of the build, since the
wheel sets `ENABLE_RUST=1` and Rust's std reaches for `addchdir_np`. Supplying it locally is
exactly what `glibc-compatibility` is for, so the shared build keeps it.

Scoping to `CHDB_STATIC_LIBRARY_BUILD` costs nothing: `libchdb.so` never had the bug
(`libchdb_export.map` makes the symbol local), the archive is only produced there, and that
build sets `ENABLE_RUST=0`. Gate 5 only ever inspects the archive.

The family is also indivisible, and both guards now say so: chdb's
`posix_spawn_file_actions_*` build a musl `fdop` list in the field glibc's `posix_spawn`
reads as a counted `__spawn_action` array, so keeping half would make a caller walk garbage
rather than merely lose its file actions.

### Gate 5

`check_static_lib_hermetic.sh` grows a fifth gate, in two halves because either alone can be
satisfied for the wrong reason:

- **symbols** — the archive must define nothing matching `posix_spawn*`
- **behaviour** — a second probe (`static-probe/posix_spawn_probe.c`) linked against the
  archive must read a child's stdout back through a `dup2` file action

The behavioural half is the one that keeps working if the archive is ever assembled a
different way. Gate 4's watchdog was factored into a `run_probe` helper both gates use.

### Verified

Against objects built from `glibc-compatibility.c` with and without the guard:

```
pre-fix archive:  9 posix_spawn symbols
  $ ./probe
  chdb-spawn-ok                                    <- child wrote to the parent's stdout
  spawn probe: expected "chdb-spawn-ok" on the pipe, read 0 byte(s): ""

post-fix archive: 0 posix_spawn symbols
  $ ./probe
  spawn probe: file actions honoured, read "chdb-spawn-ok" from the pipe
```

which is the reported symptom exactly. `run_probe` was also exercised for pass, fail and
hang (watchdog kill) under `set -euo pipefail`.

**Not** verified here: a full `build_static_lib.sh` run. The submodules in this checkout are
behind `main`, so cmake cannot configure locally; CI covers it.

## Publish `SHA256SUMS` for release assets (#217)

The four platform builds upload their assets hours apart from runners that never see each
other, so no one of them can write a file describing the release as a whole. A new workflow
runs on the completion of each of them and rewrites `SHA256SUMS` from whatever the release
holds at that moment — the run after the last upload is the complete one. A partial file for
a few hours beats hard-coding which builds a release is supposed to contain, which changes
with `DEBUG_MODE`, with re-runs and with the platform set. `cancel-in-progress` is off for
that reason; `workflow_dispatch` takes a tag for a manual re-publish.

The digests come from GitHub's own per-asset `digest` field, computed over the stored bytes
at upload. Restating them as a file is the point: that field is reachable one asset at a time
through the API, which is not something a `cargo build` script or an install one-liner will
do. Assets without one are downloaded and hashed instead, one at a time and size-checked
first, so a truncated download cannot be published as an authoritative checksum for a
complete file.

### Verified

Dry-run against the release named in the issue:

```
$ .github/scripts/publish-release-checksums.sh v26.7.2-rc.2 --dry-run
Release checksums for v26.7.2-rc.2
  16 asset(s)

  a7d138d5...  chdb_core-26.7.2-cp39-abi3-macosx_10_15_x86_64.whl (from the release)
  ...
  33ba79e7...  macos-x86_64-libchdb.tar.gz (from the release)

real  0m0.512s
```

All 16 assets, no gaps. The fallback path was checked separately on
`macos-arm64-libchdb.tar.gz`: downloaded through the same `gh api` call the script makes, and
the locally computed `8a22ea8a...a56e` matches the digest the release reports.

Both READMEs gained a short verification recipe — two curls and
`sha256sum -c --ignore-missing SHA256SUMS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release checksum publishing and stop overriding libc `posix_spawn` in static builds
> - Adds a GitHub Actions workflow ([publish_checksums.yml](https://github.com/chdb-io/chdb-core/pull/218/files#diff-d7a9bcd49e6b76a0a45b052121ba071d7b8da465cf4d25bbce912f401453c404)) that runs after platform builds or manual dispatch, and a publisher script ([publish-release-checksums.sh](https://github.com/chdb-io/chdb-core/pull/218/files#diff-910ab23ce237a0b93ed3a0b87b651c7eafab2ad88b76c73b05eacb21f8852751)) that hashes every uploaded asset into a `SHA256SUMS` file and uploads it
> - Documents the `SHA256SUMS` asset and verification steps in both [README.md](https://github.com/chdb-io/chdb-core/pull/218/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [README-zh.md](https://github.com/chdb-io/chdb-core/pull/218/files#diff-2b8d2db04fe3277c3a06cbdf5da2ba7659f95e19e31f59d5382b40ac81a1a98d)
> - Removes `musl/posix_spawn.c` from the static-library build sources and guards the bundled `posix_spawn` family in [glibc-compatibility.c](https://github.com/chdb-io/chdb-core/pull/218/files#diff-21b33bddf7bdb516d31f425f8534b22c8689dfbcf1311bf7739671d6dc804ae8) behind `CHDB_NO_POSIX_SPAWN_COMPAT`, so static builds use the platform libc implementation
> - Adds a hermetic gate and a standalone [posix_spawn_probe.c](https://github.com/chdb-io/chdb-core/pull/218/files#diff-4f817788cd954308833590bb8d02f6ee19555ff399e504cca99ce63bfc981226) to [check_static_lib_hermetic.sh](https://github.com/chdb-io/chdb-core/pull/218/files#diff-8da2876a0a2ce5607b4a2e6177599a602b692a9c110ad072f1d171c02cd6c157) that fails when `libchdb.a` exports `posix_spawn` symbols or drops file actions
> - Behavioral Change: static builds (`CHDB_STATIC_LIBRARY_BUILD`) no longer compile the in-tree `posix_spawn` compatibility code; non-static builds are unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19bee4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
