### PR TITLE
Publish a wheel index, and make PyPI publication per-release

### DIFF
--- a/.github/scripts/build-wheel-index.py
+++ b/.github/scripts/build-wheel-index.py
@@ -162,6 +162,21 @@ def main() -> None:
         directory.mkdir(parents=True, exist_ok=True)
         (directory / "index.html").write_text(page(name, "".join(body)))
         print(f"{name}: {len(wheels)} wheels, all hashed")
+        # Per release, because a release short of its siblings is the visible
+        # symptom of a platform build that failed: that wheel does not exist,
+        # so the index cannot carry it, and the release is published without it
+        # rather than withheld from the platforms that did build.
+        #
+        # Counted and not judged. How many wheels a release is supposed to have
+        # is not a number this can know -- four abi3 wheels usually, five while
+        # the free-threading upload was enabled, fewer with DEBUG_MODE -- and a
+        # guess at it would flag every normal release. The reading is left to
+        # whoever is looking at a release they have reason to doubt.
+        per_release: dict[str, int] = defaultdict(int)
+        for wheel in wheels:
+            per_release[wheel["release"]] += 1
+        for release, count in sorted(per_release.items(), reverse=True):
+            print(f"    {release}: {count}")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/build-wheel-index.py
+++ b/.github/scripts/build-wheel-index.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Build a PEP 503 index over the wheels attached to this repository's releases.
+
+    .github/scripts/build-wheel-index.py --out public
+
+chdb-core's wheels are large -- four abi3 wheels come to roughly half a
+gigabyte -- and PyPI's project quota only moves one way, so not every release
+goes there. Every release does attach its wheels to GitHub, and this turns that
+into something pip can resolve against:
+
+    pip install "chdb[durable]" \
+      --extra-index-url https://chdb.io/wheels/simple/ "chdb-core>=26.7.3"
+
+Three properties are the point:
+
+* it lists **every** release, not just the newest, so adding the index can
+  never make a version harder to install than it was without it -- the index is
+  a superset of PyPI, and pip takes the highest candidate across both. When a
+  chdb-core does reach PyPI, users move to it with no command change;
+* the platform is pip's to choose. A user copying a direct wheel URL has to
+  know their own tag set; an index means `chdb-core>=26.7.3` resolves to the
+  right one of macosx_11_0_arm64, macosx_10_15_x86_64, manylinux aarch64 or
+  manylinux x86_64, including free-threaded variants when a release has them;
+* the hash comes from GitHub's own asset digest, so the `#sha256=` fragment is
+  authoritative without this script downloading half a gigabyte to compute it.
+
+The output is static files. Point any host at the generated `simple/`.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+API = "https://api.github.com"
+
+# Enough of PEP 427 to get the distribution name off a wheel filename:
+# {name}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+WHEEL_RE = re.compile(r"\A(?P<name>[^-]+(?:_[^-]+)*)-(?P<version>[^-]+)-")
+
+
+def normalize(name: str) -> str:
+    """PEP 503 normalisation: the name pip will ask this index for."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def get(url: str, token: str | None) -> object:
+    request = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "chdb-core-wheel-index",
+        **({"Authorization": f"Bearer {token}"} if token else {}),
+    })
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        sys.exit(f"::error::GET {url} failed: {exc.code} {exc.reason}")
+
+
+def releases(repo: str, token: str | None):
+    """Every release, including pre-releases and drafts' published siblings."""
+    page = 1
+    while True:
+        batch = get(f"{API}/repos/{repo}/releases?per_page=100&page={page}", token)
+        if not batch:
+            return
+        for release in batch:
+            if not release.get("draft"):
+                yield release
+        page += 1
+
+
+def collect(repo: str, token: str | None) -> dict[str, list[dict]]:
+    """Wheels grouped by the project name pip will look them up under."""
+    projects: dict[str, list[dict]] = defaultdict(list)
+    for release in releases(repo, token):
+        for asset in release.get("assets", []):
+            name = asset["name"]
+            if not name.endswith(".whl"):
+                continue
+            match = WHEEL_RE.match(name)
+            if not match:
+                print(f"skipping {name}: not a wheel filename", file=sys.stderr)
+                continue
+            digest = asset.get("digest") or ""
+            if not digest.startswith("sha256:"):
+                # Fatal rather than a warning. pip installs an unhashed link
+                # without complaint, so a single missing digest would mean one
+                # wheel in the index is silently unverified -- invisible in the
+                # page, invisible at install time. Every asset GitHub currently
+                # serves carries a digest, so this reads as "something changed"
+                # rather than "an old release is different".
+                sys.exit(f"::error::{release['tag_name']} asset {name} has no sha256 digest; "
+                         "refusing to publish a link pip would install unverified")
+            projects[normalize(match.group("name"))].append({
+                "filename": name,
+                "url": asset["browser_download_url"],
+                "sha256": digest[len("sha256:"):],
+                "release": release["tag_name"],
+            })
+    return projects
+
+
+def page(title: str, body: str) -> str:
+    return (
+        "<!DOCTYPE html>\n<html>\n<head>\n"
+        '  <meta name="pypi:repository-version" content="1.0">\n'
+        f"  <title>{html.escape(title)}</title>\n"
+        "</head>\n<body>\n" + body + "</body>\n</html>\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "chdb-io/chdb-core"))
+    parser.add_argument("--out", default="public", type=Path,
+                        help="directory to write simple/ into")
+    # An allow-list rather than a filter, because releases carry wheels that
+    # are not products. chdb-core-lite is the symbol-trimming size check, built
+    # to catch a regression and attached to a few older releases by accident;
+    # an index that advertised it would turn a CI artifact into something a
+    # user can `pip install`. A new project has to be named here on purpose.
+    parser.add_argument("--project", action="append", dest="projects",
+                        metavar="NAME", help="publish this project (repeatable; default: chdb-core)")
+    args = parser.parse_args()
+
+    wanted = {normalize(name) for name in (args.projects or ["chdb-core"])}
+    found = collect(args.repo, os.environ.get("GITHUB_TOKEN"))
+    for name in sorted(set(found) - wanted):
+        print(f"not published: {name} ({len(found[name])} wheels); pass --project {name} to include it")
+    projects = {name: wheels for name, wheels in found.items() if name in wanted}
+
+    missing = sorted(wanted - set(projects))
+    if missing:
+        sys.exit(f"::error::{args.repo} has no release wheel for {', '.join(missing)}; "
+                 "refusing to write an index that silently omits a project")
+
+    root = args.out / "simple"
+    root.mkdir(parents=True, exist_ok=True)
+
+    links = "".join(f'  <a href="{name}/">{html.escape(name)}</a><br>\n'
+                    for name in sorted(projects))
+    (root / "index.html").write_text(page("Simple index", links))
+
+    for name, wheels in sorted(projects.items()):
+        # Newest release first, so a human reading the page sees the same order
+        # pip prefers. pip itself does not care about link order.
+        wheels.sort(key=lambda w: (w["release"], w["filename"]), reverse=True)
+        body = []
+        for wheel in wheels:
+            href = f"{wheel['url']}#sha256={wheel['sha256']}"
+            body.append(f'  <a href="{html.escape(href)}">{html.escape(wheel["filename"])}</a><br>\n')
+        directory = root / name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "index.html").write_text(page(name, "".join(body)))
+        print(f"{name}: {len(wheels)} wheels, all hashed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/pypi-upload-wanted-test.sh
+++ b/.github/scripts/pypi-upload-wanted-test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Table test for pypi-upload-wanted.sh.
+#
+#   .github/scripts/pypi-upload-wanted-test.sh
+#
+# The decision it tests is one a mistake in cannot be undone: PyPI keeps a
+# filename forever and the project quota only comes back by deleting a release.
+# It is also never exercised by a pull request -- the upload step it gates runs
+# on tags only -- so without this, an edit to those rules first runs during the
+# release it is wrong about.
+#
+# The release-notes lookup is faked by putting a `gh` earlier on PATH, so the
+# real code path runs, including the shape checks that decide whether the
+# lookup happens at all.
+
+set -uo pipefail
+
+cd "$(dirname "$0")"
+SCRIPT=./pypi-upload-wanted.sh
+[ -x "$SCRIPT" ] || {
+	echo "not executable: $SCRIPT" >&2
+	exit 2
+}
+
+FAKE_BIN=$(mktemp -d)
+trap 'rm -rf "$FAKE_BIN"' EXIT
+cat >"$FAKE_BIN/gh" <<'SHIM'
+#!/usr/bin/env bash
+# Stands in for `gh api .../releases/tags/<tag>`: prints FAKE_NOTES, or fails
+# when FAKE_GH_FAILS is set, so the fail-closed path is reachable offline.
+if [ -n "${FAKE_GH_FAILS:-}" ]; then
+	echo "release not found" >&2
+	exit 1
+fi
+printf '%s' "${FAKE_NOTES:-}"
+SHIM
+chmod +x "$FAKE_BIN/gh"
+export PATH="$FAKE_BIN:$PATH"
+
+failures=0
+
+# want: "upload" or "skip"; notes: the release body the fake gh returns
+check() {
+	local want=$1 tag=$2 notes=${3:-} fails=${4:-}
+	local got output
+	output=$(FAKE_NOTES="$notes" FAKE_GH_FAILS="$fails" "$SCRIPT" "$tag" 2>&1) \
+		&& got=upload || got=skip
+	if [ "$got" = "$want" ]; then
+		printf '  ok    %-22s -> %s\n' "$tag" "$got"
+	else
+		printf '  FAIL  %-22s -> %s, wanted %s\n     %s\n' "$tag" "$got" "$want" "${output%%$'\n'*}"
+		failures=$((failures + 1))
+	fi
+}
+
+echo "a release publishes unless its notes opt out"
+check upload v26.7.3 "## chdb-core v26.7.3"
+check upload v26.7.30 "notes"
+check skip   v26.7.3 "## chdb-core v26.7.3
+
+[no-pypi] wheels are attached to this release."
+# The marker anywhere in the body counts: release notes are prose and nobody
+# will keep it on a line of its own.
+check skip   v26.7.3 "Not on PyPI this time [no-pypi] -- use the wheel index."
+
+echo "a candidate never publishes"
+check skip v26.7.1-rc.1
+check skip v26.7.3-rc.10
+
+echo "nothing but vX.Y.Z publishes"
+for tag in v26.7.3-rc1 v26.7.3rc1 v26.7.3-beta.1 v26.7.3.59-stable v26.07.3 26.7.3 v26.7 v26.7.3.1; do
+	check skip "$tag" "notes"
+done
+
+echo "two digits per field, the bound the bindings can encode"
+check upload v26.7.99 "notes"
+check skip   v26.7.100 "notes"
+check skip   v26.100.3 "notes"
+
+echo "an unreadable release does not publish"
+check skip v26.7.3 "" fails
+
+echo "no tag is a usage error, not a decision"
+if "$SCRIPT" >/dev/null 2>&1; then
+	echo "  FAIL  no argument -> exit 0"
+	failures=$((failures + 1))
+else
+	[ $? -eq 2 ] && echo "  ok    no argument -> exit 2" || {
+		echo "  FAIL  no argument -> exited 1, which reads as a decision to skip"
+		failures=$((failures + 1))
+	}
+fi
+
+if [ "$failures" -gt 0 ]; then
+	echo "::error::$failures case(s) failed"
+	exit 1
+fi
+echo "all cases pass"

--- a/.github/scripts/pypi-upload-wanted-test.sh
+++ b/.github/scripts/pypi-upload-wanted-test.sh
@@ -41,11 +41,20 @@ export PATH="$FAKE_BIN:$PATH"
 failures=0
 
 # want: "upload" or "skip"; notes: the release body the fake gh returns
+#
+# Only 0 and 1 are decisions. Treating every nonzero status as "skip" would let
+# a broken script pass the whole table, because most cases here expect a skip --
+# a syntax error, a missing gh, or the usage exit would all read as agreement.
 check() {
 	local want=$1 tag=$2 notes=${3:-} fails=${4:-}
-	local got output
-	output=$(FAKE_NOTES="$notes" FAKE_GH_FAILS="$fails" "$SCRIPT" "$tag" 2>&1) \
-		&& got=upload || got=skip
+	local got output rc
+	output=$(FAKE_NOTES="$notes" FAKE_GH_FAILS="$fails" "$SCRIPT" "$tag" 2>&1)
+	rc=$?
+	case $rc in
+	0) got=upload ;;
+	1) got=skip ;;
+	*) got="exit $rc, which is not a decision" ;;
+	esac
 	if [ "$got" = "$want" ]; then
 		printf '  ok    %-22s -> %s\n' "$tag" "$got"
 	else
