### PR TITLE
Initialize system logs on the embedded engine

### DIFF
--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -36,6 +36,7 @@
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Interpreters/ProcessList.h>
+#include <Interpreters/SystemLog.h>
 #include <Interpreters/loadMetadata.h>
 #include <Interpreters/registerInterpreters.h>
 #include <Loggers/OwnFormattingChannel.h>
@@ -306,7 +307,10 @@ void EmbeddedServer::initialize(Poco::Util::Application & self)
 
     /// Load config files if exists
     std::string config_path;
-    if (config().has("config-file"))
+    /// Decide this before the file layer is merged in: afterwards a <config-file> element inside
+    /// an auto-discovered config would be indistinguishable from one the caller passed.
+    config_file_passed_explicitly = config().has("config-file");
+    if (config_file_passed_explicitly)
         config_path = config().getString("config-file");
     else if (config_path.empty() && fs::exists("config.xml"))
         config_path = "config.xml";
@@ -1167,10 +1171,35 @@ void EmbeddedServer::processConfig()
         DatabaseCatalog::instance().startupBackgroundTasks();
     }
 
+    setupSystemLogs();
+
     std::string default_database = config().getString("database", server_default_database);
     if (default_database.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "default_database cannot be empty");
     global_context->setCurrentDatabase(default_database);
+}
+
+void EmbeddedServer::setupSystemLogs()
+{
+    /// clickhouse-local initializes system logs only when the config asks for them
+    /// (LocalServer::processConfig). EmbeddedServer never initialized them at all, so a
+    /// <query_log> section was accepted and silently ignored on the embedded path: the table
+    /// never appeared and SYSTEM FLUSH LOGS reported success without doing anything.
+    ///
+    /// Keep LocalServer's conditions and add one more: only a config the caller passed explicitly
+    /// arms system logs. EmbeddedServer also picks up ./config.xml, ~/.clickhouse-local/config.*
+    /// and /etc/clickhouse-local/config.*, and spawning a background flush thread per log because
+    /// a config file happens to sit in the host process' working directory is not a reasonable
+    /// thing for an embedded engine to do.
+    if (config().has("no-system-tables") || config().has("only-system-tables"))
+        return;
+
+    if (!config_file_passed_explicitly || !hasAnySystemLogConfigured(config()))
+        return;
+
+    removeOrphanedSystemLogData(global_context, config());
+
+    global_context->initializeSystemLogs();
 }
 
 void EmbeddedServer::applyCmdOptions(ContextMutablePtr context)

--- a/programs/local/EmbeddedServer.h
+++ b/programs/local/EmbeddedServer.h
@@ -57,6 +57,7 @@ private:
     void setupUsers();
     void cleanup();
     void processConfig();
+    void setupSystemLogs();
     void applyCmdOptions(ContextMutablePtr context);
     void initializeWithArgs(int argc, char ** argv);
     static std::unique_ptr<EmbeddedServer> global_instance;
@@ -64,6 +65,9 @@ private:
     static size_t client_ref_count;
     /// Set by beginShutdown(); guarded by instance_mutex.
     static bool engine_stopped;
+    /// Whether --config-file was passed by the caller, as opposed to a config found next to the
+    /// process. Only an explicit one may arm system logs.
+    bool config_file_passed_explicitly = false;
     std::string db_path;
     ServerSettings server_settings;
     std::optional<StatusFile> status;

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1759,7 +1759,10 @@ void LocalServer::processConfig()
     if (!getClientConfiguration().has("no-system-tables")
         && !getClientConfiguration().has("only-system-tables")
         && hasAnySystemLogConfigured(config()))
+    {
+        removeOrphanedSystemLogData(global_context, config());
         global_context->initializeSystemLogs();
+    }
 
     std::string default_database = getClientConfiguration().getString("database", server_default_database);
     if (default_database.empty())

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -263,6 +263,27 @@ void SystemLogQueue<LogElement>::shutdown()
 }
 
 template <typename LogElement>
