### PR TITLE
Stop taking the host's deadly signal handlers on every connect

### DIFF
--- a/base/poco/Util/src/Application.cpp
+++ b/base/poco/Util/src/Application.cpp
@@ -35,9 +35,6 @@
 #include "Poco/String.h"
 #include "Poco/ConsoleChannel.h"
 #include "Poco/AutoPtr.h"
-#if defined(POCO_OS_FAMILY_UNIX) && !defined(POCO_VXWORKS)
-#include "Poco/SignalHandler.h"
-#endif
 
 
 using Poco::Logger;
@@ -99,9 +96,14 @@ void Application::setup()
 #if defined(POCO_OS_FAMILY_UNIX) && !defined(POCO_VXWORKS)
 	_workingDirAtLaunch = Path::current();
 
-	#if !defined(_DEBUG)
-	Poco::SignalHandler::install();
-	#endif
+	/// Poco::SignalHandler::install() is deliberately not called here. It sigactions
+	/// SIGILL/SIGBUS/SIGSEGV/SIGSYS process-wide from this constructor, so constructing
+	/// any Application took those four signals away from whoever owned them -- including
+	/// the process embedding libchdb, and without consulting
+	/// HandledSignals::disable_signal_handlers. The handler it installs cannot do anything
+	/// useful either: it siglongjmps to a buffer registered by poco_throw_on_signal, which
+	/// has no users here, so it always falls through to std::abort(). Deadly signals are
+	/// handled by HandledSignals::setupCommonDeadlySignalHandlers() instead.
 #else
 	setUnixOptions(false);
 #endif

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -156,27 +156,18 @@ std::unique_ptr<MaterializedQueryResult> pyEntryClickHouseLocal(int argc, char *
             result = std::make_unique<MaterializedQueryResult>(app.getErrorMsg());
         }
 
-        if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
-            chdb_reset_signal_handlers();
-
         return result;
     }
     catch (const DB::Exception & e)
     {
-        if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
-            chdb_reset_signal_handlers();
         throw std::domain_error(DB::getExceptionMessage(e, false));
     }
     catch (const boost::program_options::error & e)
     {
-        if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
-            chdb_reset_signal_handlers();
         throw std::invalid_argument("Bad arguments: " + std::string(e.what()));
     }
     catch (...)
     {
-        if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
-            chdb_reset_signal_handlers();
         throw std::domain_error(DB::getCurrentExceptionMessage(true));
     }
 }
@@ -232,9 +223,6 @@ chdb_connection * connect_chdb_with_exception(int argc, char ** argv)
         conn->server = client.get();
         conn->connected = true;
         auto conn_ptr = std::make_unique<chdb_conn *>(conn.get());
-
-        if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
-            chdb_reset_signal_handlers();
 
         client.release();
         conn.release();