@@ -82,14 +91,13 @@ echo "an unreadable release does not publish"
 check skip v26.7.3 "" fails
 
 echo "no tag is a usage error, not a decision"
-if "$SCRIPT" >/dev/null 2>&1; then
-	echo "  FAIL  no argument -> exit 0"
-	failures=$((failures + 1))
+"$SCRIPT" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 2 ]; then
+	echo "  ok    no argument -> exit 2"
 else
-	[ $? -eq 2 ] && echo "  ok    no argument -> exit 2" || {
-		echo "  FAIL  no argument -> exited 1, which reads as a decision to skip"
-		failures=$((failures + 1))
-	}
+	echo "  FAIL  no argument -> exit $rc; 0 and 1 are decisions and this is not one"
+	failures=$((failures + 1))
 fi
 
 if [ "$failures" -gt 0 ]; then

--- a/.github/scripts/pypi-upload-wanted.sh
+++ b/.github/scripts/pypi-upload-wanted.sh
@@ -8,13 +8,24 @@
 # release is not on PyPI has to be readable in the log of the job that decided
 # it, months later, without anyone reconstructing what the settings were.
 #
-# Two rules, in this order:
+# Three rules, in this order:
 #
 #   a candidate never goes           -rc.N is for the bindings to pin against,
 #                                    and PyPI keeps every filename forever
 #
