### PR TITLE
Fix four defects an ASan+UBSan build surfaced

### DIFF
--- a/.github/workflows/build_linux_arm64_wheels-gh.yml
+++ b/.github/workflows/build_linux_arm64_wheels-gh.yml
@@ -339,6 +339,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runAsanRegressionTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runConnSettingsTest.sh

--- a/.github/workflows/build_linux_x86_wheels.yml
+++ b/.github/workflows/build_linux_x86_wheels.yml
@@ -324,6 +324,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runAsanRegressionTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runConnSettingsTest.sh

--- a/.github/workflows/build_macos_arm64_wheels.yml
+++ b/.github/workflows/build_macos_arm64_wheels.yml
@@ -375,6 +375,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runAsanRegressionTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runConnSettingsTest.sh

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -376,6 +376,7 @@ jobs:
           bash -x ./examples/runArrowQueryTest.sh
           bash -x ./examples/runInsertProgressTest.sh
           bash -x ./examples/runStreamInsertTest.sh
+          bash -x ./examples/runAsanRegressionTest.sh
           bash -x ./examples/runVersionHeaderTest.sh
           bash -x ./examples/runVersionTest.sh
           bash -x ./examples/runConnSettingsTest.sh

--- a/examples/chdbArrowTest.c
+++ b/examples/chdbArrowTest.c
@@ -421,6 +421,7 @@ static void test_assert_row_count(chdb_result * result, uint64_t expected_rows, 
     char full_test_name[512];
     char * result_str;
     char * end;
+    size_t buffer_len;
     uint64_t actual_rows;
 
     test_assert_no_error(result, query_name);
@@ -429,12 +430,16 @@ static void test_assert_row_count(chdb_result * result, uint64_t expected_rows, 
     snprintf(full_test_name, sizeof(full_test_name), "%s - Result buffer is not null", query_name);
     test_assert_not_null(buffer, full_test_name);
 
-    /* Parse the count result (assuming CSV format with just the number) */
-    result_str = (char*)malloc(strlen(buffer) + 1);
-    strcpy(result_str, buffer);
+    /* Parse the count result (assuming CSV format with just the number).
+     * The buffer is not NUL-terminated -- chdb_result_length() is the only
+     * length -- so copy exactly that many bytes and terminate the copy. */
+    buffer_len = chdb_result_length(result);
+    result_str = (char*)malloc(buffer_len + 1);
+    memcpy(result_str, buffer, buffer_len);
+    result_str[buffer_len] = '\0';
 
     /* Remove trailing whitespace/newlines */
-    end = result_str + strlen(result_str) - 1;
+    end = result_str + buffer_len - 1;
     while (end > result_str && (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r' || *end == '\f' || *end == '\v')) {
         *end = '\0';
         end--;

--- a/examples/chdbAsanRegressionTest.c
+++ b/examples/chdbAsanRegressionTest.c
@@ -151,7 +151,9 @@ static void test_engine_start_leak_budget(void)
     }
     size_t after = live_bytes();
 
-    double per_cycle = (double)(after - before) / (double)cycles;
+    /* Convert before subtracting: an unrelated free between the two reads would make
+     * a size_t subtraction wrap into a huge positive delta. */
+    double per_cycle = ((double)after - (double)before) / (double)cycles;
     printf("  %.0f bytes retained per connect/close cycle (budget %d)\n", per_cycle, LEAK_BUDGET_PER_CYCLE);
     CHECK(per_cycle < (double)LEAK_BUDGET_PER_CYCLE, "engine start/stop stays within its leak budget");
 }

--- a/examples/chdbAsanRegressionTest.c
+++ b/examples/chdbAsanRegressionTest.c
@@ -1,0 +1,169 @@
+/* C-side regressions for the defects the ASan+UBSan build surfaced.
+ *
+ * On the unfixed engine this binary aborts:
+ *   - the second chdb_connect() in the process trips
+ *     chassert(!background_context_instance) in Context::makeBackgroundContext()
+ *   - the streaming INSERT worker trips chassert(!current_thread) in ThreadStatus,
+ *     because startThreadFromGlobalPool already built one for that thread
+ *
+ * It also pins the result-buffer contract (buf is chdb_result_length() bytes and is not
+ * NUL-terminated, so every consumer has to carry the length) and, when run under
+ * AddressSanitizer, bounds what one engine start/stop cycle may leave behind.
+ */
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include "chdb.h"
+
+static int failures = 0;
+
+#define CHECK(cond, what) \
+    do { \
+        if (cond) \
+            printf("  ok   %s\n", (what)); \
+        else { printf("  FAIL %s\n", (what)); failures++; } \
+    } while (0)
+
+static chdb_connection * open_memory_connection(void)
+{
+    char arg0[] = "clickhouse";
+    char arg1[] = "--multiquery";
+    char * args[] = {arg0, arg1};
+    return chdb_connect(2, args);
+}
+
+/* Engine restart inside one process. */
+static void test_repeated_connect(void)
+{
+    printf("test_repeated_connect\n");
+    for (int i = 0; i < 3; i++)
+    {
+        chdb_connection * conn = open_memory_connection();
+        CHECK(conn != NULL, "connection opens");
+        if (!conn)
+            return;
+
+        chdb_result * r = chdb_query(*conn, "SELECT 1", "CSV");
+        CHECK(r != NULL && chdb_result_error(r) == NULL, "query succeeds on a restarted engine");
+        chdb_destroy_query_result(r);
+        chdb_close_conn(conn);
+    }
+}
+
+/* Streaming INSERT: the worker runs on a pooled thread that already owns a ThreadStatus. */
+static void test_insert_stream_worker(void)
+{
+    printf("test_insert_stream_worker\n");
+    chdb_connection * conn = open_memory_connection();
+    CHECK(conn != NULL, "connection opens");
+    if (!conn)
+        return;
+
+    chdb_destroy_query_result(
+        chdb_query(*conn, "CREATE TABLE asan_ins (a UInt64, b String) ENGINE = Memory", "CSV"));
+
+    const char * rows = "1,\"one\"\n2,\"two\"\n";
+    chdb_insert_stream stream = chdb_stream_insert(*conn, "INSERT INTO asan_ins (a, b)", "CSV");
+    CHECK(stream != NULL && chdb_stream_insert_error(stream) == NULL, "insert stream opens");
+    CHECK(chdb_stream_append(stream, rows, strlen(rows)) == CHDBSuccess, "rows appended");
+    chdb_destroy_query_result(chdb_stream_done(stream));
+    chdb_destroy_insert_stream(stream);
+
+    chdb_result * r = chdb_query(*conn, "SELECT a, b FROM asan_ins ORDER BY a", "CSV");
+    CHECK(r != NULL && chdb_result_error(r) == NULL, "streamed rows are queryable");
+    if (r)
+    {
+        const char * expected = "1,\"one\"\n2,\"two\"\n";
+        size_t len = chdb_result_length(r);
+        CHECK(len == strlen(expected) && memcmp(chdb_result_buffer(r), expected, len) == 0,
+              "streamed rows read back intact");
+    }
+    chdb_destroy_query_result(r);
+    chdb_close_conn(conn);
+}
+
+/* The buffer is not a C string: length and content must agree without a terminator. */
+static void test_result_buffer_is_length_delimited(void)
+{
+    printf("test_result_buffer_is_length_delimited\n");
+    chdb_connection * conn = open_memory_connection();
+    CHECK(conn != NULL, "connection opens");
+    if (!conn)
+        return;
+
+    chdb_result * r = chdb_query(*conn, "SELECT 'abc'", "CSV");
+    CHECK(r != NULL && chdb_result_error(r) == NULL, "query succeeds");
+    if (r)
+    {
+        const char * expected = "\"abc\"\n";
+        size_t len = chdb_result_length(r);
+        /* memcmp over exactly len bytes -- strcmp/strlen here would read out of bounds. */
+        CHECK(len == strlen(expected) && memcmp(chdb_result_buffer(r), expected, len) == 0,
+              "buffer holds exactly chdb_result_length() bytes");
+    }
+    chdb_destroy_query_result(r);
+    chdb_close_conn(conn);
+}
+
+
+/* Per-cycle growth of the engine. Only meaningful under AddressSanitizer, so the counter
+ * is looked up at run time and the check is skipped where it is absent.
+ *
+ * Budget: re-parsing the built-in users XML on every start used to leak 40,736 bytes per
+ * cycle on its own. What remains is the context shared-part family, measured at ~29 KiB
+ * per cycle; the budget sits above that and below the regression it guards against. */
+#define LEAK_BUDGET_PER_CYCLE (64 * 1024)
+
+static void test_engine_start_leak_budget(void)
+{
+    size_t (*live_bytes)(void) = (size_t (*)(void))dlsym(RTLD_DEFAULT, "__sanitizer_get_current_allocated_bytes");
+
+    printf("test_engine_start_leak_budget\n");
+    if (!live_bytes)
+    {
+        printf("  skip (not an AddressSanitizer build)\n");
+        return;
+    }
+
+    /* One cycle first: the engine's one-time lazy globals are not a per-cycle cost. */
+    for (int warm = 0; warm < 1; warm++)
+    {
+        chdb_connection * conn = open_memory_connection();
+        if (conn)
+        {
+            chdb_destroy_query_result(chdb_query(*conn, "SELECT 1", "CSV"));
+            chdb_close_conn(conn);
+        }
+    }
+
+    const int cycles = 10;
+    size_t before = live_bytes();
+    for (int i = 0; i < cycles; i++)
+    {
+        chdb_connection * conn = open_memory_connection();
+        if (!conn)
+        {
+            CHECK(0, "connection opens during the leak measurement");
+            return;
+        }
+        chdb_destroy_query_result(chdb_query(*conn, "SELECT count() FROM numbers(100)", "CSV"));
+        chdb_close_conn(conn);
+    }
+    size_t after = live_bytes();
+
+    double per_cycle = (double)(after - before) / (double)cycles;
+    printf("  %.0f bytes retained per connect/close cycle (budget %d)\n", per_cycle, LEAK_BUDGET_PER_CYCLE);
+    CHECK(per_cycle < (double)LEAK_BUDGET_PER_CYCLE, "engine start/stop stays within its leak budget");
+}
+
+int main(void)
+{
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    printf("chdb %s\n", chdb_version());
+    test_repeated_connect();
+    test_insert_stream_worker();
+    test_result_buffer_is_length_delimited();
+    test_engine_start_leak_budget();
+    printf("\nfailures: %d\n", failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/examples/chdbStub.c
+++ b/examples/chdbStub.c
@@ -63,8 +63,12 @@ int main()
     // Print results (assuming it's a string type, adjust according to actual data type)
     if (result)
     {
-        /* buf is not NUL-terminated; len is the contract. */
-        printf("Query Result: %.*s\n", (int)result->len, result->buf);
+        /* buf is not NUL-terminated; len is the contract. Not %.*s either: it takes
+         * an int precision, and a result over INT_MAX would pass a negative one,
+         * which printf reads as "no precision" and then scans for a NUL. */
+        printf("Query Result: ");
+        fwrite(result->buf, 1, result->len, stdout);
+        printf("\n");
         printf("Elapsed Time: %fs\n", result->elapsed);
         printf("Rows Read: %llu\n", (unsigned long long)result->rows_read);
         printf("Bytes Read: %llu\n", (unsigned long long)result->bytes_read);

--- a/examples/chdbStub.c
+++ b/examples/chdbStub.c
@@ -63,7 +63,8 @@ int main()
     // Print results (assuming it's a string type, adjust according to actual data type)
     if (result)
     {
-        printf("Query Result: %s\n", result->buf);
+        /* buf is not NUL-terminated; len is the contract. */
+        printf("Query Result: %.*s\n", (int)result->len, result->buf);
         printf("Elapsed Time: %fs\n", result->elapsed);
         printf("Rows Read: %llu\n", (unsigned long long)result->rows_read);
         printf("Bytes Read: %llu\n", (unsigned long long)result->bytes_read);

--- a/examples/runAsanRegressionTest.sh
+++ b/examples/runAsanRegressionTest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+if [ "$(uname)" == "Darwin" ]; then
+    LDD="otool -L"
+    LIB_PATH="DYLD_LIBRARY_PATH"
+elif [ "$(uname)" == "Linux" ]; then
+    LDD="ldd"
+    LIB_PATH="LD_LIBRARY_PATH"
+else
+    echo "OS not supported"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Compile and link"
+${CC:-clang} chdbAsanRegressionTest.c -o chdbAsanRegressionTest -I../programs/local/ -L../ -lchdb
+
+export ${LIB_PATH}=..
+${LDD} chdbAsanRegressionTest
+
+echo "Run it:"
+./chdbAsanRegressionTest

--- a/programs/local/ChdbClient.cpp
+++ b/programs/local/ChdbClient.cpp
@@ -851,7 +851,12 @@ void ChdbClient::runInsertStreamWorker(const CHDB::InsertStreamContextPtr & ctx)
 
     try
     {
-        DB::ThreadStatus thread_status;
+        /// No ThreadStatus here: the worker runs on a global-pool thread and
+        /// startThreadFromGlobalPool already constructed one for it. A second one trips
+        /// chassert(!current_thread) in its constructor, and where the assert is compiled
+        /// out it is worse -- the inner object's destructor clears current_thread while the
+        /// pool's own ThreadStatus is still alive, so the thread finishes its work with no
+        /// thread status at all and loses memory accounting and query attribution.
         if (ctx->thread_group)
             DB::CurrentThread::attachToGroupIfDetached(ctx->thread_group);
 

--- a/programs/local/EmbeddedServer.cpp
+++ b/programs/local/EmbeddedServer.cpp
@@ -644,6 +644,18 @@ static ConfigurationPtr getConfigurationFromXMLString(const char * xml_data)
     return {new Poco::Util::XMLConfiguration{&input_source}};
 }
 
+/// The built-in users XML is a compile-time constant, so parse it once per process rather
+/// than once per engine start. chdb starts and stops the engine repeatedly inside one
+/// process, and each parse left its Poco name pool behind -- 40,736 bytes per start, the
+/// largest single per-start leak LeakSanitizer reports. Sharing one configuration is safe:
+/// Context::setUsersConfig() only stores the pointer and hands a const reference to
+/// AccessControl, and nothing outside Context reads it back.
+static ConfigurationPtr getDefaultUsersConfiguration(const char * xml_data)
+{
+    static ConfigurationPtr default_users_config = getConfigurationFromXMLString(xml_data);
+    return default_users_config;
+}
+
 
 void EmbeddedServer::setupUsers()
 {
@@ -686,7 +698,7 @@ void EmbeddedServer::setupUsers()
         }
 
         if (users_config_path.empty())
-            users_config = getConfigurationFromXMLString(minimal_default_user_xml);
+            users_config = getDefaultUsersConfiguration(minimal_default_user_xml);
         else
         {
             ConfigProcessor config_processor(users_config_path);
@@ -695,7 +707,7 @@ void EmbeddedServer::setupUsers()
         }
     }
     else
-        users_config = getConfigurationFromXMLString(minimal_default_user_xml);
+        users_config = getDefaultUsersConfiguration(minimal_default_user_xml);
     if (users_config)
     {
         global_context->setUsersConfig(users_config);

--- a/programs/local/LocalChdb.cpp
+++ b/programs/local/LocalChdb.cpp
@@ -956,7 +956,12 @@ PYBIND11_MODULE(_chdb, m)
 
     py::class_<query_result>(m, "query_result")
         .def(py::init<chdb_result *>(), py::return_value_policy::take_ownership)
-        .def("data", &query_result::data)
+        /// Bound to the length-aware accessor on purpose. Binding query_result::data
+        /// (a char *) makes pybind11's type_caster<char> call strlen() on a buffer that
+        /// is exactly chdb_result_length() bytes and carries no terminator, which reads
+        /// out of bounds (AddressSanitizer: container-overflow). Same Python type as
+        /// before -- str -- just built from the length the engine reports.
+        .def("data", &query_result::str)
         .def("bytes", &query_result::bytes)
         .def("__str__", &query_result::str)
         .def("__len__", &query_result::size)

--- a/programs/local/LocalChdb.h
+++ b/programs/local/LocalChdb.h
@@ -175,6 +175,8 @@ public:
     query_result(chdb_result * result) : result_wrapper(std::make_shared<local_result_wrapper>(result)) { }
     query_result(chdb_result * result, bool keep_buf) : result_wrapper(std::make_shared<local_result_wrapper>(result, keep_buf)) { }
     ~query_result() = default;
+    /// NOT NUL-terminated, and only chdb_result_length() bytes long. Callers must carry
+    /// the size: do not hand this pointer to anything that looks for a terminator.
     char * data() { return result_wrapper->data(); }
     py::bytes bytes() { return result_wrapper->bytes(); }
     py::str str() { return result_wrapper->str(); }

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -712,7 +712,7 @@ CHDB_EXPORT void chdb_destroy_insert_stream(chdb_insert_stream stream);
  * @return Read-only pointer to the result data
  * @note NOT NUL-terminated. The buffer is exactly chdb_result_length() bytes and the byte
  *       after it belongs to no one -- printf("%s"), strlen() and strcpy() read out of bounds.
- *       Use the length: printf("%.*s", (int)chdb_result_length(r), chdb_result_buffer(r)).
+ *       Use the length: fwrite(chdb_result_buffer(r), 1, chdb_result_length(r), stdout).
  */
 CHDB_EXPORT char * chdb_result_buffer(chdb_result * result);
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -12,7 +12,7 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
-#define CHDB_VERSION "26.7.2"
+#define CHDB_VERSION "26.7.2-rc.2"
 
 /**
  * Returns the version of the linked chDB library.
@@ -24,6 +24,8 @@ CHDB_EXPORT const char * chdb_version(void);
 // WARNING: The following structs are deprecated and will be removed in a future version.
 struct local_result
 {
+    /// buf is NOT NUL-terminated: len is the only length. Treating buf as a C string
+    /// (printf("%s"), strlen) reads past the end of the buffer.
     char * buf;
     size_t len;
     void * _vec; // std::vector<char> *, for freeing
@@ -708,6 +710,9 @@ CHDB_EXPORT void chdb_destroy_insert_stream(chdb_insert_stream stream);
  * Gets pointer to the result data buffer
  * @param result The query result handle
  * @return Read-only pointer to the result data
+ * @note NOT NUL-terminated. The buffer is exactly chdb_result_length() bytes and the byte
+ *       after it belongs to no one -- printf("%s"), strlen() and strcpy() read out of bounds.
+ *       Use the length: printf("%.*s", (int)chdb_result_length(r), chdb_result_buffer(r)).
  */
 CHDB_EXPORT char * chdb_result_buffer(chdb_result * result);
 

--- a/programs/local/chdb.h
+++ b/programs/local/chdb.h
@@ -12,7 +12,7 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
-#define CHDB_VERSION "26.7.2-rc.2"
+#define CHDB_VERSION "26.7.2"
 
 /**
  * Returns the version of the linked chDB library.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -7417,6 +7417,21 @@ void Context::stopServers(const ServerType & server_type) const
 
 void Context::shutdown() TSA_NO_THREAD_SAFETY_ANALYSIS
 {
+    /// chdb stops the engine and starts a new one inside a single process, which a
+    /// server never does, and these two process-global holders are only ever
+    /// assigned -- nothing releases them. So the closed engine's contexts stay
+    /// alive until the next start overwrites them, and the next
+    /// makeBackgroundContext() trips its chassert(!background_context_instance).
+    /// Release them here, when the context they belong to is shutting down.
+    if (global_context_instance.get() == this)
+    {
+        background_context_instance.reset();
+        /// Only when someone else still holds it: dropping the last reference to
+        /// this object from inside its own member function would destroy it here.
+        if (global_context_instance.use_count() > 1)
+            global_context_instance.reset();
+    }
+
     shared->shutdown();
 }
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -159,6 +159,7 @@
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <base/defines.h>
+#include <base/scope_guard.h>
 
 #include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <Processors/QueryPlan/RuntimeFilterLookup.h>
@@ -7423,14 +7424,24 @@ void Context::shutdown() TSA_NO_THREAD_SAFETY_ANALYSIS
     /// alive until the next start overwrites them, and the next
     /// makeBackgroundContext() trips its chassert(!background_context_instance).
     /// Release them here, when the context they belong to is shutting down.
-    if (global_context_instance.get() == this)
-    {
-        background_context_instance.reset();
-        /// Only when someone else still holds it: dropping the last reference to
-        /// this object from inside its own member function would destroy it here.
-        if (global_context_instance.use_count() > 1)
-            global_context_instance.reset();
-    }
+    ///
+    /// On the way out, not on the way in: ContextSharedPart::shutdown() reaches code
+    /// that reads Context::getGlobalContextInstance() -- StreamingStorageRegistry's
+    /// shutdown hands it to DatabaseCatalog::tryGetTable(), which dereferences it --
+    /// so clearing it first would pass a null context to a shutting-down queue table.
+    /// A scope guard rather than a statement after the call, so an exception on the
+    /// way through shutdown still leaves the holders released; otherwise the next
+    /// engine start in this process would hit the assertion again.
+    SCOPE_EXIT({
+        if (global_context_instance.get() == this)
+        {
+            background_context_instance.reset();
+            /// Only when someone else still holds it: dropping the last reference to
+            /// this object from inside its own member function would destroy it here.
+            if (global_context_instance.use_count() > 1)
+                global_context_instance.reset();
+        }
+    });
 
     shared->shutdown();
 }

--- a/tests/test_asan_regressions.py
+++ b/tests/test_asan_regressions.py
@@ -1,0 +1,67 @@
+"""Regressions for three of the four defects the ASan+UBSan build surfaced.
+
+Each test fails on the unfixed engine:
+  * reconnect            -> chassert(!background_context_instance) aborts the process
+  * insert stream worker -> chassert(!current_thread) aborts the process
+  * result buffer        -> AddressSanitizer: container-overflow (only under ASan)
+
+The fourth, per-engine-start leak, is asserted in examples/chdbAsanRegressionTest.c.
+"""
+
+import unittest
+
+import chdb
+
+
+class TestEngineRestart(unittest.TestCase):
+    """Second engine start in one process. Before the fix, the process-global
+    background_context_instance was still set from the first start and
+    Context::makeBackgroundContext() aborted on its chassert."""
+
+    def test_second_connect_in_same_process_succeeds(self):
+        for i in range(3):
+            conn = chdb.connect(":memory:")
+            cur = conn.cursor()
+            cur.execute("SELECT 1 + %d" % i)
+            self.assertEqual(cur.fetchall(), ((1 + i,),))
+            cur.close()
+            conn.close()
+
+
+class TestInsertStreamWorker(unittest.TestCase):
+    """The streaming INSERT worker runs on a global-pool thread that already owns a
+    ThreadStatus; constructing a second one aborted on chassert(!current_thread)."""
+
+    def test_streaming_insert_roundtrip(self):
+        conn = chdb.connect(":memory:")
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE asan_ins (a UInt64, b String) ENGINE = Memory")
+        cur.execute("INSERT INTO asan_ins VALUES (1, 'one'), (2, 'two')")
+        cur.execute("SELECT a, b FROM asan_ins ORDER BY a")
+        self.assertEqual(cur.fetchall(), ((1, "one"), (2, "two")))
+        cur.close()
+        conn.close()
+
+
+class TestResultBufferBounds(unittest.TestCase):
+    """query_result.data() was bound as a bare char *, so pybind11 ran strlen() on a
+    buffer that is exactly chdb_result_length() bytes and not NUL-terminated."""
+
+    def test_data_matches_str_and_len(self):
+        res = chdb.query("SELECT 'abc' AS c", "CSV")
+        self.assertEqual(res.data(), str(res))
+        self.assertEqual(len(res.bytes()), len(res))
+
+    def test_data_keeps_every_byte_of_a_binary_safe_format(self):
+        # A row whose output contains no trailing newline sentinel to hide behind.
+        res = chdb.query("SELECT 1", "CSV")
+        self.assertEqual(res.data().encode(), res.bytes())
+
+
+# The per-engine-start leak (examples/chdbAsanRegressionTest.c) is asserted from C, not
+# here: AddressSanitizer's counter is process-wide, and in a Python process CPython's own
+# per-cycle allocation swamps the ~40 KiB the fix removes.
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #231.

One commit per defect; the fifth adds the reproducers.

1. `query_result.data()` is bound to the length-aware accessor. The Python type is
   unchanged (`str`), and the `char *` accessor stays for `__arrow_c_stream__`, which
   passes `size()` alongside. The two examples that made the same mistake against the
   C API are fixed, and the contract is spelled out at both entry points in `chdb.h`.

2. `Context::shutdown()` releases the two process-global holders. Not
   `global_context_instance` when it is the last reference: dropping that from inside
   the object's own member function would destroy it there.

3. The redundant `ThreadStatus` in the insert-stream worker is gone; it uses the
   pool's.

4. The built-in users XML is parsed once per process. Sharing is safe:
   `setUsersConfig()` stores the pointer and gives `AccessControl` a const reference,
   and nothing outside `Context` reads it back. The config-file path is untouched,
   since that input can change between starts.

Verified on the sanitizer build, 20 connect/close cycles, chdb-attributed:

| | per cycle | name pool |
|---|---|---|
| before | 74,284 B | 814,720 B / 20 |
| after | 29,347 B | 0 |

Not fixed here: the residual 29 KB per cycle in the context shared-part family,
described at the end of the issue.

The Python reproducers run in-process. The C reproducer covers the same ground
against the C API and owns the per-cycle leak budget, which cannot be asserted from
Python — AddressSanitizer's counter is process-wide and CPython's own per-cycle
allocation is several times larger than the leak being guarded. It resolves the
counter with `dlsym`, so it runs on a non-sanitizer build and reports itself skipped;
the other three checks are meaningful either way, so its runner joins the existing
example tests in the wheel workflows.

Building main with a sanitizer on macOS needed three more changes (the Darwin
toolchain drops the sanitizer runtime, LLVM 21's asan runtime livelocks in its own
init on macOS 26, and `StackTrace.h` redefines `_XOPEN_SOURCE` after boost's ucontext
fibers set it). They are not in this PR; happy to send them separately if a macOS
sanitizer job is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix four ASan+UBSan defects in chdb engine lifecycle, streaming insert, users config, and Python result binding
> Fixes four defects surfaced by an ASan+UBSan build:
> - `ChdbClient::runInsertStreamWorker` no longer constructs a nested `ThreadStatus` on a global-pool thread, avoiding a duplicate-current-thread assertion
> - `Context::shutdown` releases process-global background and global context holders after shared shutdown (including on exception), so holders do not persist across engine restarts
> - `getDefaultUsersConfiguration` parses the built-in users XML at most once per process and reuses the cached configuration in `EmbeddedServer::setupUsers`
> - The `_chdb` pybind binding for `query_result.data` now uses the string accessor (length-aware) instead of the raw char-pointer caster that called `strlen` on a non-NUL-terminated buffer
> - Adds a C ASan regression test suite ([chdbAsanRegressionTest.c](https://github.com/chdb-io/chdb-core/pull/232/files#diff-adf83f1465bf9d37ebc3c0cecea0c9ca276a3e814ac72c2c0bd7ba580b9bf59a)) and Python regression tests ([test_asan_regressions.py](https://github.com/chdb-io/chdb-core/pull/232/files#diff-ecddc099cf08702931454b4aee2f4c31e6ee66ff8608de9f919c2e67015bca4a)) covering repeated connect/close, streaming insert, result buffer bounds, and a 64 KiB per-cycle leak budget under ASan; all wheel-build workflows now run the regression executable
> - Fixes [chdbArrowTest.c](https://github.com/chdb-io/chdb-core/pull/232/files#diff-57c979f6fcf23cd3088643306f5cb422c8f2a7f525b741a7b9c33f84e59d45e4) and [chdbStub.c](https://github.com/chdb-io/chdb-core/pull/232/files#diff-568d14ebced755a57984d0c19a5af4739a7041257999784f924b366f2cc4b2fa) to read result buffers by reported length instead of relying on NUL termination
> - Behavioral Change: `Context::shutdown` now resets the global context holder when another reference exists; callers that previously relied on the global holder surviving shutdown will see it released. The WASM workflow fetches MinIO via Docker container instead of direct download, producing a warning-only failure when unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0dde8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->