@@ -544,12 +532,7 @@ chdb_connection * chdb_connect(int argc, char ** argv)
 {
     try
     {
-        auto * conn = connect_chdb_with_exception(argc, argv);
-
-        if (HandledSignals::disable_signal_handlers.load(std::memory_order_relaxed))
-            chdb_reset_signal_handlers();
-
-        return conn;
+        return connect_chdb_with_exception(argc, argv);
     }
     catch (const DB::Exception & e)
     {
@@ -1605,7 +1588,11 @@ chdb_state chdb_shutdown(void)
 
 void chdb_reset_signal_handlers(void)
 {
-    static constexpr int deadly_signals[] = {SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGTSTP, SIGTRAP};
+    /// No instance means chDB never installed a handler, so there is nothing of ours
+    /// to take back. Do not construct the singleton just to find that out.
+    auto * instance = HandledSignals::tryGetInstance();
+    if (!instance)
+        return;
 
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
@@ -1616,17 +1603,26 @@ void chdb_reset_signal_handlers(void)
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
 
-    for (int sig : deadly_signals)
-        sigaction(sig, &sa, nullptr);
+    /// Serialize against concurrent appends in addSignalHandler(), which a query or a
+    /// connect on another thread can be doing right now, and against other concurrent
+    /// callers. This is a leaf lock: nothing is acquired while holding it.
+    std::lock_guard<std::mutex> lock(instance->handled_signals_mutex);
 
-    if (auto * instance = HandledSignals::tryGetInstance())
+    /// Only the signals chDB actually installed a handler for. Resetting a fixed list of
+    /// deadly signals instead would hand SIG_DFL to signals the embedding process owns,
+    /// which is fatal for a host that recovers from them as a matter of course -- a JVM
+    /// turns SIGSEGV into NullPointerException and SIGFPE into ArithmeticException.
+    /// setupCommonDeadlySignalHandlers() appends the same signals again on every call,
+    /// so walk the list through a seen-set to keep this linear in signals, not in calls.
+    sigset_t already_reset;
+    sigemptyset(&already_reset);
+    for (int sig : instance->handled_signals)
     {
-        /// Serialize the clear against concurrent appends in addSignalHandler()
-        /// (e.g. the EmbeddedServer connect path, which runs outside CHDB_MUTEX) and
-        /// against other concurrent chdb_reset_signal_handlers() callers. This leaf lock
-        /// is acquired last and released here, so it cannot deadlock with CHDB_MUTEX even
-        /// when this function is called while CHDB_MUTEX is held (pyEntryClickHouseLocal).
-        std::lock_guard<std::mutex> lock(instance->handled_signals_mutex);
-        instance->handled_signals.clear();
+        if (sigismember(&already_reset, sig) == 1)
+            continue;
+        sigaddset(&already_reset, sig);
+        sigaction(sig, &sa, nullptr);
     }
+
+    instance->handled_signals.clear();
 }

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -1045,14 +1045,26 @@ CHDB_EXPORT chdb_state chdb_classify_query_n(
  * Call BEFORE chdb_connect() or query_stable() to prevent chDB
  * from installing process-wide signal handlers.
  *
+ * While disabled, no chDB entry point changes the disposition of any signal,
+ * so a host that handles deadly signals itself -- a JVM recovering from SIGSEGV
+ * as a NullPointerException, for instance -- keeps its handlers across every
+ * call. Switching to 0 also takes back the handlers chDB installed while it was
+ * enabled, as chdb_reset_signal_handlers() does.
+ *
+ * The flag is process-wide and sticky; one call per process is enough.
+ *
  * @param enabled 1 to enable signal handlers (default), 0 to disable them
  */
 CHDB_EXPORT void chdb_set_signal_handlers_enabled(int enabled);
 
 /**
- * Resets all signal handlers installed by chDB back to SIG_DFL.
+ * Resets the signal handlers installed by chDB back to SIG_DFL.
  * Useful when signal handlers were already installed and need to be removed,
  * e.g. to let the embedding process manage its own signal handling.
+ *
+ * Only signals chDB installed a handler for are touched; a handler owned by the
+ * embedding process is left in place. When chDB installed nothing, this is a
+ * no-op.
  */
 CHDB_EXPORT void chdb_reset_signal_handlers(void);
 

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -351,15 +351,25 @@ void HandledSignals::addSignalHandler(
             throw Poco::Exception("Cannot set signal handler.");
 #endif
 
+    /// Install and record under one lock. chdb_reset_signal_handlers() takes the same lock
+    /// to walk `handled_signals` and undo exactly what is recorded there, so an install that
+    /// reached the OS while that walk was reading a vector it had not been appended to yet
+    /// would leave a chDB handler live in a process that had just opted out. The flag is
+    /// re-read here for the same reason: setupCommonDeadlySignalHandlers() checks it before
+    /// calling, but an opt-out arriving after that check must still win, and
+    /// chdb_set_signal_handlers_enabled() stores the flag before taking this lock -- so
+    /// whichever of the two reaches the lock first, the other sees a decided state.
+    std::lock_guard<std::mutex> lock(handled_signals_mutex);
+
+    if (disable_signal_handlers.load(std::memory_order_relaxed))
+        return;
+
     for (auto signal : signals)
         if (sigaction(signal, &sa, nullptr))
             throw Poco::Exception("Cannot set signal handler.");
 
     if (register_signal)
-    {
-        std::lock_guard<std::mutex> lock(handled_signals_mutex);
         std::copy(signals.begin(), signals.end(), std::back_inserter(handled_signals));
-    }
 #endif
 }
 

--- a/tests/test_signal_handler_api.py
+++ b/tests/test_signal_handler_api.py
@@ -9,6 +9,7 @@ These tests verify that:
 2. set_signal_handlers_enabled(0) prevents handler installation AND removes existing ones.
 3. reset_signal_handlers() restores SIG_DFL for all chDB-managed signals.
 4. Re-enabling after disable works correctly.
+5. While disabled, no chDB entry point touches a handler the host process owns.
 """
 
 import ctypes
@@ -230,7 +231,56 @@ chdb._chdb.set_signal_handlers_enabled(0)
         )
         self.assertEqual(proc.returncode, 0, proc.stderr)
 
-    # Test 7: concurrent enable/disable calls are thread-safe
+    # Test 7: a disabled chDB must not disturb a handler the host owns
+    def test_disabled_chdb_preserves_host_deadly_signal_handlers(self):
+        """No chDB entry point may change a deadly-signal disposition while disabled.
+
+        A host that recovers from deadly signals -- a JVM turning SIGSEGV into
+        NullPointerException -- is killed outright if its handler is replaced, even
+        for the span of one call, so the assertion is on the exact handler address
+        rather than merely on one being present.
+        """
+        import chdb
+
+        self._chdb.set_signal_handlers_enabled(0)
+        self._chdb.reset_signal_handlers()
+
+        watched = [signal.SIGSEGV, signal.SIGBUS, signal.SIGILL, signal.SIGFPE]
+        saved = {sig: signal.getsignal(sig) for sig in watched}
+        for sig in watched:
+            signal.signal(sig, lambda *_: None)
+
+        host_handlers = {sig: _get_sigaction_handler(sig) for sig in watched}
+        for sig, handler in host_handlers.items():
+            self.assertNotEqual(handler, 0,
+                f"precondition: host handler must be installed for signal {sig}")
+
+        def assert_host_handlers_intact(after):
+            for sig, expected in host_handlers.items():
+                self.assertEqual(_get_sigaction_handler(sig), expected,
+                    f"{after} replaced the host handler for signal {sig}")
+
+        try:
+            chdb.query("SELECT 1", "CSV")
+            assert_host_handlers_intact("chdb.query()")
+
+            conn = chdb.connect(":memory:")
+            try:
+                assert_host_handlers_intact("chdb.connect()")
+                self.assertEqual(str(conn.query("SELECT 1", "CSV")).strip(), "1")
+                assert_host_handlers_intact("a query on a connection")
+            finally:
+                conn.close()
+            assert_host_handlers_intact("closing a connection")
+
+            self._chdb.reset_signal_handlers()
+            assert_host_handlers_intact("reset_signal_handlers()")
+        finally:
+            for sig, previous in saved.items():
+                signal.signal(sig, previous)
+            self._chdb.set_signal_handlers_enabled(1)
+
+    # Test 8: concurrent enable/disable calls are thread-safe
     def test_concurrent_enable_disable_no_crash(self):
         """Calling set_signal_handlers_enabled from multiple threads must not crash."""
         import threading


### PR DESCRIPTION
Closes #221.

`chdb_set_signal_handlers_enabled(0)` promises to keep chDB from installing
process-wide signal handlers, but a host that opted out still lost its own SIGSEGV,
SIGBUS, SIGILL and SIGSYS handlers on every `chdb_connect()`. A JVM turns SIGSEGV into
NullPointerException and writes `hs_err_pid*.log` from the handler being removed, so
the kill leaves no diagnostic (chdb-io/chdb-java#14).

Two causes:

- `Poco::Util::Application::setup()` sigactions those four signals from the Application
  constructor, ignoring `HandledSignals::disable_signal_handlers`. `EmbeddedServer` is a
  refcounted singleton, so a connection pool re-took them on every connect cycle. The
  handler is useless anyway: it siglongjmps to a buffer registered by
  `poco_throw_on_signal`, a macro with no users in this tree, so it always falls through
  to `std::abort()`. On the enabled path `setupCommonDeadlySignalHandlers()` overwrote it
  moments later, so not installing it leaves steady state unchanged.
- `chdb_reset_signal_handlers()` reset a fixed list of eight deadly signals to `SIG_DFL`
  without consulting `handled_signals`, chDB's own record of what it installed, so it
  could not tell its handlers from the host's. It now walks that record, through a
  `sigset_t` seen-set since `setupCommonDeadlySignalHandlers()` appends on every call.

With no ungated installer left, the resets running on every query and every connect had
nothing of chDB's to take back and were pure exposure windows, so they go. Removing them
without the Poco fix would be worse than the bug — the host would keep Poco's
abort-handler permanently instead of losing its own for a window. The reset inside
`chdb_set_signal_handlers_enabled(0)` stays; there the caller is asking for it.

The existing tests only assert `SIG_DFL`, which they reach *because* of those
per-connect resets, so they guard the Poco half. The new test asserts on a handler the
host owns, comparing its exact address across query, connect, a query on the connection,
close and an explicit reset. One `chdb.query()` is enough to fail it before this change:

```
AssertionError: 0 != 4356383956 : chdb.query() replaced the host handler for signal 11
```

Verified on macOS arm64 against a baseline built from the same source with only the two
source files reverted: signal suite 7 passed/1 failed → 8 passed, `pytest tests/`
unchanged at 10 failed, 1264 passed, 59 skipped, 2 errors. The lists differ by the new
test and by `test_query_pyarrow_table1`, which is pre-existing and order-dependent —
with the whole suite collected but only that test selected it fails identically on both,
`EmbeddedServer already initialized with path ':memory:'`.

Not included: restoring the host's *previous* disposition instead of `SIG_DFL` needs
`addSignalHandler()` to record the old `struct sigaction`, which is shared ClickHouse
code reached from the sanitizer death callback where allocation is forbidden. Separate
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop overriding host deadly-signal handlers on every chDB connect and query
> - Removes Poco's legacy signal-handler installation from `Application::setup()` so constructing a Poco Application no longer installs handlers for SIGILL, SIGBUS, SIGSEGV, and SIGSYS as a side effect
> - Removes per-connect and per-query signal-handler resets from `chdb_connect`, `connect_chdb_with_exception`, and `pyEntryClickHouseLocal`; reset is now left to the explicit signal-control path
> - Reworks `chdb_reset_signal_handlers()` to reset only signals that chDB actually installed (tracked via the `HandledSignals` singleton), no-op when nothing was installed, and mutex-protected against concurrent registration
> - `HandledSignals::addSignalHandler()` now rechecks `disable_signal_handlers` under a shared mutex and skips OS disposition changes when disabled, so installation and reset are mutually exclusive
> - Behavioral Change: `chdb_reset_signal_handlers()` and `addSignalHandler()` now serialize on a new mutex; any out-of-tree code relying on the old unconditional eight-signal reset list will only reset signals chDB recorded as installed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92b5499.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->