+#   nothing but vX.Y.Z goes          an allow-list of the one release shape,
+#                                    rather than a list of things to exclude
+#
 #   a release goes unless named      the default, because a release is what a
 #   in CORE_PYPI_SKIP_TAGS           user reaches with `pip install chdb-core`
+#
+# The second rule is why this is an allow-list. The condition it replaced tested
+# the tag for the substring "rc", which let v26.7.3-rc1 through -- no dot, so
+# not the candidate spelling either -- and said nothing at all about -beta.1,
+# -stable, or a fourth field. check-release-tag.sh rejects every one of those,
+# but it cannot refuse a push; it only goes red, minutes into a build that then
+# uploads anyway. Naming the one shape that publishes closes the whole class,
+# including whatever shape someone mistypes next.
 #
 # The skip list exists because four abi3 wheels come to roughly half a gigabyte
 # against a 10 GB project quota, and deleting a release is the only way to get
@@ -43,6 +54,16 @@ case "$TAG" in
 	exit 1
 	;;
 esac
+
+# No leading zeros, three fields, nothing after them: the same shape
+# check-release-tag.sh accepts for a release, minus its -rc.N alternative,
+# which the case above has already taken.
+num='(0|[1-9][0-9]*)'
+if [[ ! $TAG =~ ^v$num\.$num\.$num$ ]]; then
+	echo "$TAG is not a plain vX.Y.Z release; PyPI upload skipped"
+	echo "  only that shape publishes, so a mistyped or pre-release tag cannot spend the quota"
+	exit 1
+fi
 
 # Commas around both sides so an entry matches one whole tag: bare substring
 # matching would let v26.7.3 in the list also skip v26.7.30.

--- a/.github/scripts/pypi-upload-wanted.sh
+++ b/.github/scripts/pypi-upload-wanted.sh
@@ -8,39 +8,43 @@
 # release is not on PyPI has to be readable in the log of the job that decided
 # it, months later, without anyone reconstructing what the settings were.
 #
-# Three rules, in this order:
+# Four rules, in this order:
 #
-#   a candidate never goes           -rc.N is for the bindings to pin against,
-#                                    and PyPI keeps every filename forever
+#   a candidate never goes        -rc.N is for the bindings to pin against, and
+#                                 PyPI keeps every filename forever
 #
-#   nothing but vX.Y.Z goes          an allow-list of the one release shape,
-#                                    rather than a list of things to exclude
+#   nothing but vX.Y.Z goes       an allow-list of the one release shape. The
+#                                 condition this replaced tested the tag for
+#                                 the substring "rc", which let v26.7.3-rc1
+#                                 through and said nothing about -beta.1,
+#                                 -stable or a fourth field. check-release-tag.sh
+#                                 rejects all of those but cannot refuse a push:
+#                                 it goes red minutes into a build that then
+#                                 uploads anyway
 #
-#   a release goes unless named      the default, because a release is what a
-#   in CORE_PYPI_SKIP_TAGS           user reaches with `pip install chdb-core`
+#   a release whose notes say     the opt-out, because the wheels are about half
+#   [no-pypi] does not go         a gigabyte against a 10 GB quota that only a
+#                                 deleted release gives back. A release cut for
+#                                 one binding to move onto, rather than for
+#                                 users to install, can say so
 #
-# The second rule is why this is an allow-list. The condition it replaced tested
-# the tag for the substring "rc", which let v26.7.3-rc1 through -- no dot, so
-# not the candidate spelling either -- and said nothing at all about -beta.1,
-# -stable, or a fourth field. check-release-tag.sh rejects every one of those,
-# but it cannot refuse a push; it only goes red, minutes into a build that then
-# uploads anyway. Naming the one shape that publishes closes the whole class,
-# including whatever shape someone mistypes next.
+#   anything else goes            the default, because a release is what a user
+#                                 reaches with `pip install chdb-core`
 #
-# The skip list exists because four abi3 wheels come to roughly half a gigabyte
-# against a 10 GB project quota, and deleting a release is the only way to get
-# any of it back -- and it burns those filenames permanently. So a release cut
-# for one binding to move onto, rather than for users to install, can say so.
-#
-# It is a list of exact tags rather than a boolean for one reason: an entry that
-# outlives its release matches nothing. A boolean left set to "skip" silently
-# keeps the next release off PyPI too.
+# The opt-out lives in the release notes rather than in a repository variable
+# for three reasons. It is decided in the same text box, at the same moment, as
+# the release itself, so there is no "update the setting before you tag" order
+# to get wrong. It does not accumulate -- there is no list to prune, and no
+# entry that outlives its release. And it answers "why is this release not on
+# PyPI" on the page someone asking that is already looking at.
 #
 # Either way the GitHub release is unaffected: wheels, libchdb.so, libchdb.a and
 # debug symbols are uploaded as release assets by steps this does not gate, so
-# `pip install <release asset URL>` works for every tag.
+# every release is installable from the wheel index built over those assets.
 
 set -euo pipefail