+void SystemLogQueue<LogElement>::restart()
+{
+    std::unique_lock lock(mutex);
+
+    /// Everything here describes the previous owner: its table (prepared_tables), how far its
+    /// saving thread got (flushed_index) and whatever it never drained (pop() returns early on
+    /// shutdown without emptying the queue). The new owner has a different table -- system log
+    /// metadata does not survive an engine teardown -- so leaving prepared_tables above the new
+    /// front index would make its first SYSTEM FLUSH LOGS report success without creating
+    /// anything. Hand back a queue in exactly its constructed state.
+    queue.clear();
+    queue_front_index = 0;
+    requested_flush_index = std::numeric_limits<Index>::min();
+    flushed_index = 0;
+    requested_prepare_tables = std::numeric_limits<Index>::min();
+    prepared_tables = -1;
+    ignored_logs = 0;
+    is_shutdown = false;
+}
+
+template <typename LogElement>
 SystemLogBase<LogElement>::SystemLogBase(
     const SystemLogQueueSettings & settings_,
     std::shared_ptr<SystemLogQueue<LogElement>> queue_)

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -267,12 +267,20 @@ void SystemLogQueue<LogElement>::restart()
 {
     std::unique_lock lock(mutex);
 
-    /// Everything here describes the previous owner: its table (prepared_tables), how far its
+    /// Only a queue that a previous owner shut down needs resetting. A queue that was merely
+    /// created early is still collecting for its first owner: the logging channel is attached in
+    /// buildLoggers, long before the SystemLog that drains it exists, and everything logged in
+    /// between must survive.
+    if (!is_shutdown)
+        return;
+
+    /// Everything below describes the previous owner: its table (prepared_tables), how far its
     /// saving thread got (flushed_index) and whatever it never drained (pop() returns early on
     /// shutdown without emptying the queue). The new owner has a different table -- system log
     /// metadata does not survive an engine teardown -- so leaving prepared_tables above the new
     /// front index would make its first SYSTEM FLUSH LOGS report success without creating
-    /// anything. Hand back a queue in exactly its constructed state.
+    /// anything. Hand back a queue in exactly its constructed state. Nothing is lost: while the
+    /// latch was set every push was dropped anyway.
     queue.clear();
     queue_front_index = 0;
     requested_flush_index = std::numeric_limits<Index>::min();

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -133,6 +133,12 @@ public:
 
     void shutdown();
 
+    /// Puts the queue back into its constructed state so that it can serve a new owner. Only
+    /// meaningful for queues that outlive their SystemLog, i.e. TextLog's process-wide static one.
+    /// Note that `settings` is fixed at construction and is NOT re-applied: a second owner in the
+    /// same process keeps the first one's flush interval and size limits.
+    void restart();
+
     // producer methods
     void push(LogElement && element);
 

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -133,10 +133,11 @@ public:
 
     void shutdown();
 
-    /// Puts the queue back into its constructed state so that it can serve a new owner. Only
-    /// meaningful for queues that outlive their SystemLog, i.e. TextLog's process-wide static one.
-    /// Note that `settings` is fixed at construction and is NOT re-applied: a second owner in the
-    /// same process keeps the first one's flush interval and size limits.
+    /// If a previous owner shut this queue down, puts it back into its constructed state so that
+    /// it can serve a new one; otherwise does nothing. Only meaningful for queues that outlive
+    /// their SystemLog, i.e. TextLog's process-wide static one. Note that `settings` is fixed at
+    /// construction and is NOT re-applied: a second owner in the same process keeps the first
+    /// one's flush interval and size limits.
     void restart();
 
     // producer methods

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -19,6 +19,7 @@
 #include <Interpreters/BlobStorageLog.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/CrashLog.h>
+#include <Databases/IDatabase.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/ErrorLog.h>
 #include <Interpreters/FilesystemCacheLog.h>
@@ -421,6 +422,70 @@ std::vector<ISystemLog *> SystemLogs::getAllLogs() const
     return result;
 }
 
