### PR TITLE
ADBC: read-only connections, statement cancellation, and bounded reads

### DIFF
--- a/bindings.md
+++ b/bindings.md
@@ -112,6 +112,17 @@ You can check if the `error_message` field is `NULL` to determine if an error oc
 All bindings wrap the same stable C API defined in [`chdb.h`](programs/local/chdb.h):
 
 1. **Session** — Wrap `chdb_connect()`, `chdb_query()`, and `chdb_close_conn()`.
+   The engine starts on the first connection and shuts down when the last one
+   closes, and it is meant to start once per process: cycling it repeatedly is
+   known to corrupt the process allocator on macOS and abort. This is why the
+   test suite gives every test that opens a second storage path its own process
+   (the `ISOLATED` list in [`tests/run_all.py`](tests/run_all.py)) and why the
+   ADBC conformance suite runs one case per process
+   (`programs/local/adbc/validation/run.sh`). A binding that pools connections
+   should keep one alive outside the pool for the host's lifetime — a pool
+   configured to drop to zero idle connections, or one whose maximum-lifetime
+   policy retires the last connection, cycles the engine on a schedule with
+   nothing reporting it.
 2. **Streaming** — Wrap `chdb_stream_query()`, `chdb_stream_fetch_result()`, and `chdb_stream_cancel_query()`.
 3. **Arrow Scan** — Wrap `chdb_arrow_scan()` / `chdb_arrow_array_scan()` and `chdb_arrow_unregister_table()`.
 

--- a/docs/adbc.rst
+++ b/docs/adbc.rst
@@ -10,6 +10,69 @@ to ``libchdb.so``:
    driver     = /path/to/libchdb.so
    entrypoint = chdb_adbc_init
 
+Read-Only Connections
+---------------------
+
+Setting the standard ``adbc.connection.readonly`` option puts the connection's
+session into ClickHouse's ``readonly = 2`` mode: writes and DDL are rejected by
+the engine, so the restriction covers SQL the caller writes and not only the
+driver's own entry points. Per-query settings still work, which ``readonly = 1``
+would forbid.
+
+.. code-block:: python
+
+   conn = adbc_driver_manager.dbapi.connect(
+       driver="/path/to/libchdb.so",
+       entrypoint="chdb_adbc_init",
+       db_kwargs={"path": ":memory:"},
+       conn_kwargs={"adbc.connection.readonly": "true"},
+       autocommit=True,
+   )
+
+The option can also be set on a live connection. Going read-only is one-way:
+``readonly = 2`` forbids changing ``readonly`` itself, so the engine rejects
+turning it back off.
+
+Bounding a Read
+---------------
+
+Any ClickHouse setting can be set as a statement option and applies to that
+statement alone; the connection's session is left as it was for the next
+statement. Two settings bound how much a client reads:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Setting
+     - Effect
+   * - ``max_block_size``
+     - Caps the rows in every Arrow batch, including the first one a client
+       receives from ``ExecuteQuery``.
+   * - ``max_result_rows`` with ``result_overflow_mode = 'break'``
+     - Stops the query once it has produced that many rows. The engine stops on
+       a block boundary, so set ``max_block_size`` to a divisor of the limit for
+       an exact bound.
+
+.. code-block:: python
+
+   stmt.set_options(**{
+       "max_block_size": "100",
+       "max_result_rows": "200",
+       "result_overflow_mode": "break",
+   })
+   stmt.set_sql_query("SELECT number FROM numbers(100000)")  # returns 200 rows
+
+Cancelling a Query
+------------------
+
+``AdbcStatementCancel`` stops the statement's result stream. It is thread-safe,
+so it can be called from another thread while one is blocked reading, and it
+returns without waiting for the batch already in flight. chDB cancels between
+batches: the query stops early rather than instantly, ADBC calls then report
+``ADBC_STATUS_CANCELLED`` (stream reads report ``ECANCELED``), and the statement
+and its connection are immediately reusable. Cancelling a statement with no
+result stream reports ``ADBC_STATUS_INVALID_STATE``.
+
 Compatibility Options
 ---------------------
 

--- a/docs/session.rst
+++ b/docs/session.rst
@@ -331,11 +331,12 @@ Best Practices
 
 .. note::
    - Multiple sessions on the same database path can be open at the same time; each session keeps its own state (current database, settings)
-   - A process hosts one embedded engine bound to one database path; opening a session on a different path requires closing all existing sessions first
+   - A process hosts one embedded engine bound to one database path; opening a session on a different path requires closing all existing sessions first, which shuts the engine down and starts a new one
    - Temporary sessions are automatically cleaned up when the session object is destroyed
    - File-based sessions persist data across Python interpreter restarts
 
 .. warning::
+   - Keep one session open for as long as your program needs chDB. The engine is meant to start once per process: closing the last session and opening a new one repeatedly is known to corrupt the process allocator on macOS and abort. A long-lived service should hold a session for its lifetime rather than open and close one per request
    - Always call :meth:`StreamingResult.close()` when terminating streaming queries early
    - Large result sets should use streaming queries to avoid memory issues
    - Session state is not shared between different Python processes

--- a/programs/local/adbc/validation/chdb_validation.cc
+++ b/programs/local/adbc/validation/chdb_validation.cc
@@ -175,9 +175,12 @@ public:
         }
     }
 
+    /// Cancellation lands between batches: the request never waits for the
+    /// batch in flight, and the engine stops the query at the next one.
+    bool supports_cancel() const override { return true; }
+
     /// Not implemented by the driver. ClickHouse also has no catalog level and
     /// no client-side transaction control.
-    bool supports_cancel() const override { return false; }
     bool supports_concurrent_statements() const override { return false; }
     bool supports_execute_schema() const override { return false; }
     bool supports_metadata_current_catalog() const override { return false; }

--- a/programs/local/chdb-adbc.cpp
+++ b/programs/local/chdb-adbc.cpp
@@ -10,13 +10,18 @@
 /// A statement's next Execute invalidates its own prior stream (spec-required);
 /// a different statement or a metadata call that hits a still-live stream is
 /// rejected with INVALID_STATE rather than silently invalidating it (see
-/// reclaimActiveStream). Independent concurrent readers work over separate
+/// beginConnectionOperation). Independent concurrent readers work over separate
 /// connections; note that session state (SET, temporary tables) is
 /// per-connection.
+///
+/// StatementCancel stops a stream between batches (chdbStatementCancel), and
+/// statement options that name a ClickHouse setting bound a read before it runs
+/// (applyStatementSettings).
 
 #include "chdb.h"
 #include "chdb-internal.h"
 
+#include <Core/Settings.h>
 #include <Parsers/Lexer.h>
 
 #include <arrow/c/abi.h>
@@ -40,11 +45,14 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <cerrno>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace
@@ -171,13 +179,27 @@ struct ConnectionImpl
     std::mutex mutex;
     /// The connection's outstanding streamed result, if any. The engine runs
     /// one statement at a time per connection; a new operation resolves this
-    /// via reclaimActiveStream (same statement re-execute invalidates it,
+    /// via beginConnectionOperation (same statement re-execute invalidates it,
     /// a different statement or metadata call is rejected while it is live).
     std::mutex stream_mutex;
     StreamingResultState * active_stream = nullptr;
     bool arrow_uuid_as_fixed_byte_array = false;
     bool arrow_variant_as_string = false;
+    /// ADBC_CONNECTION_OPTION_READ_ONLY, held until ConnectionInit can pass it
+    /// to the engine. Enforcement is the engine's (readonly=2: writes and DDL
+    /// are rejected, per-query settings still work), not this driver's, so it
+    /// covers SQL the caller writes as well as the driver's own entry points.
+    bool read_only = false;
+    /// Engine settings a statement applied to this session, paired with the
+    /// values to put back. See applyStatementSettings for why the restore is
+    /// deferred to the next operation on the connection.
+    std::vector<std::pair<std::string, std::string>> settings_to_restore;
 };
+
+/// Puts back the settings the last statement applied. Declared here because
+/// beginConnectionOperation is the point where they stop applying, and defined
+/// once the SQL helpers it needs are in scope.
+void restoreStatementSettings(ConnectionImpl * connection);
 
 std::atomic<uint64_t> statement_id_counter{1};
 