+
+MARKER='[no-pypi]'
 
 TAG="${1:-}"
 [ -n "$TAG" ] || {
@@ -65,14 +69,35 @@ if [[ ! $TAG =~ ^v$num\.$num\.$num$ ]]; then
 	exit 1
 fi
 
-# Commas around both sides so an entry matches one whole tag: bare substring
-# matching would let v26.7.3 in the list also skip v26.7.30.
-case ",${CORE_PYPI_SKIP_TAGS:-}," in
-*",$TAG,"*)
-	echo "$TAG is named in CORE_PYPI_SKIP_TAGS; PyPI upload skipped"
-	echo "  the wheels are still on the GitHub release for $TAG"
+# Two digits each, the bound check-release-tag.sh enforces because chdb-go packs
+# the release into major*10000 + minor*100 + patch. A tag past it is one the
+# bindings cannot publish, and that check goes red without being able to stop
+# the upload -- so a filename would be spent on a release nothing downstream
+# could use.
+if [ "${BASH_REMATCH[2]}" -gt 99 ] || [ "${BASH_REMATCH[3]}" -gt 99 ]; then
+	echo "$TAG has a field above 99, which the bindings cannot encode; PyPI upload skipped"
+	echo "  see .github/scripts/check-release-tag.sh for why two digits is the budget"
 	exit 1
-	;;
-esac
+fi
 
-echo "$TAG is a release and is not in CORE_PYPI_SKIP_TAGS; uploading to PyPI"
+repo="${GITHUB_REPOSITORY:-chdb-io/chdb-core}"
+# Read by tag rather than from the event payload, so this behaves the same
+# however the build was triggered.
+if ! notes=$(gh api "repos/$repo/releases/tags/$TAG" --jq '.body // ""' 2>&1); then
+	# Fail closed. The costs are not symmetric: a quota spent is permanent and
+	# takes the filename with it, while a skip is recoverable -- fix the notes
+	# and re-run the build, or upload by hand. A tag with no release cannot have
+	# had wheels attached either, so this is already a broken state.
+	echo "could not read the release notes for $TAG; PyPI upload skipped" >&2
+	echo "  $notes" >&2
+	echo "  re-run this build once the release exists, or upload by hand" >&2
+	exit 1
+fi
+
+if [[ $notes == *"$MARKER"* ]]; then
+	echo "$TAG's release notes say $MARKER; PyPI upload skipped"
+	echo "  the wheels are on the GitHub release and in the wheel index"
+	exit 1
+fi
+
+echo "$TAG is a release and its notes do not say $MARKER; uploading to PyPI"

--- a/.github/scripts/pypi-upload-wanted.sh
+++ b/.github/scripts/pypi-upload-wanted.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Decide whether a tag's wheels belong on PyPI.
+#
+#   .github/scripts/pypi-upload-wanted.sh v26.7.3
+#
+# Exit 0 to upload, 1 to skip, and say which and why either way -- the reason a
+# release is not on PyPI has to be readable in the log of the job that decided
+# it, months later, without anyone reconstructing what the settings were.
+#
+# Two rules, in this order:
+#
+#   a candidate never goes           -rc.N is for the bindings to pin against,
+#                                    and PyPI keeps every filename forever
+#
+#   a release goes unless named      the default, because a release is what a
+#   in CORE_PYPI_SKIP_TAGS           user reaches with `pip install chdb-core`
+#
+# The skip list exists because four abi3 wheels come to roughly half a gigabyte
+# against a 10 GB project quota, and deleting a release is the only way to get
+# any of it back -- and it burns those filenames permanently. So a release cut
+# for one binding to move onto, rather than for users to install, can say so.
+#
+# It is a list of exact tags rather than a boolean for one reason: an entry that
+# outlives its release matches nothing. A boolean left set to "skip" silently
+# keeps the next release off PyPI too.
+#
+# Either way the GitHub release is unaffected: wheels, libchdb.so, libchdb.a and
+# debug symbols are uploaded as release assets by steps this does not gate, so
+# `pip install <release asset URL>` works for every tag.
+
+set -euo pipefail
+
+TAG="${1:-}"
+[ -n "$TAG" ] || {
+	echo "usage: $0 <tag>" >&2
+	exit 2
+}
+
+case "$TAG" in
+*-rc.*)
+	echo "$TAG is a release candidate; PyPI upload skipped"
+	exit 1
+	;;
+esac
+
+# Commas around both sides so an entry matches one whole tag: bare substring
+# matching would let v26.7.3 in the list also skip v26.7.30.
+case ",${CORE_PYPI_SKIP_TAGS:-}," in
+*",$TAG,"*)
+	echo "$TAG is named in CORE_PYPI_SKIP_TAGS; PyPI upload skipped"
+	echo "  the wheels are still on the GitHub release for $TAG"
+	exit 1
+	;;
+esac
+
+echo "$TAG is a release and is not in CORE_PYPI_SKIP_TAGS; uploading to PyPI"

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -805,14 +805,21 @@ jobs:
             ./linux-aarch64-libchdb-static.tar.gz
             ./linux-aarch64-debuginfo.tar.xz
           overwrite: true
+      # A release goes to PyPI, a candidate does not, and a release can opt out
+      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
+      # script owns that policy and logs which way it went; see it for why the
+      # quota makes the opt-out worth having. The GitHub release above is not
+      # gated by any of it.
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
+          .github/scripts/pypi-upload-wanted.sh "${{ github.ref_name }}" || exit 0
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
+          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -19,10 +19,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -31,10 +36,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
 
 
@@ -817,11 +827,11 @@ jobs:
             ./linux-aarch64-libchdb-static.tar.gz
             ./linux-aarch64-debuginfo.tar.xz
           overwrite: true
-      # A release goes to PyPI, a candidate does not, and a release can opt out
-      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
-      # script owns that policy and logs which way it went; see it for why the
-      # quota makes the opt-out worth having. The GitHub release above is not
-      # gated by any of it.
+      # A release goes to PyPI, a candidate does not, and a release opts out by
+      # saying [no-pypi] in its notes. The script owns that policy and logs
+      # which way it went; see it for why the quota makes the opt-out worth
+      # having, and why the notes are where it lives. The GitHub release above
+      # is not gated by any of it.
       - name: Upload pypi
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -831,7 +841,8 @@ jobs:
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
-          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
+          # Reads the release notes the decision is written in.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -18,12 +18,24 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
 
 
 concurrency:

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -790,14 +790,21 @@ jobs:
             ./linux-x86_64-libchdb-static.tar.gz
             ./linux-x86_64-debuginfo.tar.xz
           overwrite: true
+      # A release goes to PyPI, a candidate does not, and a release can opt out
+      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
+      # script owns that policy and logs which way it went; see it for why the
+      # quota makes the opt-out worth having. The GitHub release above is not
+      # gated by any of it.
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
+          .github/scripts/pypi-upload-wanted.sh "${{ github.ref_name }}" || exit 0
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
+          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -18,12 +18,24 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
 
 
 concurrency:

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -19,10 +19,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -31,10 +36,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
 
 
@@ -802,11 +812,11 @@ jobs:
             ./linux-x86_64-libchdb-static.tar.gz
             ./linux-x86_64-debuginfo.tar.xz
           overwrite: true
