### PR TITLE
Add chdb_insert_arrow_array/stream C ABI for name-mapped Arrow ingest.

### DIFF
--- a/bindings.md
+++ b/bindings.md
@@ -12,6 +12,7 @@ chDB exposes four main capabilities through its C API ([`chdb.h`](programs/local
 | **Session (Connection)** | `chdb_connect()` / `chdb_query()` | Persistent connection with reusable engine context. Supports multi-statement workflows. |
 | **Streaming Query** | `chdb_stream_query()` / `chdb_stream_fetch_result()` | Chunked result iteration with constant memory usage. Ideal for large result sets that should not be fully materialized. |
 | **Arrow Scan** | `chdb_arrow_scan()` / `chdb_arrow_array_scan()` | Register Arrow streams or arrays as queryable table functions. Enables zero-copy data exchange with Arrow-native ecosystems. |
+| **Arrow Insert** | `chdb_insert_arrow_array()` / `chdb_insert_arrow_stream()` | One-shot insert from Arrow C Data Interface into a MergeTree (or compatible) table. Matches columns by name. |
 
 ### Feature Matrix
 
@@ -114,6 +115,7 @@ All bindings wrap the same stable C API defined in [`chdb.h`](programs/local/chd
 1. **Session** — Wrap `chdb_connect()`, `chdb_query()`, and `chdb_close_conn()`.
 2. **Streaming** — Wrap `chdb_stream_query()`, `chdb_stream_fetch_result()`, and `chdb_stream_cancel_query()`.
 3. **Arrow Scan** — Wrap `chdb_arrow_scan()` / `chdb_arrow_array_scan()` and `chdb_arrow_unregister_table()`.
+4. **Arrow Insert** — Wrap `chdb_insert_arrow_array()` / `chdb_insert_arrow_stream()`.
 
 ### Need Help?
 

--- a/chdb/libchdb_export.map
+++ b/chdb/libchdb_export.map
@@ -59,6 +59,8 @@
         chdb_arrow_scan;
         chdb_arrow_array_scan;
         chdb_arrow_unregister_table;
+        chdb_insert_arrow_array;
+        chdb_insert_arrow_stream;
         chdb_query_arrow;
         chdb_query_arrow_n;
         chdb_stream_query_arrow;

--- a/chdb/libchdb_export_macos.txt
+++ b/chdb/libchdb_export_macos.txt
@@ -53,6 +53,8 @@ _chdb_version
 _chdb_arrow_scan
 _chdb_arrow_array_scan
 _chdb_arrow_unregister_table
+_chdb_insert_arrow_array
+_chdb_insert_arrow_stream
 _chdb_query_arrow
 _chdb_query_arrow_n
 _chdb_stream_query_arrow

--- a/examples/chdbArrowTest.c
+++ b/examples/chdbArrowTest.c
@@ -968,6 +968,88 @@ void test_arrow_array_scan(chdb_connection conn)
     if (schema3.release) schema3.release(&schema3);
 }
 
+void test_arrow_insert(chdb_connection conn)
+{
+    struct ArrowSchema schema;
+    struct ArrowArray array;
+    chdb_result * create_result;
+    chdb_result * insert_result;
+    chdb_result * select_result;
+    chdb_result * count_result;
+    chdb_result * err_result;
+    chdb_arrow_insert_options opts;
+    struct ArrowArrayStream stream;
+    CustomStreamData * stream_data;
+    const char * error;
+
+    printf("\n=== Testing Arrow Insert Functions ===\n");
+
+    create_result = chdb_query(
+        conn,
+        "CREATE TABLE arrow_insert_dest (id Int64, extra String DEFAULT '', value String) ENGINE=Memory",
+        "CSV");
+    test_assert_no_error(create_result, "CREATE TABLE arrow_insert_dest");
+    chdb_destroy_query_result(create_result);
+
+    create_schema(&schema);
+    memset(&array, 0, sizeof(array));
+    create_arrow_array(&array, 1000);
+
+    /* Name mapping: table has `extra` between id and value; Arrow has (id, value). */
+    insert_result = chdb_insert_arrow_array(
+        conn, "arrow_insert_dest",
+        (chdb_arrow_schema)&schema, (chdb_arrow_array)&array, NULL);
+    test_assert_no_error(insert_result, "chdb_insert_arrow_array into arrow_insert_dest");
+    chdb_destroy_query_result(insert_result);
+
+    count_result = chdb_query(conn, "SELECT count() FROM arrow_insert_dest", "CSV");
+    test_assert_row_count(count_result, 1000, "Inserted row count");
+    chdb_destroy_query_result(count_result);
+
+    select_result = chdb_query(
+        conn, "SELECT id, extra, value FROM arrow_insert_dest ORDER BY id LIMIT 1", "TabSeparated");
+    test_assert_query_result_contains(select_result, "0\t\tvalue_0", "Name mapping leaves extra defaulted");
+    chdb_destroy_query_result(select_result);
+
+    err_result = chdb_insert_arrow_array(NULL, "arrow_insert_dest",
+        (chdb_arrow_schema)&schema, (chdb_arrow_array)&array, NULL);
+    error = chdb_result_error(err_result);
+    test_assert(error != NULL, "Null connection insert returns error", error ? error : "no error");
+    chdb_destroy_query_result(err_result);
+
+    create_result = chdb_query(
+        conn,
+        "CREATE TABLE arrow_insert_stream_dest (id Int64, value String) ENGINE=Memory",
+        "CSV");
+    test_assert_no_error(create_result, "CREATE TABLE arrow_insert_stream_dest");
+    chdb_destroy_query_result(create_result);
+
+    memset(&stream, 0, sizeof(stream));
+    stream_data = (CustomStreamData *)malloc(sizeof(CustomStreamData));
+    init_custom_stream_data(stream_data);
+    stream_data->total_rows = 250;
+    stream_data->batch_size = 50;
+    stream.get_schema = custom_get_schema;
+    stream.get_next = custom_get_next;
+    stream.get_last_error = custom_get_last_error;
+    stream.release = custom_release;
+    stream.private_data = stream_data;
+
+    opts.settings = "max_threads=2";
+    insert_result = chdb_insert_arrow_stream(
+        conn, "arrow_insert_stream_dest", (chdb_arrow_stream)&stream, &opts);
+    test_assert_no_error(insert_result, "chdb_insert_arrow_stream into arrow_insert_stream_dest");
+    chdb_destroy_query_result(insert_result);
+
+    count_result = chdb_query(conn, "SELECT count() FROM arrow_insert_stream_dest", "CSV");
+    test_assert_row_count(count_result, 250, "Stream insert row count");
+    chdb_destroy_query_result(count_result);
+
+    if (array.release) array.release(&array);
+    if (schema.release) schema.release(&schema);
+    if (stream.release) stream.release(&stream);
+}
+
 int main(void)
 {
     char * argv[] = {"clickhouse", "--multiquery"};
@@ -990,6 +1072,7 @@ int main(void)
     /* Run test suites */
     test_arrow_scan(conn);
     test_arrow_array_scan(conn);
+    test_arrow_insert(conn);
 
     /* Clean up */
     chdb_close_conn(conn_ptr);

--- a/programs/local/CMakeLists.txt
+++ b/programs/local/CMakeLists.txt
@@ -30,6 +30,7 @@ else()
     # so the wheel doubles as the ADBC driver.
     set (CHDB_ARROW_SOURCES
         chdb-arrow.cpp
+        chdb-arrow-insert.cpp
         chdb-arrow-output.cpp
         chdb-adbc.cpp
         ArrowStreamSource.cpp

--- a/programs/local/chdb-arrow-insert.cpp
+++ b/programs/local/chdb-arrow-insert.cpp
@@ -1,0 +1,225 @@
+#include "chdb.h"
+#include "chdb-internal.h"
+#include "ChdbClient.h"
+#include "QueryResult.h"
+
+#include <Common/Exception.h>
+
+#include <arrow/c/abi.h>
+
+#include <atomic>
+#include <cstring>
+#include <memory>
+#include <string>
+
+using namespace DB;
+
+namespace
+{
+
+std::atomic<uint64_t> g_insert_stream_seq{0};
+
+String nextInternalStreamName()
+{
+    return "__chdb_ins_" + std::to_string(g_insert_stream_seq.fetch_add(1, std::memory_order_relaxed));
+}
+
+String escapeStreamNameForSql(const String & name)
+{
+    String escaped;
+    escaped.reserve(name.size());
+    for (char c : name)
+    {
+        if (c == '\'')
+            escaped += "''";
+        else
+            escaped += c;
+    }
+    return escaped;
+}
+
+String quoteIdent(const char * name)
+{
+    String out = "`";
+    for (const char * p = name; *p; ++p)
+    {
+        if (*p == '`')
+            out += "``";
+        else
+            out += *p;
+    }
+    out += '`';
+    return out;
+}
+
+/// `(col1, col2, ...)` from an Arrow struct schema so INSERT maps by name.
+/// Empty when any child is unnamed — callers then fall back to position mapping.
+String columnListFromArrowSchema(const ArrowSchema * schema)
+{
+    if (!schema || schema->n_children <= 0)
+        return {};
+
+    String cols;
+    for (int64_t i = 0; i < schema->n_children; ++i)
+    {
+        const ArrowSchema * child = schema->children[static_cast<size_t>(i)];
+        if (!child || !child->name || child->name[0] == '\0')
+            return {};
+        if (i)
+            cols += ", ";
+        cols += quoteIdent(child->name);
+    }
+    return " (" + cols + ")";
+}
+
+String columnListFromStream(chdb_arrow_stream arrow_stream)
+{
+    auto * stream = reinterpret_cast<ArrowArrayStream *>(arrow_stream);
+    if (!stream || !stream->get_schema)
+        return {};
+
+    ArrowSchema schema;
+    std::memset(&schema, 0, sizeof(schema));
+    if (stream->get_schema(stream, &schema) != 0)
+        return {};
+
+    String cols = columnListFromArrowSchema(&schema);
+    if (schema.release)
+        schema.release(&schema);
+    return cols;
+}
+
+chdb_result * makeErrorResult(String message)
+{
+    return reinterpret_cast<chdb_result *>(new CHDB::MaterializedQueryResult(std::move(message)));
+}
+
+struct UnregisterGuard
+{
+    chdb_connection conn;
+    String name;
+
+    ~UnregisterGuard()
+    {
+        if (!name.empty())
+            chdb_arrow_unregister_table(conn, name.c_str());
+    }
+};
+
+chdb_result * runArrowInsert(
+    chdb_connection conn,
+    const char * dest_table,
+    const String & stream_name,
+    const String & column_list,
+    const chdb_arrow_insert_options * options)
+{
+    if (!dest_table || dest_table[0] == '\0')
+        return makeErrorResult("Unexpected null dest_table");
+
+    auto * connection = reinterpret_cast<chdb_conn *>(conn);
+    if (!checkConnectionValidity(connection))
+        return makeErrorResult("Invalid or closed connection");
+
+    String sql = "INSERT INTO ";
+    sql += dest_table;
+    sql += column_list;
+    sql += " SELECT * FROM ArrowStream('";
+    sql += escapeStreamNameForSql(stream_name);
+    sql += "')";
+
+    if (options && options->settings && options->settings[0] != '\0')
+    {
+        sql += " SETTINGS ";
+        sql += options->settings;
+    }
+
+    auto * client = static_cast<ChdbClient *>(connection->server);
+    auto query_result = client->executeMaterializedQuery(
+        sql.data(), sql.size(),
+        "Null", std::strlen("Null"));
+
+    if (!query_result)
+        return makeErrorResult("Insert query processing failed");
+
+    if (!query_result->getError().empty())
+        return makeErrorResult(query_result->getError());
+
+    return reinterpret_cast<chdb_result *>(query_result.release());
+}
+
+} // namespace
+
+extern "C" {
+
+chdb_result * chdb_insert_arrow_array(
+    chdb_connection conn,
+    const char * dest_table,
+    chdb_arrow_schema arrow_schema,
+    chdb_arrow_array arrow_array,
+    const chdb_arrow_insert_options * options)
+{
+    if (!conn)
+        return makeErrorResult("Unexpected null connection");
+    if (!arrow_schema || !arrow_array)
+        return makeErrorResult("Unexpected null Arrow schema or array");
+
+    try
+    {
+        String stream_name = nextInternalStreamName();
+        String column_list = columnListFromArrowSchema(reinterpret_cast<const ArrowSchema *>(arrow_schema));
+        if (chdb_arrow_array_scan(conn, stream_name.c_str(), arrow_schema, arrow_array) != CHDBSuccess)
+            return makeErrorResult("Failed to register Arrow array for insert");
+
+        UnregisterGuard guard{conn, stream_name};
+        return runArrowInsert(conn, dest_table, stream_name, column_list, options);
+    }
+    catch (const Exception & e)
+    {
+        return makeErrorResult(getExceptionMessage(e, false));
+    }
+    catch (const std::exception & e)
+    {
+        return makeErrorResult(e.what());
+    }
+    catch (...)
+    {
+        return makeErrorResult(DB::getCurrentExceptionMessage(true));
+    }
+}
+
+chdb_result * chdb_insert_arrow_stream(
+    chdb_connection conn,
+    const char * dest_table,
+    chdb_arrow_stream arrow_stream,
+    const chdb_arrow_insert_options * options)
+{
+    if (!conn)
+        return makeErrorResult("Unexpected null connection");
+    if (!arrow_stream)
+        return makeErrorResult("Unexpected null Arrow stream");
+
+    try
+    {
+        String stream_name = nextInternalStreamName();
+        String column_list = columnListFromStream(arrow_stream);
+        if (chdb_arrow_scan(conn, stream_name.c_str(), arrow_stream) != CHDBSuccess)
+            return makeErrorResult("Failed to register Arrow stream for insert");
+
+        UnregisterGuard guard{conn, stream_name};
+        return runArrowInsert(conn, dest_table, stream_name, column_list, options);
+    }
+    catch (const Exception & e)
+    {
+        return makeErrorResult(getExceptionMessage(e, false));
+    }
+    catch (const std::exception & e)
+    {
+        return makeErrorResult(e.what());
+    }
+    catch (...)
+    {
+        return makeErrorResult(DB::getCurrentExceptionMessage(true));
+    }
+}
+
+} // extern "C"

--- a/programs/local/chdb.cpp
+++ b/programs/local/chdb.cpp
@@ -55,6 +55,10 @@ namespace CHDB
 extern "C"
 {
     extern chdb_state chdb_arrow_scan(chdb_connection, const char *, chdb_arrow_stream);
+    extern chdb_result * chdb_insert_arrow_array(
+        chdb_connection, const char *, chdb_arrow_schema, chdb_arrow_array, const chdb_arrow_insert_options *);
+    extern chdb_result * chdb_insert_arrow_stream(
+        chdb_connection, const char *, chdb_arrow_stream, const chdb_arrow_insert_options *);
     extern chdb_result * chdb_query_arrow(chdb_connection, const char *, chdb_arrow_stream, const chdb_arrow_options *);
     extern chdb_result * chdb_query_arrow_n(chdb_connection, const char *, size_t, chdb_arrow_stream, const chdb_arrow_options *);
     extern chdb_result * chdb_stream_query_arrow(chdb_connection, const char *, const chdb_arrow_options *);
@@ -66,13 +70,15 @@ extern "C"
     extern unsigned char chdb_adbc_init(int, void *, void *);
 }
 
-/// Force-link references: chdb-arrow.cpp.o and chdb-arrow-output.cpp.o each
-/// live in their own translation unit and have no internal callers, so the
-/// linker would discard them under --gc-sections / .a archive semantics
-/// when libchdb.so is linked from main.cpp's perspective. Taking the
-/// address of one entry point from each .o keeps the whole .o alive.
+/// Force-link references: chdb-arrow.cpp.o, chdb-arrow-insert.cpp.o and
+/// chdb-arrow-output.cpp.o each live in their own translation unit and have
+/// no internal callers, so the linker would discard them under --gc-sections /
+/// .a archive semantics when libchdb.so is linked from main.cpp's perspective.
+/// Taking the address of one entry point from each .o keeps the whole .o alive.
 [[maybe_unused]] void * force_link_arrow_functions[] = {
     reinterpret_cast<void*>(chdb_arrow_scan),
+    reinterpret_cast<void*>(chdb_insert_arrow_array),
+    reinterpret_cast<void*>(chdb_insert_arrow_stream),
     reinterpret_cast<void*>(chdb_query_arrow),
     reinterpret_cast<void*>(chdb_query_arrow_n),
     reinterpret_cast<void*>(chdb_stream_query_arrow),

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -900,6 +900,43 @@ CHDB_EXPORT chdb_state chdb_arrow_array_scan(
  */
 CHDB_EXPORT chdb_state chdb_arrow_unregister_table(chdb_connection conn, const char * table_name);
 
+/**
+ * Options for direct Arrow insert APIs.
+ */
+typedef struct chdb_arrow_insert_options
+{
+    /// Optional INSERT SETTINGS clause body, e.g. "max_threads=4,min_insert_block_size_rows=65536".
+    /// Pass NULL for engine defaults.
+    const char * settings;
+} chdb_arrow_insert_options;
+
+/**
+ * Insert rows from an Arrow C Data Interface schema+array directly into a
+ * MergeTree (or compatible) table. Combines register, INSERT … SELECT, and
+ * unregister in one call. Destination columns are matched by name from the
+ * Arrow schema (not by position), so ALTER TABLE ADD COLUMN is safe.
+ *
+ * @param conn Active connection
+ * @param dest_table Destination table identifier (bare name or already-quoted)
+ * @param arrow_schema Arrow schema pointer
+ * @param arrow_array Arrow array pointer
+ * @param options Optional insert settings; pass NULL for defaults
+ * @return chdb_result with metrics or error (no result buffer on success)
+ */
+CHDB_EXPORT chdb_result * chdb_insert_arrow_array(
+    chdb_connection conn, const char * dest_table,
+    chdb_arrow_schema arrow_schema, chdb_arrow_array arrow_array,
+    const chdb_arrow_insert_options * options);
+
+/**
+ * Insert rows from an Arrow C Data Interface stream directly into a destination table.
+ * See chdb_insert_arrow_array for semantics.
+ */
+CHDB_EXPORT chdb_result * chdb_insert_arrow_stream(
+    chdb_connection conn, const char * dest_table,
+    chdb_arrow_stream arrow_stream,
+    const chdb_arrow_insert_options * options);
+
 //===--------------------------------------------------------------------===//
 // Backup, Restore and Statement Classification
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry 
Added `chdb_insert_arrow_array` and `chdb_insert_arrow_stream` to the C API, so language bindings can insert Arrow C Data Interface batches into a table in one call. Destination columns are matched by name, not position, so `ALTER TABLE ADD COLUMN` does not scatter values.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chdb_insert_arrow_array` and `chdb_insert_arrow_stream` C ABI for name-mapped Arrow ingest
> - Adds two one-shot C entrypoints that insert an Arrow array or Arrow stream into a destination table via an internal temporary table function and `INSERT SELECT`, with optional settings and standard query-result error handling.
> - When the Arrow schema has named fields, columns are matched by name; when names are missing, insertion falls back to positional mapping.
> - Registers temporary Arrow data per-call with an atomic-unique stream name and an `UnregisterGuard` that cleans up on all paths.
> - Exports both symbols in the Linux and macOS shared-library export maps and adds force-link anchors so the new translation unit is retained.
> - Adds an integration test exercising array and stream inserts, default-column values, insert settings, and null-connection error handling.
> - Risk: `columnListFromArrowSchema` returns an empty list for schemas with any unnamed child, silently switching to positional insertion; verify column order matches the destination table in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08bf9c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->