@@ -204,6 +226,10 @@ struct StatementImpl
     std::optional<bool> arrow_uuid_as_fixed_byte_array;
     std::optional<bool> arrow_variant_as_string;
 
+    /// Statement options that name a ClickHouse setting, applied around this
+    /// statement's execution only (see applyStatementSettings).
+    std::map<std::string, std::string> engine_settings;
+
     void releaseBoundStream()
     {
         if (has_bound_stream && bound_stream.release)
@@ -225,6 +251,12 @@ bool outputVariantAsString(const StatementImpl * impl)
     return impl->arrow_variant_as_string.value_or(impl->connection->arrow_variant_as_string);
 }
 
+constexpr const char * kStreamInvalidatedBySuccessor
+    = "[chdb] result stream invalidated by a subsequent statement on this connection";
+constexpr const char * kStreamInvalidatedByClose
+    = "[chdb] result stream invalidated: connection closed";
+constexpr const char * kStreamCancelled = "[chdb] query cancelled";
+
 /// Streaming result adapter: exposes chdb's pull-one-batch streaming
 /// (chdb_stream_query_arrow + chdb_stream_fetch_arrow, where each fetch
 /// yields a single-batch ArrowArrayStream) as one continuous
@@ -235,7 +267,7 @@ struct StreamingResultState
     /// Identity of the statement that produced this stream (compared, never
     /// dereferenced). The spec lets the SAME statement's next Execute
     /// invalidate its own prior result, but a DIFFERENT statement (or a
-    /// metadata call) must not silently invalidate it — see reclaimActiveStream.
+    /// metadata call) must not silently invalidate it — see beginConnectionOperation.
     /// Stored as the owning statement's monotonic id (0 = none), never a
     /// pointer, so a reused statement address cannot cause a false match.
     uint64_t owner_statement = 0;
@@ -249,10 +281,42 @@ struct StreamingResultState
     /// the connection) takes over: the engine runs one statement at a time
     /// per connection, so the older stream must stop touching it.
     bool invalidated = false;
+    /// Same effect as `invalidated`, but the consumer is told the query was
+    /// cancelled (ADBC_STATUS_CANCELLED / ECANCELED), which is what the spec
+    /// has callers act on.
+    bool cancelled = false;
+    /// StatementCancel's request, published without taking `mutex` so that
+    /// cancelling never waits for an in-flight fetch to finish. Whichever
+    /// thread next holds `mutex` turns it into `cancelled`.
+    std::atomic<bool> cancel_requested{false};
     std::string last_error;
     /// Guards all mutable members: get_next runs on the consumer's thread
     /// while invalidation comes from the thread executing the next statement.
     std::mutex mutex;
+
+    /// Caller holds `mutex`. Honours a StatementCancel that could not take
+    /// the lock itself, and reports whether the stream is now cancelled.
+    bool absorbCancelRequest()
+    {
+        if (cancelled)
+            return true;
+        if (!cancel_requested.load(std::memory_order_acquire))
+            return false;
+        cancelled = true;
+        last_error = kStreamCancelled;
+        retirePendingBatch();
+        releaseEngineStream();
+        return true;
+    }
+
+    /// Caller holds `mutex`. Drops a batch that was fetched but never handed
+    /// out, which every path that retires the engine stream does first.
+    void retirePendingBatch()
+    {
+        if (has_pending && pending.release)
+            pending.release(&pending);
+        has_pending = false;
+    }
 
     /// Caller holds `mutex`.
     void releaseEngineStream()
@@ -275,13 +339,49 @@ struct StreamingResultState
                 owner->active_stream = nullptr;
         }
         std::lock_guard guard(mutex);
-        if (has_pending && pending.release)
-            pending.release(&pending);
+        retirePendingBatch();
         releaseEngineStream();
     }
 };
 
-/// A new operation wants the connection, which runs one statement at a time.
+/// Caller holds connection.stream_mutex and state.mutex. Drops the
+/// connection's reference to the stream and the stream's back-reference to the
+/// connection, so a consumer that releases the ArrowArrayStream after the
+/// connection is gone cannot reach freed state from ~StreamingResultState.
+void detachStream(ConnectionImpl & connection, StreamingResultState & state)
+{
+    if (connection.active_stream == &state)
+        connection.active_stream = nullptr;
+    state.owner = nullptr;
+}
+
+/// Asks the connection's outstanding stream to stop, and retires it right
+/// away unless a fetch is inside the engine with it — that thread honours the
+/// request when its batch is done (absorbCancelRequest), so cancelling never
+/// waits for a batch to arrive. owner_statement limits this to one statement's
+/// stream; 0 means any. Reports whether there was such a stream.
+///
+/// Only the stream registry is locked, never the connection's execution mutex:
+/// cancelling has to work while the Execute or fetch being cancelled holds it.
+bool cancelActiveStream(ConnectionImpl * connection, uint64_t owner_statement)
+{
+    std::lock_guard reg(connection->stream_mutex);
+    auto * stream = connection->active_stream;
+    if (!stream || (owner_statement != 0 && stream->owner_statement != owner_statement))
+        return false;
+    stream->cancel_requested.store(true, std::memory_order_release);
+    std::unique_lock guard(stream->mutex, std::try_to_lock);
+    if (guard.owns_lock())
+    {
+        stream->absorbCancelRequest();
+        detachStream(*connection, *stream);
+    }
+    return true;
+}
+
+/// Hands the connection to a new operation, which the engine can only serve
+/// one at a time.
+///
 /// The ADBC concurrency spec offers three ways to handle an outstanding
 /// result stream: buffer it, execute concurrently, or error. chDB can do
 /// neither of the first two for a live stream, so it takes the error option —
@@ -290,35 +390,42 @@ struct StreamingResultState
 /// when it is that statement's Execute (nullptr for metadata calls and other
 /// statements, which may never reuse and so always get the error).
 ///
-/// A stream that is already exhausted or invalidated is not "live": it is
-/// silently detached so ordinary sequential use is unaffected.
-[[nodiscard]] AdbcStatusCode reclaimActiveStream(
+/// A stream that is already exhausted, invalidated or cancelled is not
+/// "live": it is silently detached so ordinary sequential use is unaffected.
+///
+/// Once the connection is free, the engine settings the previous statement
+/// applied are put back. This is the first moment a SET can run without
+/// destroying that statement's result stream, and it is also where the
+/// previous statement's settings stop applying (see applyStatementSettings).
+[[nodiscard]] AdbcStatusCode beginConnectionOperation(
     ConnectionImpl * connection, uint64_t owner_for_reuse, const char * reason, AdbcError * error)
 {
-    std::lock_guard reg(connection->stream_mutex);
-    auto * old = connection->active_stream;
-    if (!old)
-        return ADBC_STATUS_OK;
-    std::lock_guard guard(old->mutex);
-    const bool consumed = old->exhausted || old->invalidated;
-    if (!consumed && !(owner_for_reuse != 0 && old->owner_statement == owner_for_reuse))
-        return setError(
-            error,
-            ADBC_STATUS_INVALID_STATE,
-            "[chdb] another result stream is still open on this connection; release it "
-            "before running new operations (chDB executes one statement at a time per "
-            "connection)");
-    old->invalidated = true;
-    old->last_error = reason;
-    old->releaseEngineStream();
-    connection->active_stream = nullptr;
+    {
+        std::lock_guard reg(connection->stream_mutex);
+        if (auto * old = connection->active_stream)
+        {
+            std::lock_guard guard(old->mutex);
+            const bool consumed = old->exhausted || old->invalidated || old->absorbCancelRequest();
+            if (!consumed && !(owner_for_reuse != 0 && old->owner_statement == owner_for_reuse))
+                return setError(
+                    error,
+                    ADBC_STATUS_INVALID_STATE,
+                    "[chdb] another result stream is still open on this connection; release it "
+                    "before running new operations (chDB executes one statement at a time per "
+                    "connection)");
+            if (!old->cancelled)
+            {
+                old->invalidated = true;
+                old->last_error = reason;
+            }
+            old->retirePendingBatch();
+            old->releaseEngineStream();
+            detachStream(*connection, *old);
+        }
+    }
+    restoreStatementSettings(connection);
     return ADBC_STATUS_OK;
 }
-
-constexpr const char * kStreamInvalidatedBySuccessor
-    = "[chdb] result stream invalidated by a subsequent statement on this connection";
-constexpr const char * kStreamInvalidatedByClose
-    = "[chdb] result stream invalidated: connection closed";
 
 /// ---------------------------------------------------------------------
 /// Small utilities
@@ -489,6 +596,103 @@ std::string quoteStringLiteral(const std::string & value)
     }
     quoted += '\'';
     return quoted;