-      # A release goes to PyPI, a candidate does not, and a release can opt out
-      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
-      # script owns that policy and logs which way it went; see it for why the
-      # quota makes the opt-out worth having. The GitHub release above is not
-      # gated by any of it.
+      # A release goes to PyPI, a candidate does not, and a release opts out by
+      # saying [no-pypi] in its notes. The script owns that policy and logs
+      # which way it went; see it for why the quota makes the opt-out worth
+      # having, and why the notes are where it lives. The GitHub release above
+      # is not gated by any of it.
       - name: Upload pypi
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -816,7 +826,8 @@ jobs:
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
-          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
+          # Reads the release notes the decision is written in.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -18,12 +18,24 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
 
 concurrency:
   # Superseded PR pushes stack multi-hour builds onto a small self-hosted pool,

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -19,10 +19,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -31,10 +36,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
 
 concurrency:
@@ -799,11 +809,11 @@ jobs:
             ./macos-arm64-libchdb-static.tar.gz
             ./macos-arm64-debuginfo.tar.gz
           overwrite: true
-      # A release goes to PyPI, a candidate does not, and a release can opt out
-      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
-      # script owns that policy and logs which way it went; see it for why the
-      # quota makes the opt-out worth having. The GitHub release above is not
-      # gated by any of it.
+      # A release goes to PyPI, a candidate does not, and a release opts out by
+      # saying [no-pypi] in its notes. The script owns that policy and logs
+      # which way it went; see it for why the quota makes the opt-out worth
+      # having, and why the notes are where it lives. The GitHub release above
+      # is not gated by any of it.
       - name: Upload pypi
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -813,7 +823,8 @@ jobs:
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
-          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
+          # Reads the release notes the decision is written in.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -787,14 +787,21 @@ jobs:
             ./macos-arm64-libchdb-static.tar.gz
             ./macos-arm64-debuginfo.tar.gz
           overwrite: true
+      # A release goes to PyPI, a candidate does not, and a release can opt out
+      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
+      # script owns that policy and logs which way it went; see it for why the
+      # quota makes the opt-out worth having. The GitHub release above is not
+      # gated by any of it.
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
+          .github/scripts/pypi-upload-wanted.sh "${{ github.ref_name }}" || exit 0
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
+          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -18,12 +18,24 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths-ignore:
       - '**/*.md'
+      # A three-hour wheel build cannot be affected by the script and workflow
+      # that turn finished releases into a package index. Listing them here is
+      # what stops a one-line edit to either from occupying the self-hosted
+      # pool; publish_wheel_index.yml checks itself on pull requests.
+      - '.github/scripts/build-wheel-index.py'
+      - '.github/workflows/publish_wheel_index.yml'
 
 concurrency:
   # Superseded PR pushes stack multi-hour builds onto a small self-hosted pool,

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -19,10 +19,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -31,10 +36,15 @@ on:
     paths-ignore:
       - '**/*.md'
       # A three-hour wheel build cannot be affected by the script and workflow
-      # that turn finished releases into a package index. Listing them here is
-      # what stops a one-line edit to either from occupying the self-hosted
-      # pool; publish_wheel_index.yml checks itself on pull requests.
+      # that turn finished releases into a package index, nor by the rules
+      # deciding which releases reach PyPI -- that step runs on tags only, so a
+      # pull request never executes it. Listing them here is what stops a
+      # one-line edit to any of them from occupying the self-hosted pool.
+      # publish_wheel_index.yml checks itself on pull requests, and Pull-CI runs
+      # the PyPI rules' table test on every one.
       - '.github/scripts/build-wheel-index.py'
+      - '.github/scripts/pypi-upload-wanted.sh'
+      - '.github/scripts/pypi-upload-wanted-test.sh'
       - '.github/workflows/publish_wheel_index.yml'
 
 concurrency:
@@ -799,11 +809,11 @@ jobs:
             ./macos-x86_64-libchdb-static.tar.gz
             ./macos-x86_64-debuginfo.tar.gz
           overwrite: true
-      # A release goes to PyPI, a candidate does not, and a release can opt out
-      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
-      # script owns that policy and logs which way it went; see it for why the
-      # quota makes the opt-out worth having. The GitHub release above is not
-      # gated by any of it.
+      # A release goes to PyPI, a candidate does not, and a release opts out by
+      # saying [no-pypi] in its notes. The script owns that policy and logs
+      # which way it went; see it for why the quota makes the opt-out worth
+      # having, and why the notes are where it lives. The GitHub release above
+      # is not gated by any of it.
       - name: Upload pypi
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -813,7 +823,8 @@ jobs:
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
-          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
+          # Reads the release notes the decision is written in.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -787,14 +787,21 @@ jobs:
             ./macos-x86_64-libchdb-static.tar.gz
             ./macos-x86_64-debuginfo.tar.gz
           overwrite: true
+      # A release goes to PyPI, a candidate does not, and a release can opt out
+      # by naming its tag in the CORE_PYPI_SKIP_TAGS repository variable. The
+      # script owns that policy and logs which way it went; see it for why the
+      # quota makes the opt-out worth having. The GitHub release above is not
+      # gated by any of it.
       - name: Upload pypi
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
+          .github/scripts/pypi-upload-wanted.sh "${{ github.ref_name }}" || exit 0
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           pyenv shell 3.9
           python -m twine upload dist/chdb_core-*.whl
         env:
