### PR TITLE
Fix python -m chdb crashing with NameError

### DIFF
--- a/chdb/__main__.py
+++ b/chdb/__main__.py
@@ -1,9 +1,14 @@
 import argparse
-from .__init__ import query
+import os
+import sys
+
+from chdb import query
 
 
 def main():
-    prog = 'python -m chdb'
+    # Installed as a console script the program is `chdb`; under `python -m
+    # chdb` argparse would otherwise report `__main__.py`.
+    prog = 'chdb' if os.path.basename(sys.argv[0]) == 'chdb' else 'python -m chdb'
     custom_usage = "%(prog)s [-h] \"SELECT 1\" [format]"
     description = ('''A simple command line interface for chdb
                    to run SQL and output in specified format''')

--- a/chdb/__main__.py
+++ b/chdb/__main__.py
@@ -6,8 +6,6 @@ from chdb import query
 
 
 def main():
-    # Installed as a console script the program is `chdb`; under `python -m
-    # chdb` argparse would otherwise report `__main__.py`.
     prog = 'chdb' if os.path.basename(sys.argv[0]) == 'chdb' else 'python -m chdb'
     custom_usage = "%(prog)s [-h] \"SELECT 1\" [format]"
     description = ('''A simple command line interface for chdb


### PR DESCRIPTION
`python -m chdb "SELECT 1"` has been dead since chdb 4.1.8 on every platform:

```
$ pip install chdb==4.3.0 && python -m chdb "SELECT 1"
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File ".../chdb/__main__.py", line 2, in <module>
    from .__init__ import query
  File ".../chdb/__init__.py", line 63, in <module>
    _preload_chdb_with_deepbind()
  File ".../chdb/__init__.py", line 60, in _preload_chdb_with_deepbind
    for candidate_dir in [_this_dir] + [p for p in __path__ if p != _this_dir]:
                                                   ^^^^^^^^
NameError: name '__path__' is not defined. Did you mean: '__name__'?
```

`from .__init__ import query` imports `__init__.py` a *second* time, as the
submodule `chdb.__init__`. That namespace is a plain module, so package globals
like `__path__` do not exist in it. It happened to work until #572 added the
RTLD_DEEPBIND pre-load, which iterates `__path__`; every release from 4.1.8
onwards raises `NameError`. `python -m chdb` is still what the README and
https://clickhouse.com/docs/chdb tell users to run.

Import the package instead of re-importing its `__init__` module. As a bonus
this stops the CLI from running the engine bootstrap (dlopen, `connect()`,
`SELECT version()`) twice per invocation.

The second hunk takes the program name from `argv[0]`, so the `chdb` console
script added in chdb-io/chdb#636 reports `usage: chdb ...` instead of telling
the user to type `python -m chdb`.

Verified against a real install (chdb 4.3.0 + chdb-core 26.7.0, Python 3.12)
with `__main__.py` replaced by this version:

```
$ python -m chdb "SELECT 1,'abc'"
1,"abc"
$ python -m chdb "SELECT 1,'abc'" Pretty
   ┏━━━┳━━━━━━━┓
   ┃ 1 ┃ 'abc' ┃
   ┡━━━╇━━━━━━━┩
1. │ 1 │ abc   │
   └───┴───────┘
$ python -m chdb --help | head -1
usage: python -m chdb [-h] "SELECT 1" [format]
$ chdb --help | head -1
usage: chdb [-h] "SELECT 1" [format]
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `python -m chdb` crashing with `NameError` in `__main__.py`
> Fixes the `NameError` crash by switching the query import to the top-level `chdb` package import. Also sets the argparse program name to `chdb` when the executable name is `chdb`, and keeps `python -m chdb` for other invocations. Adds `os` and `sys` imports to support this selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ab7768.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->