+}
+
+/// Undoes the CSV quoting of a single cell, the shape runScalarQuery returns.
+std::string unquoteCsvCell(std::string cell)
+{
+    if (cell.size() < 2 || cell.front() != '"' || cell.back() != '"')
+        return cell;
+    cell = cell.substr(1, cell.size() - 2);
+    size_t pos = 0;
+    while ((pos = cell.find("\"\"", pos)) != std::string::npos)
+    {
+        cell.erase(pos, 1);
+        ++pos;
+    }
+    return cell;
+}
+
+/// Reads one value out of the connection's session on the driver's own behalf
+/// (an option, a setting): takes the connection like any other operation, so a
+/// live stream from another statement is rejected instead of silently killed.
+AdbcStatusCode readSessionScalar(
+    ConnectionImpl * connection, const std::string & sql, std::string & out, AdbcError * error)
+{
+    std::lock_guard lock(connection->mutex);
+    if (AdbcStatusCode s
+        = beginConnectionOperation(connection, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+        s != ADBC_STATUS_OK)
+        return s;
+    std::string cell;
+    if (AdbcStatusCode s = runScalarQuery(connection, sql, cell, error); s != ADBC_STATUS_OK)
+        return s;
+    out = unquoteCsvCell(std::move(cell));
+    return ADBC_STATUS_OK;
+}
+
+/// Assembles the assignment list of a SET statement. Values go through as
+/// string literals whatever the setting's type is; the engine parses each one
+/// into that type, so one form covers numbers, enums and strings alike.
+std::string settingsAssignmentSql(const std::vector<std::pair<std::string, std::string>> & settings)
+{
+    std::string assignments;
+    for (const auto & [name, value] : settings)
+    {
+        if (!assignments.empty())
+            assignments += ", ";
+        assignments += name + " = " + quoteStringLiteral(value);
+    }
+    return assignments;
+}
+
+/// Applies a statement's engine settings so the statement runs under them,
+/// recording the previous values for beginConnectionOperation to put back.
+///
+/// chDB has no per-statement settings channel — SET writes the session — and
+/// no query can run while a result stream is open, so the restore has to wait
+/// for the next operation on this connection. That is still exactly
+/// statement scope: the engine copies the settings into the query context when
+/// the query starts, which for a streamed result happens during its init, so
+/// the stream keeps the values it was started with no matter what the session
+/// looks like afterwards.
+///
+/// Caller holds connection->mutex and has just called beginConnectionOperation.
+[[nodiscard]] AdbcStatusCode applyStatementSettings(
+    ConnectionImpl * connection, const std::map<std::string, std::string> & settings, AdbcError * error)
+{
+    if (settings.empty())
+        return ADBC_STATUS_OK;
+
+    std::vector<std::pair<std::string, std::string>> to_apply;
+    to_apply.reserve(settings.size());
+    for (const auto & [name, value] : settings)
+    {
+        std::string previous;
+        if (AdbcStatusCode s = runScalarQuery(
+                connection, "SELECT getSetting(" + quoteStringLiteral(name) + ")", previous, error);
+            s != ADBC_STATUS_OK)
+            return s;
+        /// Recorded before the SET runs: a SET that fails halfway still has to
+        /// be undone.
+        connection->settings_to_restore.emplace_back(name, unquoteCsvCell(std::move(previous)));
+        to_apply.emplace_back(name, value);
+    }
+    return runUpdateQuery(connection, "SET " + settingsAssignmentSql(to_apply), nullptr, error);
+}
+
+void restoreStatementSettings(ConnectionImpl * connection)
+{
+    if (connection->settings_to_restore.empty())
+        return;
+    const std::string sql = "SET " + settingsAssignmentSql(connection->settings_to_restore);
+    /// Cleared first: a value the engine will not take back must not be
+    /// retried in front of every later statement.
+    connection->settings_to_restore.clear();
+    /// Best effort — a failed restore is not the caller's error to handle.
+    AdbcError ignored{};
+    if (runUpdateQuery(connection, sql, nullptr, &ignored) != ADBC_STATUS_OK && ignored.release)
+        ignored.release(&ignored);
 }
 
 /// Finds `?` placeholders through the engine's own lexer, so every literal
@@ -779,7 +983,7 @@ AdbcStatusCode queryToTable(
     ConnectionImpl * connection, const std::string & sql, std::shared_ptr<arrow::Table> & table, AdbcError * error)
 {
     /// Metadata helper: never a statement reuse, so a live stream is rejected.
-    if (AdbcStatusCode s = reclaimActiveStream(connection, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+    if (AdbcStatusCode s = beginConnectionOperation(connection, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
         s != ADBC_STATUS_OK)
         return s;
     ArrowArrayStream stream;
@@ -982,6 +1186,36 @@ AdbcStatusCode chdbConnectionSetOption(
             return ADBC_STATUS_OK; /// autocommit is the only supported mode
         return notImplemented(error, "disabling autocommit (ClickHouse has no classic transactions)");
     }
+    if (std::strcmp(key, ADBC_CONNECTION_OPTION_READ_ONLY) == 0)
+    {
+        auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+        bool requested = false;
+        if (AdbcStatusCode s = parseBoolOption(value, requested, error, key); s != ADBC_STATUS_OK)
+            return s;
+        /// Set before Init (the usual case — driver managers pass connection
+        /// options straight through to a fresh handle): remembered and given to
+        /// the engine as readonly=2 when the session starts.
+        if (!impl->conn)
+        {
+            impl->read_only = requested;
+            return ADBC_STATUS_OK;
+        }
+        /// Set on a live connection: the same setting, written the way SQL
+        /// would. Going read-only is one-way — readonly=2 lets a session change
+        /// any setting except `readonly` itself — so the engine rejects turning
+        /// it back off and that error is what the caller sees.
+        std::lock_guard lock(impl->mutex);
+        if (AdbcStatusCode s
+            = beginConnectionOperation(impl, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+            s != ADBC_STATUS_OK)
+            return s;
+        if (AdbcStatusCode s
+            = runUpdateQuery(impl, requested ? "SET readonly = 2" : "SET readonly = 0", nullptr, error);
+            s != ADBC_STATUS_OK)
+            return s;
+        impl->read_only = requested;
+        return ADBC_STATUS_OK;
+    }
     if (std::strcmp(key, kArrowUuidAsFixedByteArrayOption) == 0)
     {
         auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
@@ -1011,6 +1245,12 @@ AdbcStatusCode chdbConnectionInit(
     std::vector<std::string> args = {"chdb"};
     if (db->path != ":memory:")
         args.push_back("--path=" + db->path);
+    /// readonly=2, not 1: writes and DDL are rejected, but the session may
+    /// still tune per-query settings (SET / SETTINGS clauses), which is what a
+    /// read-only *connection* means — and what the driver itself needs to
+    /// scope a statement's settings. readonly=1 would reject those too.
+    if (impl->read_only)
+        args.push_back("--readonly=2");
     args.insert(args.end(), db->extra_args.begin(), db->extra_args.end());
     std::vector<char *> argv;
     argv.reserve(args.size());
@@ -1041,9 +1281,9 @@ AdbcStatusCode chdbConnectionRelease(AdbcConnection * connection, AdbcError * er
             std::lock_guard guard(s->mutex);
             s->invalidated = true;
             s->last_error = kStreamInvalidatedByClose;
+            s->retirePendingBatch();
             s->releaseEngineStream();
-            s->owner = nullptr;
-            impl->active_stream = nullptr;
+            detachStream(*impl, *s);
         }
     }
     if (impl->conn)
@@ -1065,6 +1305,22 @@ AdbcStatusCode chdbConnectionRollback(AdbcConnection *, AdbcError * error)
         error, ADBC_STATUS_INVALID_STATE, "[chdb] no active transaction: connections are autocommit-only");
 }
 
+/// Stops whatever the connection has outstanding, which is the result stream
+/// a statement left open. Metadata readers are materialized before they are
+/// handed out, so for those nothing is left running in the engine and this is a
+/// no-op — which is why it reports OK, not INVALID_STATE, when there is no
+/// stream to stop.
+AdbcStatusCode chdbConnectionCancel(AdbcConnection * connection, AdbcError * error)
+{
+    if (!connection || !connection->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    auto * impl = static_cast<ConnectionImpl *>(connection->private_data);
+    if (!impl->conn)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    cancelActiveStream(impl, /*owner_statement=*/0);
+    return ADBC_STATUS_OK;
+}
+
 AdbcStatusCode chdbConnectionGetOption(
     AdbcConnection * connection, const char * key, char * value, size_t * length, AdbcError * error)
 {
@@ -1076,39 +1332,33 @@ AdbcStatusCode chdbConnectionGetOption(
     if (!impl->conn)
         return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
 
+    std::string option_value;
     if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0)
     {
-        std::string current;
-        {
-            std::lock_guard lock(impl->mutex);
-            /// Metadata read: reject (don't silently kill) a live stream.
-            if (AdbcStatusCode s = reclaimActiveStream(impl, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
-                s != ADBC_STATUS_OK)
-                return s;
-            AdbcStatusCode status = runScalarQuery(impl, "SELECT currentDatabase()", current, error);
-            if (status != ADBC_STATUS_OK)
-                return status;
-        }
-        /// The scalar helper hands back a CSV cell: strip the quoting.
-        if (current.size() >= 2 && current.front() == '"' && current.back() == '"')
-        {
-            current = current.substr(1, current.size() - 2);
-            size_t pos = 0;
-            while ((pos = current.find("\"\"", pos)) != std::string::npos)
-            {
-                current.erase(pos, 1);
-                ++pos;
-            }
-        }
-        /// Standard get-option contract: report the required size (with NUL)
-        /// and copy only when the caller's buffer already fits it.
-        const size_t needed = current.size() + 1;
-        if (value && *length >= needed)
-            std::memcpy(value, current.c_str(), needed);
-        *length = needed;
-        return ADBC_STATUS_OK;
+        if (AdbcStatusCode s = readSessionScalar(impl, "SELECT currentDatabase()", option_value, error);
+            s != ADBC_STATUS_OK)
+            return s;
     }
-    return setError(error, ADBC_STATUS_NOT_FOUND, "[chdb] unknown connection option '" + std::string(key) + "'");
+    else if (std::strcmp(key, ADBC_CONNECTION_OPTION_READ_ONLY) == 0)
+    {
+        /// Read from the engine rather than from `read_only`: SQL the caller
+        /// ran itself (SET readonly = ...) counts just as much as the option.
+        std::string readonly_setting;
+        if (AdbcStatusCode s = readSessionScalar(impl, "SELECT getSetting('readonly')", readonly_setting, error);
+            s != ADBC_STATUS_OK)
+            return s;
+        option_value = readonly_setting == "0" ? ADBC_OPTION_VALUE_DISABLED : ADBC_OPTION_VALUE_ENABLED;
+    }
+    else
+        return setError(error, ADBC_STATUS_NOT_FOUND, "[chdb] unknown connection option '" + std::string(key) + "'");
+
+    /// Standard get-option contract: report the required size (with NUL)
+    /// and copy only when the caller's buffer already fits it.
+    const size_t needed = option_value.size() + 1;
+    if (value && *length >= needed)
+        std::memcpy(value, option_value.c_str(), needed);
+    *length = needed;
+    return ADBC_STATUS_OK;
 }
 
 AdbcStatusCode chdbConnectionGetInfo(
@@ -1621,7 +1871,7 @@ AdbcStatusCode chdbConnectionGetTableSchema(
 
     std::lock_guard lock(impl->mutex);
     /// Metadata read: reject (don't silently kill) a live stream.
-    if (AdbcStatusCode s = reclaimActiveStream(impl, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
+    if (AdbcStatusCode s = beginConnectionOperation(impl, /*owner_for_reuse=*/0, kStreamInvalidatedBySuccessor, error);
         s != ADBC_STATUS_OK)
         return s;
     ArrowArrayStream stream;
@@ -1750,6 +2000,17 @@ AdbcStatusCode chdbStatementSetOption(
         if (AdbcStatusCode status = parseBoolOption(value, parsed, error, key); status != ADBC_STATUS_OK)
             return status;
         impl->arrow_variant_as_string = parsed;
+        return ADBC_STATUS_OK;
+    }
+    /// Any ClickHouse setting can be set on a statement and applies to that
+    /// statement alone. This is how a client bounds a read before executing:
+    /// max_block_size caps the rows in each Arrow batch (so also in the first
+    /// one), and max_result_rows with result_overflow_mode = 'break' stops the
+    /// query once it has produced enough — no query rewriting, no session state
+    /// left behind for the next statement.
+    if (DB::Settings::hasBuiltin(key))
+    {
+        impl->engine_settings[key] = value ? value : "";
         return ADBC_STATUS_OK;
     }
     return notImplemented(error, std::string("statement option '") + key + "'");
@@ -2204,6 +2465,8 @@ AdbcStatusCode executeBoundQuery(
 int streamingGetNextImpl(StreamingResultState & state, ArrowArray * out)
 {
     std::lock_guard guard(state.mutex);
+    if (state.absorbCancelRequest())
+        return ECANCELED; /// last_error says the query was cancelled
     if (state.invalidated)
         return EIO; /// last_error carries the reason
     if (state.has_pending)
@@ -2237,6 +2500,17 @@ int streamingGetNextImpl(StreamingResultState & state, ArrowArray * out)
         state.last_error = "failed to read batch from stream";
         return rc;
     }
+    /// A cancel that arrived while the engine was producing this batch could
+    /// not take the lock; it is honoured here instead, and the batch is dropped
+    /// rather than handed to a consumer that already asked to stop.
+    if (state.cancel_requested.load(std::memory_order_acquire))
+    {
+        if (out->release)
+            out->release(out);
+        out->release = nullptr;
+        state.absorbCancelRequest();
+        return ECANCELED;
+    }
     if (!out->release)
         state.exhausted = true;
     return 0;
@@ -2260,31 +2534,24 @@ AdbcStatusCode executeMaterializedSelect(
     return consumeArrowCDataResult(result, out, rows_affected, error, statementIsInsert(impl->query));
 }
 
-/// Takes ownership of a freshly initialized streaming query handle and wires
-/// the adapter into the caller's ArrowArrayStream. Shared by the plain and
-/// parameterized execution paths.
-AdbcStatusCode wireStreamingResult(
-    ConnectionImpl * connection,
-    uint64_t owner_statement,
-    chdb_result * stream_result,
-    ArrowArrayStream * out,
-    AdbcError * error)
+/// Reads the result schema and the first batch into the stream's state.
+///
+/// Fetching eagerly drives statements without a result set to completion and
+/// tells us whether there is a result schema at all. It runs under the stream's
+/// own lock, which is what lets a StatementCancel racing with Execute be
+/// resolved rather than lost.
+AdbcStatusCode primeStreamingResult(StreamingResultState & state, AdbcError * error)
 {
-    chdb_connection conn = *connection->conn;
-    auto state = std::make_unique<StreamingResultState>();
-    state->owner = connection;
-    state->owner_statement = owner_statement;
-    state->conn = conn;
-    state->stream_result = stream_result;
+    std::lock_guard guard(state.mutex);
+    if (state.absorbCancelRequest())
+        return setError(error, ADBC_STATUS_CANCELLED, kStreamCancelled);
 
-    /// Fetch the first batch eagerly: it drives statements without a result
-    /// set to completion and tells us whether there is a result schema.
     ArrowArrayStream first;
     std::memset(&first, 0, sizeof(first));
-    if (chdb_stream_fetch_arrow(conn, stream_result, reinterpret_cast<chdb_arrow_stream>(&first))
+    if (chdb_stream_fetch_arrow(state.conn, state.stream_result, reinterpret_cast<chdb_arrow_stream>(&first))
         != CHDBSuccess)
     {
-        const char * err = chdb_result_error(stream_result);
+        const char * err = chdb_result_error(state.stream_result);
         const std::string message = err ? err : "first fetch failed";
         return setError(error, err ? statusForEngineError(message) : ADBC_STATUS_INTERNAL, "[chdb] " + message);
     }
@@ -2311,17 +2578,54 @@ AdbcStatusCode wireStreamingResult(
             first.release(&first);
         return setError(error, ADBC_STATUS_INTERNAL, "[chdb] " + imported.status().ToString());
     }
-    state->schema = imported.ValueUnsafe();
+    state.schema = imported.ValueUnsafe();
 
-    int rc = first.get_next(&first, &state->pending);
+    int rc = first.get_next(&first, &state.pending);
     if (first.release)
         first.release(&first);
     if (rc != 0)
         return setError(error, ADBC_STATUS_INTERNAL, "[chdb] failed to read first batch");
-    if (state->pending.release)
-        state->has_pending = true;
+    if (state.pending.release)
+        state.has_pending = true;
     else
-        state->exhausted = true; /// empty result — schema-only stream
+        state.exhausted = true; /// empty result — schema-only stream
+
+    /// A cancel raised while the engine was producing that batch could not take
+    /// this lock, so it is honoured here: Execute reports the cancellation
+    /// instead of handing back a stream the caller already asked to stop.
+    if (state.absorbCancelRequest())
+        return setError(error, ADBC_STATUS_CANCELLED, kStreamCancelled);
+    return ADBC_STATUS_OK;
+}
+
+/// Takes ownership of a freshly initialized streaming query handle and wires
+/// the adapter into the caller's ArrowArrayStream. Shared by the plain and
+/// parameterized execution paths.
+AdbcStatusCode wireStreamingResult(
+    ConnectionImpl * connection,
+    uint64_t owner_statement,
+    chdb_result * stream_result,
+    ArrowArrayStream * out,
+    AdbcError * error)
+{
+    auto state = std::make_unique<StreamingResultState>();
+    state->owner = connection;
+    state->owner_statement = owner_statement;
+    state->conn = *connection->conn;
+    state->stream_result = stream_result;
+
+    /// Register before fetching anything. Execute holds the connection's
+    /// execution mutex, so StatementCancel is the only operation that can reach
+    /// this stream while the engine is producing the first batch — and stopping
+    /// a query that has not yielded a row yet is what cancelling is for. Every
+    /// failure path below destroys `state`, whose destructor deregisters it.
+    {
+        std::lock_guard reg(connection->stream_mutex);
+        connection->active_stream = state.get();
+    }
+
+    if (AdbcStatusCode status = primeStreamingResult(*state, error); status != ADBC_STATUS_OK)
+        return status;
 
     out->private_data = state.release();
     out->get_schema = [](ArrowArrayStream * self, ArrowSchema * schema_out) -> int
@@ -2356,22 +2660,18 @@ AdbcStatusCode wireStreamingResult(
         self->release = nullptr;
     };
 
-    /// Register as the connection's outstanding stream; exhausted
-    /// (schema-only) streams have nothing left in the engine to invalidate.
+    /// An exhausted (schema-only) stream has nothing left in the engine, so it
+    /// stops being the connection's outstanding stream right away: it must not
+    /// point back at a connection that may be released before the consumer
+    /// releases the stream, and the finished engine handle can be dropped now.
     auto * registered = static_cast<StreamingResultState *>(out->private_data);
-    if (!registered->exhausted)
+    if (registered->exhausted)
     {
         std::lock_guard reg(connection->stream_mutex);
-        connection->active_stream = registered;
-    }
-    else
-    {
-        /// Unregistered, so connection close would never clear these: the
-        /// stream must not point back at a connection that may be released
-        /// before it, and the completed engine handle can be dropped now.
-        registered->owner = nullptr;
+        std::lock_guard guard(registered->mutex);
         chdb_destroy_query_result(registered->stream_result);
         registered->stream_result = nullptr;
+        detachStream(*connection, *registered);
     }
     return ADBC_STATUS_OK;
 }
@@ -2418,7 +2718,10 @@ AdbcStatusCode chdbStatementExecuteQuery(
     /// live stream from a DIFFERENT statement makes this Execute fail with
     /// INVALID_STATE instead of silently killing the other reader.
     if (AdbcStatusCode s
-        = reclaimActiveStream(impl->connection, /*owner_for_reuse=*/impl->id, kStreamInvalidatedBySuccessor, error);
+        = beginConnectionOperation(impl->connection, /*owner_for_reuse=*/impl->id, kStreamInvalidatedBySuccessor, error);
+        s != ADBC_STATUS_OK)
+        return s;
+    if (AdbcStatusCode s = applyStatementSettings(impl->connection, impl->engine_settings, error);
         s != ADBC_STATUS_OK)
         return s;
 
@@ -2454,6 +2757,24 @@ AdbcStatusCode chdbStatementExecuteQuery(
     }
 
     return executeStreamingSelect(impl, out, rows_affected, error);
+}
+
+/// Stops this statement's result stream.
+///
+/// What the engine offers is cancellation between batches, so the query stops
+/// early rather than instantly — which is what the spec allows for ("it is not
+/// guaranteed to, for instance, the result set may be buffered in memory
+/// already") — and the statement is immediately reusable afterwards.
+AdbcStatusCode chdbStatementCancel(AdbcStatement * statement, AdbcError * error)
+{
+    if (!statement || !statement->private_data)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] statement is not allocated");
+    auto * impl = static_cast<StatementImpl *>(statement->private_data);
+    if (!impl->connection || !impl->connection->conn)
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] connection is not initialized");
+    if (!cancelActiveStream(impl->connection, /*owner_statement=*/impl->id))
+        return setError(error, ADBC_STATUS_INVALID_STATE, "[chdb] this statement has no query to cancel");
+    return ADBC_STATUS_OK;
 }
 
 AdbcStatusCode chdbStatementExecutePartitions(
@@ -2555,7 +2876,11 @@ extern "C" AdbcStatusCode chdb_adbc_init(int version, void * raw_driver, AdbcErr
     /// ADBC 1.1.0 additions beyond these stay zeroed: the driver manager
     /// backfills unset entries with NOT_IMPLEMENTED stubs.
     if (version == ADBC_VERSION_1_1_0)
+    {
+        driver->ConnectionCancel = chdbConnectionCancel;
         driver->ConnectionGetOption = chdbConnectionGetOption;
+        driver->StatementCancel = chdbStatementCancel;
+    }
 
     return ADBC_STATUS_OK;
 }

--- a/programs/local/chdb-adbc.cpp
+++ b/programs/local/chdb-adbc.cpp
@@ -681,6 +681,19 @@ std::string settingsAssignmentSql(const std::vector<std::pair<std::string, std::
     return runUpdateQuery(connection, "SET " + settingsAssignmentSql(to_apply), nullptr, error);
 }
 
+/// Settings that gate their own modification: once a session sets one to its
+/// restrictive value, the engine refuses to set it back (SettingsConstraints
+/// rejects `readonly` while readonly is on, `allow_ddl` once DDL is off, and
+/// `allow_python_table_function` once that is off). A statement option lasts
+/// for one statement, so accepting these would quietly turn into a permanent
+/// change to the whole connection when the restore is refused.
+bool isOneWaySetting(const char * key)
+{
+    return std::strcmp(key, "readonly") == 0
+        || std::strcmp(key, "allow_ddl") == 0
+        || std::strcmp(key, "allow_python_table_function") == 0;
+}
+
 void restoreStatementSettings(ConnectionImpl * connection)
 {
     if (connection->settings_to_restore.empty())
@@ -2002,12 +2015,26 @@ AdbcStatusCode chdbStatementSetOption(
         impl->arrow_variant_as_string = parsed;
         return ADBC_STATUS_OK;
     }
-    /// Any ClickHouse setting can be set on a statement and applies to that
-    /// statement alone. This is how a client bounds a read before executing:
-    /// max_block_size caps the rows in each Arrow batch (so also in the first
-    /// one), and max_result_rows with result_overflow_mode = 'break' stops the
-    /// query once it has produced enough — no query rewriting, no session state
-    /// left behind for the next statement.
+    /// Refused rather than silently made permanent: this one cannot be put
+    /// back after the statement, so it would outlive the statement it was set
+    /// on. Checked before the pass-through below, which would otherwise
+    /// accept it like any other setting.
+    if (isOneWaySetting(key))
+    {
+        std::string message = "[chdb] setting '" + std::string(key)
+            + "' cannot be scoped to a statement: the engine refuses to set it back afterwards, so it "
+              "would stay in effect for the rest of the connection";
+        if (std::strcmp(key, "readonly") == 0)
+            message += std::string(" (set the ") + ADBC_CONNECTION_OPTION_READ_ONLY
+                + " connection option instead)";
+        return setError(error, ADBC_STATUS_INVALID_ARGUMENT, message);
+    }
+    /// Any other ClickHouse setting can be set on a statement and applies to
+    /// that statement alone. This is how a client bounds a read before
+    /// executing: max_block_size caps the rows in each Arrow batch (so also in
+    /// the first one), and max_result_rows with result_overflow_mode = 'break'
+    /// stops the query once it has produced enough — no query rewriting, no
+    /// session state left behind for the next statement.
     if (DB::Settings::hasBuiltin(key))
     {
         impl->engine_settings[key] = value ? value : "";

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -207,9 +207,21 @@ CHDB_EXPORT void free_result_v2(struct local_result_v2 * result);
 
 /**
  * Creates a new chDB connection.
+ *
  * The engine uses one storage path per process: multiple connections to that
  * same path may be open at once. Connecting with a different path requires
- * closing all existing connections first.
+ * closing all existing connections first, which shuts the engine down and
+ * boots a new one.
+ *
+ * Keep at least one connection open for as long as the host needs chDB. The
+ * engine is meant to start once per process: repeatedly closing the last
+ * connection and reconnecting puts it through a full shutdown and boot each
+ * time, and doing that many times in one process is known to corrupt the
+ * process allocator on macOS and abort -- either in the engine's own teardown
+ * or at some unrelated allocation afterwards. A host that pools connections
+ * should hold one outside the pool rather than let the pool empty and
+ * reconnect on the next request: an idle timeout or a maximum-lifetime policy
+ * that retires the last connection puts it on that path with no indication.
  *
  * Arguments naming a ClickHouse query-level setting (--<setting>=<value>,
  * e.g. --max_threads=4 or --output_format_json_quote_denormals=1) apply to
@@ -229,6 +241,9 @@ CHDB_EXPORT struct chdb_conn ** connect_chdb(int argc, char ** argv);
 /**
  * Closes an existing chDB connection and cleans up resources.
  * Thread-safe function that handles connection shutdown and cleanup.
+ *
+ * Closing the last open connection shuts the engine down. See chdb_connect()
+ * for why a host should not do that until it is finished with chDB.
  *
  * @param conn Pointer to connection pointer to close
  */
@@ -334,9 +349,21 @@ CHDB_EXPORT void chdb_streaming_cancel_query(struct chdb_conn * conn, chdb_strea
 
 /**
  * Creates a new chDB connection.
+ *
  * The engine uses one storage path per process: multiple connections to that
  * same path may be open at once. Connecting with a different path requires
- * closing all existing connections first.
+ * closing all existing connections first, which shuts the engine down and
+ * boots a new one.
+ *
+ * Keep at least one connection open for as long as the host needs chDB. The
+ * engine is meant to start once per process: repeatedly closing the last
+ * connection and reconnecting puts it through a full shutdown and boot each
+ * time, and doing that many times in one process is known to corrupt the
+ * process allocator on macOS and abort -- either in the engine's own teardown
+ * or at some unrelated allocation afterwards. A host that pools connections
+ * should hold one outside the pool rather than let the pool empty and
+ * reconnect on the next request: an idle timeout or a maximum-lifetime policy
+ * that retires the last connection puts it on that path with no indication.
  *
  * Arguments naming a ClickHouse query-level setting (--<setting>=<value>,
  * e.g. --max_threads=4 or --output_format_json_quote_denormals=1) apply to
@@ -356,6 +383,9 @@ CHDB_EXPORT chdb_connection * chdb_connect(int argc, char ** argv);
 /**
  * Closes an existing chDB connection and cleans up resources.
  * Thread-safe function that handles connection shutdown and cleanup.
+ *
+ * Closing the last open connection shuts the engine down. See chdb_connect()
+ * for why a host should not do that until it is finished with chDB.
  *
  * @param conn Pointer to connection pointer to close
  */

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -24,11 +24,14 @@ class Colors:
 # each of those its own process: the engine is built once there and goes away
 # with the process, instead of being torn down and rebuilt in place.
 ISOLATED = [
+    "test_adbc_driver.TestAdbcCancel",
     "test_adbc_driver.TestAdbcGetObjects",
     "test_adbc_driver.TestAdbcIngest",
     "test_adbc_driver.TestAdbcMetadata",
     "test_adbc_driver.TestAdbcParameters",
     "test_adbc_driver.TestAdbcQuery",
+    "test_adbc_driver.TestAdbcReadOnly",
+    "test_adbc_driver.TestAdbcStatementSettings",
     "test_adbc_driver.TestAdbcPersistence.test_on_disk_path_roundtrip",
     "test_adbc_driver.TestAdbcUri.test_chdb_bad_authority_rejected",
     "test_adbc_driver.TestAdbcUri.test_chdb_memory_forms",
@@ -44,6 +47,8 @@ ISOLATED = [
 ]
 
 # Modules covered by the ISOLATED targets above; excluded from the main shards.
+# Note the consequence: a class of one of these modules that is NOT named above
+# does not run at all. Add new test_adbc_driver classes here.
 ISOLATED_MODULES = {t.split(".", 1)[0] for t in ISOLATED}
 
 # Shard the remaining suite across this many subprocesses so that no single

--- a/tests/test_adbc_driver.py
+++ b/tests/test_adbc_driver.py
@@ -1546,6 +1546,33 @@ class TestAdbcStatementSettings(unittest.TestCase):
             cur.execute("SELECT count() FROM settings_parts")
             self.assertEqual(cur.fetchone()[0], 4)
 
+    def test_settings_that_cannot_be_restored_are_refused(self):
+        # A statement option lasts for one statement. These three gate their
+        # own modification, so the engine refuses to set them back and they
+        # would silently become permanent for the connection -- the driver
+        # rejects them up front instead.
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn, conn.cursor() as cur:
+            for key in ("readonly", "allow_ddl", "allow_python_table_function"):
+                with self.assertRaises(Exception, msg=key) as ctx:
+                    cur.adbc_statement.set_options(**{key: "1"})
+                self.assertEqual(
+                    ctx.exception.status_code, AdbcStatusCode.INVALID_ARGUMENT, key
+                )
+            # The readonly message points at the option that does work.
+            with self.assertRaises(Exception) as ctx:
+                cur.adbc_statement.set_options(**{"readonly": "2"})
+            self.assertIn("adbc.connection.readonly", str(ctx.exception))
+
+            # Nothing was applied: the connection is still writable, and the
+            # next statement is unaffected.
+            cur.execute("SELECT getSetting('readonly')")
+            self.assertEqual(cur.fetchone()[0], 0)
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("CREATE DATABASE IF NOT EXISTS one_way_probe")
+            cur.execute("DROP DATABASE one_way_probe")
+
     def test_unknown_statement_option_is_rejected(self):
         from adbc_driver_manager import AdbcStatusCode
 

--- a/tests/test_adbc_driver.py
+++ b/tests/test_adbc_driver.py
@@ -174,6 +174,20 @@ def _connect(path=":memory:"):
     return _raw_connect({"path": path})
 
 
+def _connect_read_only(path=":memory:"):
+    if path == ":memory:":
+        _pin_memory_engine()
+    else:
+        _release_memory_keepalive()
+    return adbc_dbapi.connect(
+        driver=_LIBCHDB_PATH,
+        entrypoint="chdb_adbc_init",
+        db_kwargs={"path": path},
+        conn_kwargs={"adbc.connection.readonly": "true"},
+        autocommit=True,
+    )
+
+
 def _extension_name(field):
     if hasattr(field.type, "extension_name"):
         return field.type.extension_name
@@ -401,6 +415,37 @@ class TestAdbcQuery(unittest.TestCase):
             cur.execute("SELECT 7")
             self.assertEqual(cur.fetchone()[0], 7)
             cur.close()
+
+    def test_sequential_queries_after_closing_a_stream(self):
+        # A client's normal loop: run a query, read part of it, close the
+        # result, run the next one on a fresh statement. Closing the stream has
+        # to hand the connection back, or the next execute is rejected.
+        with _connect() as conn:
+            for expected in (1, 2, 3):
+                cur = conn.cursor()
+                cur.execute("SELECT number FROM numbers(1000000)")
+                reader = cur.fetch_record_batch()
+                self.assertGreater(next(iter(reader)).num_rows, 0)
+                reader.close()
+                del reader
+                cur.close()
+                with conn.cursor() as probe:
+                    probe.execute(f"SELECT {expected}")
+                    self.assertEqual(probe.fetchone()[0], expected)
+
+    def test_empty_result_stream_reports_schema_and_no_batches(self):
+        # A schema-only stream still answers get_schema and yields no batches:
+        # the shape a client needs to render an empty grid with real columns.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT number AS n, toString(number) AS s "
+                "FROM numbers(10) WHERE number < 0"
+            )
+            reader = cur.fetch_record_batch()
+            self.assertEqual(reader.schema.names, ["n", "s"])
+            self.assertEqual(reader.schema.field("n").type, pa.uint64())
+            batches = list(reader)
+        self.assertEqual([b.num_rows for b in batches], [])
 
     def test_error_reports_message(self):
         with _connect() as conn, conn.cursor() as cur:
@@ -1215,6 +1260,311 @@ class TestAdbcPythonInterop(unittest.TestCase):
             if native is not None:
                 native.close()
             shutil.rmtree(tmp, ignore_errors=True)
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcReadOnly(unittest.TestCase):
+    def test_read_only_connection_reports_and_enforces_read_only(self):
+        # The canonical option maps to the engine's readonly=2, so enforcement
+        # covers SQL the caller writes, not just the driver's own entry points.
+        with _connect_read_only() as conn:
+            self.assertEqual(
+                conn.adbc_connection.get_option("adbc.connection.readonly"), "true"
+            )
+            with conn.cursor() as cur:
+                cur.execute("SELECT getSetting('readonly')")
+                self.assertEqual(cur.fetchone()[0], 2)
+                cur.execute("SELECT sum(number) FROM numbers(10)")
+                self.assertEqual(cur.fetchone()[0], 45)
+                for sql in (
+                    "CREATE TABLE ro_denied (x Int64) ENGINE = MergeTree() ORDER BY x",
+                    "CREATE DATABASE ro_denied_db",
+                ):
+                    with self.assertRaises(Exception, msg=sql) as ctx:
+                        cur.execute(sql)
+                    self.assertRegex(str(ctx.exception), "[Rr]eadonly")
+
+    def test_read_only_connection_rejects_writes_to_an_existing_table(self):
+        # The gap this closes: with the option unhandled, writes went through.
+        # The table has to exist first, or name resolution reports the missing
+        # table before the read-only check is reached.
+        with _connect() as writable, writable.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS ro_target (x Int64) "
+                "ENGINE = MergeTree() ORDER BY x"
+            )
+            cur.execute("TRUNCATE TABLE ro_target")
+            cur.execute("INSERT INTO ro_target VALUES (7)")
+
+        with _connect_read_only() as conn, conn.cursor() as cur:
+            cur.execute("SELECT x FROM ro_target")
+            self.assertEqual(cur.fetchone()[0], 7)
+            for sql in (
+                "INSERT INTO ro_target VALUES (8)",
+                "TRUNCATE TABLE ro_target",
+                "DROP TABLE ro_target",
+            ):
+                with self.assertRaises(Exception, msg=sql) as ctx:
+                    cur.execute(sql)
+                self.assertRegex(str(ctx.exception), "[Rr]eadonly")
+
+        with _connect() as writable, writable.cursor() as cur:
+            cur.execute("SELECT count(), sum(x) FROM ro_target")
+            self.assertEqual(cur.fetchone(), (1, 7))
+
+    def test_read_only_connection_still_takes_per_query_settings(self):
+        # readonly=2, not 1: a read-only session may still tune settings, which
+        # is what statement-level settings need.
+        with _connect_read_only() as conn, conn.cursor() as cur:
+            cur.execute("SELECT count() FROM numbers(4) SETTINGS max_threads = 1")
+            self.assertEqual(cur.fetchone()[0], 4)
+
+    def test_read_only_connection_rejects_bulk_ingest(self):
+        with _connect_read_only() as conn, conn.cursor() as cur:
+            with self.assertRaises(Exception) as ctx:
+                cur.adbc_ingest(
+                    "ro_ingest",
+                    pa.table({"v": pa.array([1, 2], pa.int64())}),
+                    mode="create",
+                )
+            self.assertRegex(str(ctx.exception), "[Rr]eadonly")
+
+    def test_read_only_set_on_a_live_connection_is_one_way(self):
+        # Setting the option after Init goes through the engine too. Going
+        # read-only is one-way: readonly=2 forbids changing `readonly` itself,
+        # so the engine — not this driver — rejects turning it back off.
+        with _connect() as conn:
+            conn.adbc_connection.set_options(**{"adbc.connection.readonly": "true"})
+            self.assertEqual(
+                conn.adbc_connection.get_option("adbc.connection.readonly"), "true"
+            )
+            with conn.cursor() as cur:
+                with self.assertRaises(Exception) as ctx:
+                    cur.execute("CREATE DATABASE ro_live_denied")
+                self.assertRegex(str(ctx.exception), "[Rr]eadonly")
+            with self.assertRaises(Exception):
+                conn.adbc_connection.set_options(
+                    **{"adbc.connection.readonly": "false"}
+                )
+
+    def test_connection_is_writable_without_the_option(self):
+        with _connect() as conn:
+            # The cursor is closed first: its result stream still holds the
+            # connection, and reading an option is an operation like any other.
+            with conn.cursor() as cur:
+                cur.execute("SELECT getSetting('readonly')")
+                self.assertEqual(cur.fetchone()[0], 0)
+            self.assertEqual(
+                conn.adbc_connection.get_option("adbc.connection.readonly"), "false"
+            )
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcCancel(unittest.TestCase):
+    def test_cancel_stops_the_stream_and_the_statement_is_reusable(self):
+        with _connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT number FROM numbers(1000000000)")
+            reader = iter(cur.fetch_record_batch())
+            self.assertGreater(next(reader).num_rows, 0)
+
+            cur.adbc_cancel()
+
+            with self.assertRaises(Exception) as ctx:
+                for _ in reader:
+                    pass
+            self.assertIn("cancelled", str(ctx.exception))
+
+            # Cancel-and-reuse: the same statement runs again straight away.
+            cur.execute("SELECT 11")
+            self.assertEqual(cur.fetchone()[0], 11)
+            cur.close()
+
+    def test_cancel_hands_the_connection_to_another_statement(self):
+        # A cancelled stream is no longer "live", so the statement that would
+        # otherwise be rejected with INVALID_STATE can run.
+        with _connect() as conn:
+            cur1 = conn.cursor()
+            cur1.execute("SELECT number FROM numbers(1000000000)")
+            reader = iter(cur1.fetch_record_batch())
+            next(reader)
+            cur1.adbc_cancel()
+
+            cur2 = conn.cursor()
+            cur2.execute("SELECT 3")
+            self.assertEqual(cur2.fetchone()[0], 3)
+            cur1.close()
+            cur2.close()
+
+    def test_cancel_from_another_thread_ends_a_running_read(self):
+        # The spec requires Cancel to be thread-safe: it is called from a UI
+        # thread while the consumer thread sits inside the engine. It must not
+        # deadlock against the fetch, and the read must end early.
+        import threading
+
+        with _connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT number FROM numbers(1000000000)")
+            reader = iter(cur.fetch_record_batch())
+            rows = next(reader).num_rows
+
+            cancelled = threading.Event()
+
+            def cancel():
+                cur.adbc_cancel()
+                cancelled.set()
+
+            worker = threading.Thread(target=cancel)
+            worker.start()
+            with self.assertRaises(Exception):
+                for batch in reader:
+                    rows += batch.num_rows
+            worker.join(60)
+            self.assertTrue(cancelled.is_set())
+            self.assertLess(rows, 1000000000)
+            cur.close()
+
+    def test_connection_cancel_stops_the_open_stream(self):
+        with _connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT number FROM numbers(1000000000)")
+            reader = iter(cur.fetch_record_batch())
+            next(reader)
+
+            conn.adbc_cancel()
+
+            with self.assertRaises(Exception) as ctx:
+                for _ in reader:
+                    pass
+            self.assertIn("cancelled", str(ctx.exception))
+            cur.close()
+
+    def test_connection_cancel_with_nothing_running_reports_success(self):
+        # Metadata readers are materialized before they are handed out, so
+        # there is nothing left running in the engine to stop.
+        with _connect() as conn:
+            conn.adbc_cancel()
+            conn.adbc_get_objects(depth="catalogs").read_all()
+            conn.adbc_cancel()
+            with conn.cursor() as cur:
+                cur.execute("SELECT 4")
+                self.assertEqual(cur.fetchone()[0], 4)
+
+    def test_cancel_without_a_query_reports_invalid_state(self):
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn, conn.cursor() as cur:
+            with self.assertRaises(Exception) as ctx:
+                cur.adbc_cancel()
+            self.assertEqual(ctx.exception.status_code, AdbcStatusCode.INVALID_STATE)
+
+
+@unittest.skipUnless(_ENABLED, _SKIP_REASON)
+class TestAdbcStatementSettings(unittest.TestCase):
+    def test_max_block_size_bounds_every_batch_including_the_first(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_statement.set_options(**{"max_block_size": "128"})
+            cur.execute("SELECT number FROM numbers(1000)")
+            batches = list(cur.fetch_record_batch())
+        self.assertEqual(batches[0].num_rows, 128)
+        self.assertTrue(all(b.num_rows <= 128 for b in batches))
+        self.assertEqual(sum(b.num_rows for b in batches), 1000)
+
+    def test_max_result_rows_with_break_bounds_the_whole_read(self):
+        # The engine stops at a block boundary, so a client that wants an exact
+        # bound sets the block size to match — 200 rows in blocks of 100.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_statement.set_options(
+                **{
+                    "max_block_size": "100",
+                    "max_result_rows": "200",
+                    "result_overflow_mode": "break",
+                }
+            )
+            cur.execute("SELECT number FROM numbers(100000)")
+            table = cur.fetch_arrow_table()
+        self.assertEqual(table.num_rows, 200)
+        self.assertEqual(table.column("number").to_pylist()[:3], [0, 1, 2])
+
+    def test_statement_settings_do_not_outlive_the_statement(self):
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT getSetting('max_block_size')")
+                default_block_size = cur.fetchone()[0]
+
+            with conn.cursor() as bounded:
+                bounded.adbc_statement.set_options(**{"max_block_size": "128"})
+                bounded.execute("SELECT getSetting('max_block_size')")
+                self.assertEqual(bounded.fetchone()[0], 128)
+
+            # The next statement on the same connection sees the old value back.
+            with conn.cursor() as cur:
+                cur.execute("SELECT getSetting('max_block_size')")
+                self.assertEqual(cur.fetchone()[0], default_block_size)
+
+    def test_statement_settings_do_not_bound_metadata_calls(self):
+        # A leftover result bound would silently truncate GetObjects; the
+        # settings are put back before any other operation runs.
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "CREATE TABLE IF NOT EXISTS settings_probe (a Int64) "
+                    "ENGINE = MergeTree() ORDER BY a"
+                )
+            with conn.cursor() as bounded:
+                bounded.adbc_statement.set_options(
+                    **{"max_result_rows": "1", "result_overflow_mode": "break"}
+                )
+                bounded.execute("SELECT number FROM numbers(1000)")
+                bounded.fetch_arrow_table()
+            self.assertEqual(
+                conn.adbc_get_table_schema("settings_probe").names, ["a"]
+            )
+
+    def test_settings_reach_an_update_statement(self):
+        # Statement settings apply on the update path too, not only to reads:
+        # a one-partition-per-block cap makes a four-partition INSERT fail.
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS settings_parts")
+            cur.execute(
+                "CREATE TABLE settings_parts (p Int64) ENGINE = MergeTree() "
+                "PARTITION BY p ORDER BY p"
+            )
+            cur.adbc_statement.set_options(
+                **{"max_partitions_per_insert_block": "1"}
+            )
+            with self.assertRaises(Exception) as ctx:
+                cur.execute(
+                    "INSERT INTO settings_parts SELECT number FROM numbers(4)"
+                )
+            self.assertRegex(str(ctx.exception), "[Pp]artition")
+
+            cur.adbc_statement.set_options(
+                **{"max_partitions_per_insert_block": "0"}
+            )
+            cur.execute("INSERT INTO settings_parts SELECT number FROM numbers(4)")
+            cur.execute("SELECT count() FROM settings_parts")
+            self.assertEqual(cur.fetchone()[0], 4)
+
+    def test_unknown_statement_option_is_rejected(self):
+        from adbc_driver_manager import AdbcStatusCode
+
+        with _connect() as conn, conn.cursor() as cur:
+            with self.assertRaises(Exception) as ctx:
+                cur.adbc_statement.set_options(**{"not_a_clickhouse_setting": "1"})
+            self.assertEqual(
+                ctx.exception.status_code, AdbcStatusCode.NOT_IMPLEMENTED
+            )
+
+    def test_invalid_setting_value_is_reported_at_execute(self):
+        with _connect() as conn, conn.cursor() as cur:
+            cur.adbc_statement.set_options(**{"max_block_size": "not_a_number"})
+            with self.assertRaises(Exception):
+                cur.execute("SELECT 1")
+            # The connection is still usable and unbounded afterwards.
+            with conn.cursor() as probe:
+                probe.execute("SELECT count() FROM numbers(500)")
+                self.assertEqual(probe.fetchone()[0], 500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #228.

**Read-only** — `adbc.connection.readonly` maps to the engine's `readonly = 2`: an engine argument when set before `ConnectionInit`, a `SET` when set after. Enforcement is the engine's, so it covers the caller's own SQL too. `2` rather than `1`, because a read-only session still has to be able to change settings; turning it back off is refused by the engine. `ConnectionGetOption` reads the value back from the engine.

The issue's first bullet needs nothing — `mode=ro` is already fixed on `main` (3231c03afca, in v26.7.2-rc.2, not in the reported v26.7.0) and already has coverage.

**Cancellation** — `AdbcStatementCancel` / `AdbcConnectionCancel` publish the request without taking the stream's lock, so cancelling never waits on the batch in flight; whichever thread is inside the engine honours it when that batch ends. Streams now register with the connection before the first fetch, so a cancel racing with `ExecuteQuery` finds something to cancel, and a cancelled stream frees the connection for another statement. Flips `supports_cancel()` in the conformance quirks.

**Bounded reads** — any ClickHouse setting can be set as a statement option, scoped to that statement: `max_block_size` caps every Arrow batch including the first, `max_result_rows` with `result_overflow_mode = 'break'` caps the whole read. The restore runs on the connection's next operation, since no query can run while a result stream is open; that is still statement scope, because the engine snapshots settings into the query context when the query starts. The three settings that gate their own modification — `readonly`, `allow_ddl`, `allow_python_table_function` — are refused, as the engine would not let us put them back.

**Also** — fixes a use-after-free where detaching a stream left its back-pointer to the connection, so releasing an abandoned stream after the connection closed reached freed state. And `chdb_connect`'s doc comment plus `docs/session.rst` presented "close all connections, then reconnect on another path" as an ordinary operation, when it is the sequence `tests/run_all.py` and the ADBC conformance runner isolate per process ("can corrupt the process allocator and abort under load on macOS"); now stated in `chdb.h`, `docs/session.rst` and `bindings.md`, connection pools included.

**Tests** — 18 new cases (96 total), covering what the issue asked for: empty-result schemas, read-only enforcement, cancel-and-reuse, bounded reads, and sequential queries after closing a stream. Registered in `tests/run_all.py`, which matters because `test_adbc_driver` is excluded from that runner's sharded groups — a class not in `ISOLATED` never runs. No crashes across 192 subprocesses under the runner; a single-process run of all 96, which the runner exists to avoid, hits a pre-existing corruption either way (5/30 with these tests, 4/30 without).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