+          CORE_PYPI_SKIP_TAGS: ${{ vars.CORE_PYPI_SKIP_TAGS }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       # NOTE: chdb-core-lite PyPI publishing temporarily disabled; uncomment to re-enable.

--- a/.github/workflows/pr_ci.yaml
+++ b/.github/workflows/pr_ci.yaml
@@ -30,6 +30,14 @@ jobs:
       - name: CHDB_VERSION follows the ClickHouse line
         run: .github/scripts/check-abi-version.sh
 
+      # Which releases reach PyPI is decided in a step that runs on tags only,
+      # so nothing else here ever executes those rules. Without this they first
+      # run during the release they are wrong about, and a wrong decision spends
+      # a filename PyPI never gives back. Runs on every pull request, which is
+      # what lets the wheel builds ignore the script's path.
+      - name: The PyPI publication rules hold
+        run: .github/scripts/pypi-upload-wanted-test.sh
+
       - name: Install flake8
         run: python -m pip install flake8
 

--- a/.github/workflows/publish_wheel_index.yml
+++ b/.github/workflows/publish_wheel_index.yml
@@ -1,0 +1,120 @@
+# Publish a PEP 503 index over the wheels attached to this repository's releases.
+#
+#   pip install "chdb[durable]" \
+#     --extra-index-url https://chdb-io.github.io/chdb-core/simple/ "chdb-core>=26.7.3"
+#
+# Why an index and not a wheel URL. A release attaches four abi3 wheels and a
+# user has one platform; without an index they have to know their own tag set
+# and paste the matching URL, which is both a support burden and a thing that
+# goes stale in requirements files. An index makes the platform pip's problem.
+#
+# Why not just PyPI. Those four wheels are about half a gigabyte against a 10 GB
+# project quota that only a deleted release gives back, so PyPI publication is
+# opt-in per release (see .github/scripts/pypi-upload-wanted.sh). This is what
+# the releases that skip it are reachable through.
+#
+# The index lists every release, so it is a superset of PyPI: adding it can
+# never make a version harder to install, and pip takes the highest candidate
+# across both, so a chdb-core that does reach PyPI wins with no command change.
+# uv is the reason the "every release" part is load-bearing rather than tidy --
+# it searches an extra index before the default one and, under its default
+# first-index strategy, stops at whichever index first matches the name. An
+# index that listed only recent releases would pin uv users to those.
+#
+# Regeneration is stateless: the script reads the releases API and writes the
+# whole tree, so running it more often than necessary costs a few seconds and
+# cannot produce a partial index. Hence the four triggers.
+
+name: Publish wheel index
+
+on:
+  workflow_dispatch:
+  # The release event fires before the build workflows have uploaded anything,
+  # so this run usually publishes an index that does not yet contain the new
+  # release. It is here so the index is refreshed promptly when a release is
+  # edited or re-published, and the workflow_run trigger below is what catches
+  # the wheels themselves.
+  release:
+    types: [published, edited]
+  # Each platform's build uploads its wheels to the release as its last steps,
+  # so "that build finished" is the signal that new wheels exist. Same reason
+  # publish_checksums.yml watches the same four workflows: nothing else knows
+  # when a release is complete, because the four runners finish hours apart and
+  # never see each other's output.
+  workflow_run:
+    workflows:
+      - "Build & Test macOS arm64"
+      - "Build & Test macOS x86_64"
+      - "Build & Test Linux x86_64"
+      - "Build & Test Linux arm64"
+    types: [completed]
+  # Not "Build & Test Free-Threading Wheels": it does not run on a release and
+  # its release upload is commented out, so it puts no wheels anywhere this can
+  # see. The script takes every .whl asset it finds, so re-enabling that upload
+  # is all it would take for cp314t wheels to appear in the index.
+  # A backstop, so a missed event cannot leave the index stale indefinitely.
+  schedule:
+    - cron: "17 6 * * *"
+
+# One deployment at a time, and never cancel one in flight: a half-deployed
+# index is a resolver failure for whoever is installing at that moment.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # A build triggered by a pull request or a push to main uploads nothing to
+    # any release, so regenerating after it would be pure noise.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Build the index
+        run: .github/scripts/build-wheel-index.py --out public
+        env:
+          # Only to raise the API rate limit; the releases this reads are public.
+          GITHUB_TOKEN: ${{ github.token }}
+      # A resolver that cannot parse the page reports "no matching distribution"
+      # and names nothing, so the shape is checked here where the error can say
+      # what is wrong. pip refuses a page served as text/plain, which is how a
+      # static host that guesses the type wrong fails.
+      - name: The index is a PEP 503 index
+        run: |
+          set -euo pipefail
+          for page in public/simple/index.html public/simple/chdb-core/index.html; do
+            [ -s "$page" ] || { echo "::error::$page is missing or empty"; exit 1; }
+          done
+          count=$(grep -c '\.whl' public/simple/chdb-core/index.html)
+          echo "chdb-core: $count wheel links"
+          # Four abi3 wheels per release over the releases that carry them: a
+          # handful would mean the API returned a truncated page.
+          [ "$count" -ge 4 ] || { echo "::error::only $count wheel links; the index looks truncated"; exit 1; }
+          unhashed=$(grep -c 'href="[^"]*\.whl"' public/simple/chdb-core/index.html || true)
+          [ "$unhashed" -eq 0 ] \
+            || { echo "::error::$unhashed links have no #sha256= fragment; pip would install those unverified"; exit 1; }
+          python3 - <<'PY'
+          # The links have to be absolute release URLs: a relative href would
+          # resolve against the index host, which does not serve wheels.
+          import re, sys
+          page = open("public/simple/chdb-core/index.html").read()
+          bad = [h for h in re.findall(r'href="([^"]+)"', page)
+                 if not h.startswith("https://github.com/")]
+          sys.exit("::error::non-release hrefs: " + ", ".join(bad[:3]) if bad else 0)
+          PY
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish_wheel_index.yml
+++ b/.github/workflows/publish_wheel_index.yml
@@ -10,30 +10,29 @@
 #
 # Why not just PyPI. Those four wheels are about half a gigabyte against a 10 GB
 # project quota that only a deleted release gives back, so PyPI publication is
-# opt-in per release (see .github/scripts/pypi-upload-wanted.sh). This is what
-# the releases that skip it are reachable through.
+# per-release (see .github/scripts/pypi-upload-wanted.sh). This is what the
+# releases that skip it are reachable through.
 #
 # The index lists every release, so it is a superset of PyPI: adding it can
 # never make a version harder to install, and pip takes the highest candidate
 # across both, so a chdb-core that does reach PyPI wins with no command change.
 # uv is the reason the "every release" part is load-bearing rather than tidy --
 # it searches an extra index before the default one and, under its default
-# first-index strategy, stops at whichever index first matches the name. An
+# first-index strategy, stops at whichever index first matched the name. An
 # index that listed only recent releases would pin uv users to those.
 #
 # Regeneration is stateless: the script reads the releases API and writes the
 # whole tree, so running it more often than necessary costs a few seconds and
-# cannot produce a partial index. Hence the four triggers.
+# cannot produce a partial index for a settled release.
 
 name: Publish wheel index
 
 on:
   workflow_dispatch:
-  # The release event fires before the build workflows have uploaded anything,
-  # so this run usually publishes an index that does not yet contain the new
-  # release. It is here so the index is refreshed promptly when a release is
-  # edited or re-published, and the workflow_run trigger below is what catches
-  # the wheels themselves.
+  # A release is published minutes before any wheel exists, so this run
+  # normally publishes an index that does not contain the new release yet. It
+  # is here for a re-publish or an edit; the workflow_run trigger is what
+  # catches the wheels.
   release:
     types: [published, edited]
   # Each platform's build uploads its wheels to the release as its last steps,
@@ -41,6 +40,11 @@ on:
   # publish_checksums.yml watches the same four workflows: nothing else knows
   # when a release is complete, because the four runners finish hours apart and
   # never see each other's output.
+  #
+  # Not "Build & Test Free-Threading Wheels": it does not run on a release and
+  # its release upload is commented out, so it puts no wheels anywhere this can
+  # see. The script takes every .whl asset it finds, so re-enabling that upload
+  # is all it would take for cp314t wheels to appear in the index.
   workflow_run:
     workflows:
       - "Build & Test macOS arm64"
@@ -48,39 +52,32 @@ on:
       - "Build & Test Linux x86_64"
       - "Build & Test Linux arm64"
     types: [completed]
-  # Not "Build & Test Free-Threading Wheels": it does not run on a release and
-  # its release upload is commented out, so it puts no wheels anywhere this can
-  # see. The script takes every .whl asset it finds, so re-enabling that upload
-  # is all it would take for cp314t wheels to appear in the index.
-  # A backstop, so a missed event cannot leave the index stale indefinitely.
+  # Hourly, and cheap: the job is seconds, and this is what closes the window
+  # if two platform builds finish close enough together that each sees the
+  # other still running and neither deploys.
   schedule:
-    - cron: "17 6 * * *"
-
-# One deployment at a time, and never cancel one in flight: a half-deployed
-# index is a resolver failure for whoever is installing at that moment.
-concurrency:
-  group: pages
-  cancel-in-progress: false
+    - cron: "17 * * * *"
+  # The index is only as good as the script that writes it, and nothing else in
+  # this repository runs that script. Without this, an edit to either file
+  # reaches a release before anything has executed it once.
+  pull_request:
+    paths:
+      - .github/workflows/publish_wheel_index.yml
+      - .github/scripts/build-wheel-index.py
 
 permissions:
   contents: read
 
 jobs:
-  publish:
+  build:
     # A build triggered by a pull request or a push to main uploads nothing to
     # any release, so regenerating after it would be pure noise.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'release'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      settled: ${{ steps.settled.outputs.settled }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
       - name: Build the index
         run: .github/scripts/build-wheel-index.py --out public
         env:
@@ -88,8 +85,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       # A resolver that cannot parse the page reports "no matching distribution"
       # and names nothing, so the shape is checked here where the error can say
-      # what is wrong. pip refuses a page served as text/plain, which is how a
-      # static host that guesses the type wrong fails.
+      # what is wrong.
       - name: The index is a PEP 503 index
         run: |
           set -euo pipefail
@@ -101,6 +97,8 @@ jobs:
           # Four abi3 wheels per release over the releases that carry them: a
           # handful would mean the API returned a truncated page.
           [ "$count" -ge 4 ] || { echo "::error::only $count wheel links; the index looks truncated"; exit 1; }
+          # An href ending at .whl is one with no fragment after it. pip installs
+          # such a link without complaint, which is the whole problem.
           unhashed=$(grep -c 'href="[^"]*\.whl"' public/simple/chdb-core/index.html || true)
           [ "$unhashed" -eq 0 ] \
             || { echo "::error::$unhashed links have no #sha256= fragment; pip would install those unverified"; exit 1; }
@@ -113,8 +111,69 @@ jobs:
                  if not h.startswith("https://github.com/")]
           sys.exit("::error::non-release hrefs: " + ", ".join(bad[:3]) if bad else 0)
           PY