+void removeOrphanedSystemLogData(ContextPtr context, const Poco::Util::AbstractConfiguration & config)
+{
+    /// Every application except the server gets a `system` database with the Memory database
+    /// engine (see loadMetadataSystem), whose table metadata is never written to disk. The data
+    /// directory of a MergeTree system log table is, so after a restart on the same path there is
+    /// a directory that no table can claim: creating the table fails with
+    /// "Directory for table data ... already exists" (InterpreterCreateQuery), the saving thread
+    /// retries in a loop and SYSTEM FLUSH LOGS can block until its timeout. Drop those leftovers.
+    ///
+    /// Atomic and Ordinary system databases keep their metadata and key data by UUID, so they have
+    /// nothing to clean up here -- and DatabaseAtomic::getTableDataPath() throws for a table it
+    /// does not hold.
+    DatabasePtr system_database = DatabaseCatalog::instance().tryGetDatabase(DatabaseCatalog::SYSTEM_DATABASE);
+    if (!system_database || system_database->getEngineName() != "Memory")
+        return;
+
+    auto remove_if_orphaned = [&](const String & table)
+    {
+        /// Best effort: a directory we fail to remove degrades one log, it must not stop startup.
+        try
+        {
+            /// An empty <table></table> would resolve to the database directory itself.
+            if (table.empty() || system_database->isTableExist(table, context))
+                return;
+
+            /// Ask the database for the path, so that this cannot drift from the check in
+            /// InterpreterCreateQuery that fails on it.
+            const String relative_data_path = system_database->getTableDataPath(table);
+            if (relative_data_path.empty())
+                return;
+
+            const std::filesystem::path data_path = std::filesystem::path(context->getPath()) / relative_data_path;
+            if (!std::filesystem::exists(data_path))
+                return;
+
+            LOG_INFO(
+                getLogger("SystemLog"),
+                "Removing orphaned data directory {} left by system log table {}.{}: its metadata did not survive the "
+                "previous run, so the table has to be created anew",
+                data_path.string(),
+                DatabaseCatalog::SYSTEM_DATABASE,
+                table);
+
+            std::filesystem::remove_all(data_path);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    };
+
+    /// createSystemLog() forces every system log into the `system` database, ignoring a custom
+    /// <database>, so only the table name can be redirected.
+#define REMOVE_ORPHANED_SYSTEM_LOG_DATA(log_type, member, descr) \
+    if (config.has(#member)) \
+        remove_if_orphaned(config.getString(#member ".table", #member));
+
+    LIST_OF_ALL_SYSTEM_LOGS(REMOVE_ORPHANED_SYSTEM_LOG_DATA)
+    #if CLICKHOUSE_CLOUD
+        LIST_OF_CLOUD_SYSTEM_LOGS(REMOVE_ORPHANED_SYSTEM_LOG_DATA)
+    #endif
+#undef REMOVE_ORPHANED_SYSTEM_LOG_DATA
+}
+
 bool hasAnySystemLogConfigured(const Poco::Util::AbstractConfiguration & config)
 {
 #define CHECK_HAS_SYSTEM_LOG(log_type, member, descr) \
@@ -556,7 +621,22 @@ void SystemLogs::shutdown()
 {
     auto logs = getAllLogs();
     for (auto & log : logs)
-        log->shutdown();
+    {
+        /// Two callers. The constructor's catch below, where a throw from here would replace the
+        /// real startup error with a misleading teardown one; and
+        /// ContextSharedPart::shutdown() -> DatabaseCatalog::shutdown(callback) -> flushAndShutdown(),
+        /// where an escaping exception aborts DatabaseCatalog::shutdownImpl before it resets the
+        /// singleton, after which every later context in the process fails with "Database catalog
+        /// is initialized twice". Never let one log's shutdown take the rest down with it.
+        try
+        {
+            log->shutdown();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
 }
 
 void SystemLogs::handleCrash()

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -149,6 +149,11 @@ LIST_OF_ALL_SYSTEM_LOGS(FORWARD_DECLARATION)
 /// (e.g. `query_log`, `processors_profile_log`).
 bool hasAnySystemLogConfigured(const Poco::Util::AbstractConfiguration & config);
 
+/// Removes data directories left behind by system log tables of a previous run whose metadata was
+/// not persisted. Only applies to a `system` database with the Memory engine, i.e. every
+/// application except the server. Call before initializeSystemLogs().
+void removeOrphanedSystemLogData(ContextPtr context, const Poco::Util::AbstractConfiguration & config);
+
 /// System logs should be destroyed in destructor of the last Context and before tables,
 ///  because SystemLog destruction makes insert query while flushing data into underlying tables
 class SystemLogs

--- a/src/Interpreters/TextLog.cpp
+++ b/src/Interpreters/TextLog.cpp
@@ -107,6 +107,13 @@ TextLog::TextLog(ContextPtr context_,
                  const SystemLogSettings & settings)
     : SystemLog<TextLogElement>(context_, settings, getLogQueue(settings.queue_settings))
 {
+    /// The queue is process-wide (the logging channel has to reach it without a Context), so it
+    /// outlives the TextLog that consumes it. shutdown() latches it as shut down and nothing used
+    /// to clear that latch, so in a process that builds more than one engine -- chdb opens and
+    /// closes them repeatedly -- every TextLog after the first was dead on arrival: its saving
+    /// thread exited at once, pushes were dropped and SYSTEM FLUSH LOGS failed with ABORTED.
+    /// This instance is a live consumer again, so hand the queue back to it.
+    queue->restart();
 }
 
 }

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -41,6 +41,7 @@ ISOLATED = [
     "test_c_api_query_with_params",
     "test_c_api_stream_insert",
     "test_signal_handler_api",
+    "test_system_logs",
 ]
 
 # Modules covered by the ISOLATED targets above; excluded from the main shards.

--- a/tests/test_system_logs.py
+++ b/tests/test_system_logs.py
@@ -1,0 +1,225 @@
+#!python3
+
+import os
+import tempfile
+import unittest
+
+from chdb.state.sqlitelike import connect
+
+QUERY_LOG_CONFIG = """<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </query_log>
+    <processors_profile_log>
+        <database>system</database>
+        <table>processors_profile_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </processors_profile_log>
+</clickhouse>
+"""
+
+CUSTOM_TABLE_CONFIG = """<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>my_query_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </query_log>
+</clickhouse>
+"""
+
+# text_log only receives anything if a real log channel raises the logger level,
+# so give it a file to write to.
+TEXT_LOG_CONFIG = """<clickhouse>
+    <logger>
+        <log>{log_path}</log>
+        <async>false</async>
+    </logger>
+    <text_log>
+        <database>system</database>
+        <table>text_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </text_log>
+</clickhouse>
+"""
+
+
+def scalar(conn, sql):
+    return str(conn.query(sql, "CSV")).strip()
+
+
+class TestSystemLogs(unittest.TestCase):
+    """System logs configured through a config file must be created and populated
+    on the embedded engine, and the storage path must stay usable for the next
+    engine (chdb-io/chdb-core#222)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmp.name, "db")
+        self.config = self.write_config("logs.xml", QUERY_LOG_CONFIG)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_config(self, name, body):
+        path = os.path.join(self.tmp.name, name)
+        with open(path, "w") as f:
+            f.write(body)
+        return path
+
+    def write_sentinel(self, *parts):
+        directory = os.path.join(self.db_path, *parts)
+        os.makedirs(directory)
+        path = os.path.join(directory, "sentinel.txt")
+        with open(path, "w") as f:
+            f.write("keep me")
+        return path
+
+    def run_marker_query(self, conn, marker):
+        conn.query(f"SELECT '{marker}' AS m", "CSV")
+        conn.query("SYSTEM FLUSH LOGS", "CSV")
+
+    def finished_query(self, conn, marker, table="query_log"):
+        return scalar(
+            conn,
+            f"SELECT query FROM system.{table} "
+            f"WHERE type = 'QueryFinish' AND query LIKE '%{marker}%'",
+        )
+
+    def test_query_log_records_the_query_that_was_run(self):
+        conn = connect(f"{self.db_path}?config-file={self.config}")
+        try:
+            self.run_marker_query(conn, "MARKER_ONE")
+            self.assertEqual(
+                self.finished_query(conn, "MARKER_ONE"),
+                "\"SELECT 'MARKER_ONE' AS m\"",
+            )
+        finally:
+            conn.close()
+
+    def test_processors_profile_log_is_populated(self):
+        conn = connect(f"{self.db_path}?config-file={self.config}")
+        try:
+            conn.query("SELECT count() FROM numbers(1000)", "CSV")
+            conn.query("SYSTEM FLUSH LOGS", "CSV")
+            self.assertGreater(
+                int(scalar(conn, "SELECT count() FROM system.processors_profile_log")),
+                0,
+            )
+        finally:
+            conn.close()
+
+    def test_query_log_works_again_for_a_second_engine_on_the_same_path(self):
+        """A MergeTree system log table leaves a data directory behind that its
+        never-persisted metadata cannot reclaim, so without cleanup the next
+        engine on the same path fails to create the table at all."""
+        first = connect(f"{self.db_path}?config-file={self.config}")
+        try:
+            self.run_marker_query(first, "MARKER_FIRST")
+            self.assertEqual(
+                self.finished_query(first, "MARKER_FIRST"),
+                "\"SELECT 'MARKER_FIRST' AS m\"",
+            )
+        finally:
+            first.close()
+
+        second = connect(f"{self.db_path}?config-file={self.config}")
+        try:
+            self.run_marker_query(second, "MARKER_SECOND")
+            self.assertEqual(
+                self.finished_query(second, "MARKER_SECOND"),
+                "\"SELECT 'MARKER_SECOND' AS m\"",
+            )
+            # The previous engine's rows are gone with its metadata: system log
+            # history does not survive an engine, even on a persistent path.
+            self.assertEqual(
+                scalar(
+                    second,
+                    "SELECT count() FROM system.query_log WHERE query LIKE '%MARKER_FIRST%'",
+                ),
+                "0",
+            )
+        finally:
+            second.close()
+
+    def test_cleanup_only_touches_the_configured_log_table(self):
+        """The config names my_query_log, so only that directory may be removed;
+        a directory named after the default table must be left alone."""
+        config = self.write_config("custom.xml", CUSTOM_TABLE_CONFIG)
+        configured = self.write_sentinel("data", "system", "my_query_log")
+        unconfigured = self.write_sentinel("data", "system", "query_log")
+
+        conn = connect(f"{self.db_path}?config-file={config}")
+        try:
+            self.run_marker_query(conn, "MARKER_CUSTOM")
+            self.assertEqual(
+                self.finished_query(conn, "MARKER_CUSTOM", table="my_query_log"),
+                "\"SELECT 'MARKER_CUSTOM' AS m\"",
+            )
+        finally:
+            conn.close()
+
+        self.assertFalse(os.path.exists(configured))
+        self.assertTrue(os.path.exists(unconfigured))
+        with open(unconfigured) as f:
+            self.assertEqual(f.read(), "keep me")
+
+    def test_text_log_works_in_a_second_engine_in_the_same_process(self):
+        """text_log's queue is a process-wide static; its shutdown latch and its
+        flush bookkeeping used to survive into the next engine, which made
+        SYSTEM FLUSH LOGS fail with ABORTED and left the table uncreated."""
+        log_path = os.path.join(self.tmp.name, "clickhouse.log")
+        config = self.write_config(
+            "text.xml", TEXT_LOG_CONFIG.format(log_path=log_path)
+        )
+
+        first = connect(f"{self.db_path}?config-file={config}")
+        try:
+            first.query("SELECT 'MARKER_TEXT_FIRST' AS m", "CSV")
+            first.query("SYSTEM FLUSH LOGS", "CSV")
+        finally:
+            first.close()
+
+        second = connect(f"{self.db_path}?config-file={config}")
+        try:
+            second.query("SELECT 'MARKER_TEXT_SECOND' AS m", "CSV")
+            # Used to raise "Shutdown has been called" (ABORTED).
+            second.query("SYSTEM FLUSH LOGS", "CSV")
+            self.assertEqual(scalar(second, "EXISTS TABLE system.text_log"), "1")
+            # And the new engine's messages really reach the new consumer.
+            self.assertGreater(
+                int(scalar(second, "SELECT count() FROM system.text_log")), 0
+            )
+        finally:
+            second.close()
+
+    def test_no_system_logs_without_a_config_file(self):
+        conn = connect(self.db_path)
+        try:
+            self.run_marker_query(conn, "MARKER_NONE")
+            self.assertEqual(scalar(conn, "EXISTS TABLE system.query_log"), "0")
+        finally:
+            conn.close()
+
+    def test_config_discovered_from_the_working_directory_does_not_arm_logs(self):
+        """An embedded engine must not spawn flush threads because of a config
+        file that happens to sit in the host process' working directory."""
+        self.write_config("config.xml", QUERY_LOG_CONFIG)
+        cwd = os.getcwd()
+        os.chdir(self.tmp.name)
+        try:
+            conn = connect(self.db_path)
+            try:
+                # SYSTEM FLUSH LOGS forces table creation when logs are armed, so
+                # this assertion can actually fail if the discovery armed them.
+                self.run_marker_query(conn, "MARKER_CWD")
+                self.assertEqual(scalar(conn, "EXISTS TABLE system.query_log"), "0")
+            finally:
+                conn.close()
+        finally:
+            os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes `<query_log>`, `<processors_profile_log>` and the other system log sections work when the engine is driven from Python.

Closes #222.

## Changes

- **`EmbeddedServer::setupSystemLogs()`** initializes system logs at the same point `LocalServer` does, under the same three conditions plus one more: only a config the caller passed explicitly arms them. `EmbeddedServer` also auto-discovers `./config.xml`, `~/.clickhouse-local/config.*` and `/etc/clickhouse-local/config.*`, and an embedded engine should not spawn a flush thread per log because of a file that happens to sit next to the host process. Whether the config was explicit is recorded in `initialize()`, before the file layer is merged in.

- **`removeOrphanedSystemLogData()`** (`src/Interpreters/SystemLog.cpp`, next to `hasAnySystemLogConfigured`) drops the data directory of a configured log table when no attached table owns it. The `system` database is a Memory database for every application except the server, so system log metadata never persists while a MergeTree log table's directory does — and the next engine on that path then cannot create the table (`Code: 57 ... Directory for table data ... already exists`). It only runs for a Memory `system` database, skips empty table names, asks the database for the path so it cannot drift from the check that fails on it, and is best-effort per table. `LocalServer` has the same clash and is still reachable from the C API, so it calls the helper too.

- **`SystemLogQueue::restart()`**, called from `TextLog`'s constructor, hands the process-wide static queue back in its constructed state. Only clearing the shutdown latch is not enough: `prepared_tables` and `flushed_index` also survive, so the next engine's `SYSTEM FLUSH LOGS` would report success without ever creating the table, and undrained elements from the previous engine would be inserted into the new one's table.

- **`SystemLogs::shutdown()` catches per log.** An exception escaping it aborts `DatabaseCatalog::shutdownImpl` before it resets the singleton, after which every later context in the process fails with "Database catalog is initialized twice".

## Tests

`tests/test_system_logs.py`, registered as isolated because it needs its own engine: query_log stores the exact query text, processors_profile_log is populated, a second engine on the same path works (and does not see the first engine's rows), cleanup removes the configured `<table>` directory while leaving a directory named after the default table untouched, text_log survives into a second engine and receives its messages, and neither a missing config nor a config discovered from the working directory creates any log table — both negative tests run `SYSTEM FLUSH LOGS` first so they can actually fail.

## Not covered

- Each configured `PeriodicLog` (`metric_log`, `error_log`, `transposed_metric_log`, `aggregated_zookeeper_log`) adds up to one collect interval — 1 s by default — to engine shutdown: the collector thread is joined while parked in an uninterruptible `sleep_until`.
- A later connection whose `config-file` is discarded because the engine is already running still gets no warning.
- Log rows do not survive an engine. That would need the `system` database to stop being a Memory database.

## Verification

The touched translation units pass `clang -fsyntax-only`; the Python tests have not been run locally (this tree cannot complete a full build for unrelated reasons), so CI is the first real run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Initialize system logs on `EmbeddedServer` only with explicit config file
> - `EmbeddedServer` now records whether `--config-file` was explicitly supplied and initializes system logs only when it was, skipping discovered configs and the `no-system-tables`/`only-system-tables` modes.
> - Adds `SystemLogQueue::restart` so a queue shut down by a previous owner can accept new entries again; `TextLog::TextLog` calls it to support a second engine in the same process.
> - Adds `removeOrphanedSystemLogData` in [SystemLog.cpp](https://github.com/chdb-io/chdb-core/pull/223/files#diff-02543fded55c372fe0f4b432547d205ef3ed48b55717659c7e34d29550c8d9ea) to remove data directories for configured system-log tables whose metadata is absent, applied before initialization for Memory-backed system databases; `LocalServer` gets the same cleanup.
> - `SystemLogs::shutdown` now catches per-log exceptions so one failure does not stop remaining shutdowns.
> - Adds [test_system_logs.py](https://github.com/chdb-io/chdb-core/pull/223/files#diff-b1d1f045cc0f0407aa56aa7612297d997fdd36f87cdc1ea9ee7cb82e610c10ea) covering query log, processors profile log, second-engine reuse, orphan cleanup, and config-discovery suppression; runs as an isolated test target.
> - Behavioral Change: system logs no longer initialize when `EmbeddedServer` discovers a config from the working directory instead of receiving an explicit `--config-file`; callers that relied on discovered configs arming system logs will no longer get them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56cd2cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->