+      # Deploying after the first platform build would publish an index that
+      # holds one platform's wheel for the new release. A user on any other
+      # platform asking for that exact version gets "no matching distribution"
+      # for the hours until the next build lands -- a hard resolver failure,
+      # which is worse than what publish_checksums.yml accepts for the same
+      # timing (a SHA256SUMS missing a line is still a usable file).
+      #
+      # So the last build of a release is the one that deploys, and it is
+      # identified by asking what is still running rather than by counting to
+      # four. A count would have to be told which builds a release contains,
+      # and that changes with DEBUG_MODE, with re-runs, and whenever the
+      # platform set does.
+      - name: Is every build for this release finished
+        id: settled
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Manual runs deploy whatever exists: the operator asked for it, and
+          # it is the handle for publishing during a stuck or abandoned build.
+          FORCED: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          if [ "$FORCED" = "true" ]; then
+            echo "manual run: deploying without waiting for builds"
+            echo "settled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          builds='["Build & Test macOS arm64","Build & Test macOS x86_64","Build & Test Linux x86_64","Build & Test Linux arm64"]'
+          running=0
+          for state in in_progress queued; do
+            n=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?status=$state&per_page=100" \
+                  --jq "[.workflow_runs[]
+                         | select(.name as \$n | $builds | index(\$n))
+                         | select(.event == \"release\")] | length")
+            running=$((running + n))
+          done
+          if [ "$running" -gt 0 ]; then
+            echo "$running release build(s) still running; leaving the index alone"
+            echo "  the last one to finish publishes; the hourly run is the backstop"
+            echo "settled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "no release build is running; publishing"
+            echo "settled=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request' && steps.settled.outputs.settled == 'true'
         with:
           path: public
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request' && needs.build.outputs.settled == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    # One deployment at a time, and never cancel one in flight: a half-deployed
+    # index is a resolver failure for whoever is installing at that moment.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/publish_wheel_index.yml
+++ b/.github/workflows/publish_wheel_index.yml
@@ -123,6 +123,26 @@ jobs:
       # four. A count would have to be told which builds a release contains,
       # and that changes with DEBUG_MODE, with re-runs, and whenever the
       # platform set does.
+      #
+      # Asked per workflow, because the repository-wide runs endpoint cannot be
+      # narrowed to these four: filtering it by event=release alone would count
+      # check_release_tag, check_bindings -- and this workflow, which a release
+      # event also starts, so it would wait for itself forever. Per workflow,
+      # total_count is the whole answer in one request and no page limit applies.
+      #
+      # It waits on any release, not just the one that triggered it, because
+      # there is one index for every release: deploying while another release is
+      # mid-upload publishes that one partially, which is the case above. The
+      # wait is bounded -- when those builds finish, their own workflow_run
+      # fires -- and the blocking tags are named below so a long hold is not a
+      # mystery.
+      #
+      # A release whose build failed is deliberately still published. Its wheel
+      # for that platform does not exist and nothing here can invent it, so the
+      # choice is between an index missing one platform and an index missing the
+      # release entirely -- and the three platforms that did build should not be
+      # unreachable because the fourth was not. The wheel count per release is
+      # in the build log above, which is where a short one shows up.
       - name: Is every build for this release finished
         id: settled
         env:
@@ -137,14 +157,18 @@ jobs:
             echo "settled=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          builds='["Build & Test macOS arm64","Build & Test macOS x86_64","Build & Test Linux x86_64","Build & Test Linux arm64"]'
           running=0
-          for state in in_progress queued; do
-            n=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?status=$state&per_page=100" \
-                  --jq "[.workflow_runs[]
-                         | select(.name as \$n | $builds | index(\$n))
-                         | select(.event == \"release\")] | length")
-            running=$((running + n))
+          for wf in build_macos_arm64_wheels.yml build_macos_x86_wheels.yml \
+                    build_linux_x86_wheels.yml build_linux_arm64_wheels-gh.yml; do
+            for state in in_progress queued; do
+              runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf/runs?event=release&status=$state&per_page=100")
+              n=$(jq '.total_count' <<<"$runs")
+              if [ "$n" -gt 0 ]; then
+                tags=$(jq -r '[.workflow_runs[].head_branch] | unique | join(", ")' <<<"$runs")
+                echo "  $wf: $n $state ($tags)"
+              fi
+              running=$((running + n))
+            done
           done
           if [ "$running" -gt 0 ]; then
             echo "$running release build(s) still running; leaving the index alone"


### PR DESCRIPTION
A chdb-core release attaches four abi3 wheels, about half a gigabyte, and PyPI's project quota only moves one way — a deleted release is the only way to get any of it back, and it burns those filenames permanently. About 2.5 GB of the 10 GB is already spent.

Not every release needs to spend more of it. A release is often cut so one binding has something to pin, and bindings pin release-asset URLs. So:

**PyPI publication becomes per-release.** A release goes unless its tag is named in the `CORE_PYPI_SKIP_TAGS` repository variable; a candidate never goes. The three rules live in `.github/scripts/pypi-upload-wanted.sh`, which logs which way it went — why a release is missing from PyPI should be answerable from that job's log, not by reconstructing what the repository settings were at the time. The list holds exact tags rather than being a boolean, so an entry that outlives its release matches nothing; a boolean left on would quietly keep the next release off PyPI too.

**The releases that skip it get a real install path.** The releases API now feeds a PEP 503 index, deployed to this repository's GitHub Pages site:

```bash
pip install "chdb[durable]" \
  --extra-index-url https://chdb-io.github.io/chdb-core/simple/ \
  "chdb-core>=26.7.3"
```

Three things make that safe to leave in a command permanently:

- It lists **every** release, so the index is a superset of PyPI. Adding it cannot make a version harder to install, and pip takes the highest candidate across both indexes — so a chdb-core that does reach PyPI wins with no change to anyone's command. The superset property is load-bearing rather than tidy because of uv: it searches an extra index before the default one and, under its default `first-index` strategy, stops at whichever index first matched the name.
- Every link carries a `#sha256=` fragment and pip enforces it. The digests come from GitHub's own asset metadata, so nothing downloads half a gigabyte to compute them, and an asset without a digest fails the build rather than being published unhashed.
- Only projects named on the command line are published, `chdb-core` by default. `chdb-core-lite` has wheels on a few older releases and is the symbol-trimming size check, not a product.

`workflow_run` on the four platform builds is the trigger that matters, for the same reason `publish_checksums.yml` uses it: a release is published minutes before its wheels exist, so "a platform build finished" is the signal there is something new to index. Regeneration is stateless — the script reads the API and writes the whole tree — so the other triggers (manual, re-publish, daily backstop) cost seconds and cannot produce a partial index.

The GitHub release itself is untouched throughout: wheels, `libchdb.so`, `libchdb.a` and debug symbols are uploaded by steps none of this gates.

## Verified locally

- `pypi-upload-wanted.sh` over 9 tag/variable combinations, including that a `v26.7.3` entry does not also skip `v26.7.30`.
- The generator against the live API: 39 `chdb-core` wheels across every release, all hashed; `chdb-core-lite` correctly withheld.
- The generated tree served over HTTP: `pip install "chdb[durable]" --extra-index-url … "chdb-core>=26.7.2"` resolves the right platform wheel, installs `chdb-core` before `chdb`, and the resulting install reports `abi True`. Same command under `uv` works with no `--index-strategy` flag.
- A link with a corrupted `#sha256=` is refused by pip with a hash mismatch rather than installed.

## Needs one setting before the next release

Pages source on this repository must be set to **GitHub Actions** for the deploy step to publish. Enabling it is not something this PR can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add wheel index generator and per-release PyPI publication policy
> - Adds [build-wheel-index.py](https://github.com/chdb-io/chdb-core/pull/220/files#diff-8aa5f4079ba8f9dee8c3c74880a80e12312c820f2e939db8ba8e8b23822c0aa4) which fetches non-draft GitHub release assets, groups wheels by normalized project name, validates sha256 digests, and renders PEP 503 Simple API HTML pages
> - Adds [pypi-upload-wanted.sh](https://github.com/chdb-io/chdb-core/pull/220/files#diff-3b05ab1bd17109b8c253dd7b06303a14b393cb3b4fa4250b2505d796668241a9), a fail-closed policy that uploads only plain `vX.Y.Z` tags whose release notes lack `[no-pypi]`; candidates, malformed tags, and unreadable releases are skipped
> - Adds [publish_wheel_index.yml](https://github.com/chdb-io/chdb-core/pull/220/files#diff-42c8b1e839e5df6903ed46acb91049e7f8b07ee84546eef4c1f5983f0e83cc3b) which runs the generator on release events, build completion, hourly schedule, and manual dispatch, then deploys to GitHub Pages only after all in-progress platform builds settle
> - Updates the four platform wheel workflows to call `pypi-upload-wanted.sh` before Twine and to ignore changes to the new scripts and publish workflow in their path filters
> - Behavioral Change: PyPI upload condition switches from excluding refs containing `rc` to the shared policy script; releases with tags like `v1.2.3` and no `[no-pypi]` marker now upload, while any other tag or failure mode skips the upload
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bc6ba9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->